### PR TITLE
Add missing peer dependencies

### DIFF
--- a/blueprints/ember-caluma/index.js
+++ b/blueprints/ember-caluma/index.js
@@ -5,7 +5,12 @@ module.exports = {
 
   afterInstall() {
     return this.addAddonsToProject({
-      packages: [{ name: "ember-power-select" }]
+      packages: [
+        { name: "ember-engines" },
+        { name: "ember-power-select" },
+        { name: "ember-promise-helpers" },
+        { name: "ember-math-helpers" }
+      ]
     });
   }
 };


### PR DESCRIPTION
It seems that even if a helper is only used inside the addon, the addon providing it still needs to be installed in the host app.