### PR TITLE
FIX missing dependency transmission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/)
+and this project adheres to [Semantic Versioning](https://semver.org/).
+
+## [unreleased]
+
+### Added
+* Single and multiple choice questions now offer a dropdown widget.
+* Questions/Forms for tabular data.
+
+### Changed
+* Fix 'missing translations' by adding `intl` to the dependencies.  
+  Consuming code must also specify the `intl` dependency for it to be injected.
+* Archived questions now visible (and marked as archived) on assigned forms.
+
+## [0.0.2] - 2019-03-01
+
+### Added
+* Archived and published toggles for forms and questions.
+
+## [0.0.1] - 2019-01-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [unreleased]
+## [Unreleased]
 
 ### Added
 * Single and multiple choice questions now offer a dropdown widget.
 * Questions/Forms for tabular data.
 
 ### Changed
-* Fix 'missing translations' by adding `intl` to the dependencies.  
-  Consuming code must also specify the `intl` dependency for it to be injected.
+* Fix 'missing translations' by adding `intl` to the dependencies.
 * Archived questions now visible (and marked as archived) on assigned forms.
 
 ## [0.0.2] - 2019-03-01

--- a/addon/engine.js
+++ b/addon/engine.js
@@ -11,7 +11,7 @@ const Eng = Engine.extend({
   Resolver,
 
   dependencies: {
-    services: ["apollo", "notification", "router"]
+    services: ["apollo", "notification", "router", "intl"]
   }
 });
 

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -12,7 +12,7 @@ const App = Application.extend({
   engines: {
     emberCaluma: {
       dependencies: {
-        services: ["apollo", "notification", "router"]
+        services: ["apollo", "notification", "router", "intl"]
       }
     }
   }

--- a/tests/dummy/app/snippets/usage/app.js
+++ b/tests/dummy/app/snippets/usage/app.js
@@ -7,7 +7,8 @@ const App = Application.extend({
         services: [
           "apollo", // ember-apollo-client for graphql
           "notification", // ember-uikit for notifications
-          "router" // ember router for navigation
+          "router", // ember router for navigation
+          "intl" // ember-intl for i18n
         ]
       }
     }

--- a/tests/dummy/app/templates/docs/index.md
+++ b/tests/dummy/app/templates/docs/index.md
@@ -13,7 +13,8 @@ mounted in `app/router.js`:
 {{docs-snippet name='usage/router.js'}}
 
 To make `ember-apollo-client` work, we need to pass it as dependency for our
-engine in `app/app.js`:
+engine in `app/app.js`. Additionally, we need to specify `ember-intl` as a 
+dependency so that the the application has access to the addon's translations. 
 
 {{docs-snippet name='usage/app.js'}}
 


### PR DESCRIPTION
**Do not merge this before the consuming apps have been changed!**

This fixes the missing translations by requesting the `intl` service from the host app.

Additionally, this change adds the dependency to the dummy app to avoid having an error, when running the add-on standalone.