### PR TITLE
Document store: use map instead of array, add save method

### DIFF
--- a/addon/services/document-store.js
+++ b/addon/services/document-store.js
@@ -15,7 +15,7 @@ export default Service.extend({
    * @property {Document[]} documents
    * @accessor
    */
-  documents: computed(() => []).readOnly(),
+  documents: computed(() => ({})).readOnly(),
 
   /**
    * Find a document in the cache or build it and put it in the cache.
@@ -24,16 +24,29 @@ export default Service.extend({
    * @param {Object} document The raw document
    * @return {Document} The document
    */
-  find(document) {
-    const cached = this.documents.find(doc => doc.id === atob(document.id));
+  find(document, { noCache } = {}) {
+    const id = atob(document.id);
+    const cached = this.documents[id];
 
-    if (!cached) {
-      this.documents.push(this._build(document));
+    if (noCache || !cached) {
+      const builtDocument = this._build(document);
+      this.documents[id] = builtDocument;
 
-      return this.find(document);
+      return builtDocument;
     }
 
     return cached;
+  },
+
+  /**
+   * Save (override) a document in the cache without considering existing cache entries
+   *
+   * @method save
+   * @param {Object} document The raw document
+   * @return {Document} The document
+   */
+  save(document) {
+    return this.find(document, { noCache: true });
   },
 
   /**

--- a/tests/unit/services/document-store-test.js
+++ b/tests/unit/services/document-store-test.js
@@ -43,13 +43,13 @@ module("Unit | Service | document-store", function(hooks) {
 
     const service = this.owner.lookup("service:document-store");
 
-    assert.equal(service.documents.length, 0);
+    assert.equal(Object.keys(service.documents), 0);
     assert.ok(service.find(this.document)); // uncached
-    assert.equal(service.documents.length, 1);
+    assert.equal(Object.keys(service.documents), 1);
 
     service._build = () => assert.ok(false); // make sure _build is not called
     assert.ok(service.find(this.document)); // cached
-    assert.equal(service.documents.length, 1);
+    assert.equal(Object.keys(service.documents), 1);
   });
 
   test("can build a document", function(assert) {
@@ -62,5 +62,21 @@ module("Unit | Service | document-store", function(hooks) {
     assert.ok(document);
     assert.equal(document.id, "1");
     assert.equal(document.fields.length, 1);
+  });
+
+  test("can override document in cache", function(assert) {
+    const service = this.owner.lookup("service:document-store");
+
+    const document = service.find(this.document);
+    assert.ok(document);
+
+    this.document.answers.edges[0].node.stringValue = "Something else!";
+    const changedDocument = service.save(this.document);
+
+    assert.equal(
+      changedDocument.fields[0].answer.stringValue,
+      "Something else!"
+    );
+    assert.equal(Object.keys(service.documents), 1);
   });
 });


### PR DESCRIPTION
Before, it was not possible to override an existing entry in the
document store, which can cause issues if the same document is requested
and passed to `find()` twice (The document store would return the old
built document).

By switching to an object we can also make sure that each document is
only present once in the cache.