### PR TITLE
feat(jexl): add support for multiline expressions

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -9,3 +9,7 @@
     white-space: nowrap;
   }
 }
+
+.jexl-textarea textarea {
+  font-family: monospace;
+}

--- a/addon/templates/components/cfb-form-editor/question.hbs
+++ b/addon/templates/components/cfb-form-editor/question.hbs
@@ -241,9 +241,10 @@
       </p>
       {{#if showAdvanced}}
         {{f.input
-          type="text"
+          type="textarea"
           label=(t "caluma.form-builder.question.isHidden")
           name="isHidden"
+          class="jexl-textarea"
         }}
       {{/if}}
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "graphql-iso-date": "^3.6.1",
     "graphql-tag": "^2.10.1",
     "graphql-tools": "^4.0.4",
-    "jexl": "^1.1.4",
+    "jexl": "czosel/Jexl#allow-arbitrary-whitespace",
     "liquid-fire": "^0.29.5",
     "sass": "^1.18.0",
     "slugify": "^1.3.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9084,10 +9084,9 @@ jest-docblock@^21.0.0:
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
   integrity sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==
 
-jexl@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/jexl/-/jexl-1.1.4.tgz#35cf86f881ea219d1e215c7a41e2e747ce6ee8a6"
-  integrity sha1-Nc+G+IHqIZ0eIVx6QeLnR85u6KY=
+jexl@czosel/Jexl#allow-arbitrary-whitespace:
+  version "2.1.1"
+  resolved "https://codeload.github.com/czosel/Jexl/tar.gz/6b3eb2f6177b1e042e06bfc5d958a7272d6bb39d"
 
 joi@^12.0.0:
   version "12.0.0"


### PR DESCRIPTION
This aims to make the jexl field in the form builder a bit more pleasant
to work with by allowing multiline expressions and rendering it with a
monospace font.

Multiline support in JEXL has already been added in the past, but was
(i suppose unintentionally) lost during the 2.0 release. See
https://github.com/TomFrost/Jexl/pull/54 for details.

pyJexl already supports multiline expressions.