### PR TITLE
Stop updating slug on label change after manual slug changes

### DIFF
--- a/addon/components/cfb-form-editor/question.js
+++ b/addon/components/cfb-form-editor/question.js
@@ -48,6 +48,11 @@ export default Component.extend(ComponentQueryManager, {
   intl: service(),
   calumaOptions: service(),
 
+  /**
+   * Determines if the slug is "linked" to the question label, i.e. follows it's updates
+   */
+  linkSlug: true,
+
   possibleTypes: computed(function() {
     return Object.keys(TYPES).map(value => ({
       value,
@@ -312,8 +317,9 @@ export default Component.extend(ComponentQueryManager, {
     updateLabel(value, changeset) {
       changeset.set("label", value);
 
-      if (!this.get("slug")) {
+      if (!this.get("slug") && this.get("linkSlug")) {
         const slug = slugify(value);
+
         changeset.set("slug", slug);
 
         this.get("validateSlug").perform(this.prefix + slug, changeset);
@@ -322,6 +328,7 @@ export default Component.extend(ComponentQueryManager, {
 
     updateSlug(value, changeset) {
       changeset.set("slug", value);
+      this.set("linkSlug", false);
 
       this.get("validateSlug").perform(this.prefix + value, changeset);
     }

--- a/addon/components/cfb-form-editor/question/options.js
+++ b/addon/components/cfb-form-editor/question/options.js
@@ -42,7 +42,7 @@ export default RenderComponent.extend({
           )
         : [
             new Changeset(
-              { slug: "", label: "", isNew: true },
+              { slug: "", label: "", isNew: true, linkSlug: true },
               lookupValidator(OptionValidations),
               OptionValidations
             )
@@ -81,7 +81,7 @@ export default RenderComponent.extend({
       this.set("optionRows", [
         ...this.optionRows,
         new Changeset(
-          { slug: "", label: "", isNew: true },
+          { slug: "", label: "", isNew: true, linkSlug: true },
           lookupValidator(OptionValidations),
           OptionValidations
         )
@@ -99,9 +99,14 @@ export default RenderComponent.extend({
     updateLabel(value, changeset) {
       changeset.set("label", value);
 
-      if (changeset.get("isNew")) {
+      if (changeset.get("isNew") && changeset.get("linkSlug")) {
         changeset.set("slug", slugify(value));
       }
+    },
+
+    updateSlug(value, changeset) {
+      changeset.set("slug", value);
+      changeset.set("linkSlug", false);
     },
 
     update() {

--- a/addon/templates/components/cfb-form-editor/question/options.hbs
+++ b/addon/templates/components/cfb-form-editor/question/options.hbs
@@ -34,7 +34,7 @@
             inputName=(concat "option-" (add i 1) "-slug")
             required=true
             disabled=(not row.isNew)
-            on-update=(action (queue (action (mut f.model.slug)) (action "update")))
+            on-update=(action (queue (action "updateSlug") (action "update")))
           }}
         </div>
       </div>

--- a/tests/integration/components/cfb-form-editor/question-test.js
+++ b/tests/integration/components/cfb-form-editor/question-test.js
@@ -397,13 +397,36 @@ module("Integration | Component | cfb-form-editor/question", function(hooks) {
 
     assert.dom("input[name=slug] + span").doesNotExist();
 
-    await fillIn("input[name=label]", "Other Test Slug");
-    await blur("input[name=label]");
+    await fillIn("input[name=slug]", "other-test-slug");
     await blur("input[name=slug]");
     await settled();
 
     assert
       .dom("input[name=slug] + span")
       .hasText("A question with this slug already exists");
+  });
+
+  test("it auto-suggests the slug if it has not been manually changed", async function(assert) {
+    assert.expect(3);
+
+    await render(hbs`{{cfb-form-editor/question slug=null}}`);
+
+    await fillIn("input[name=label]", "Foo Bar");
+    await blur("input[name=label]");
+    await settled();
+
+    assert.dom("input[name=slug]").hasValue("foo-bar");
+
+    await fillIn("input[name=slug]", "x-y");
+    await blur("input[name=slug]");
+    await settled();
+
+    assert.dom("input[name=slug]").hasValue("x-y");
+
+    await fillIn("input[name=label]", "Something Else");
+    await blur("input[name=label]");
+    await settled();
+
+    assert.dom("input[name=slug]").hasValue("x-y");
   });
 });


### PR DESCRIPTION
Currently, we're overwriting manual slug changes (made by the user) when
the label is changed afterwards. This is not great UX.