### PR TITLE
Add ember-power-select to blueprint

### DIFF
--- a/blueprints/ember-caluma/index.js
+++ b/blueprints/ember-caluma/index.js
@@ -1,0 +1,11 @@
+"use strict";
+
+module.exports = {
+  normalizeEntityName() {}, // no-op since we're just adding dependencies
+
+  afterInstall() {
+    return this.addAddonsToProject({
+      packages: [{ name: "ember-power-select" }]
+    });
+  }
+};


### PR DESCRIPTION
In order for sass imports to work in the consuming app,
ember-power-select needs to be installed in the app.