### PR TITLE
Cf-form: Use didReceiveAttrs instead of willRender

### DIFF
--- a/addon/components/cf-form.js
+++ b/addon/components/cf-form.js
@@ -29,7 +29,8 @@ export default Component.extend(ComponentQueryManager, {
   attributeBindings: ["novalidate"],
   novalidate: "novalidate",
 
-  willInsertElement() {
+  didReceiveAttrs() {
+    this._super(...arguments);
     if (this.documentId) {
       this.data.perform();
     }


### PR DESCRIPTION
This allows passing a computed property as documentId which is initially
null.