### PR TITLE
Add "root" to doc slug lookups, improve reporting

### DIFF
--- a/addon/lib/question.js
+++ b/addon/lib/question.js
@@ -44,18 +44,6 @@ export default EmberObject.extend({
 
     return dependents.map(slugWithPath => {
       const field = this.document.findField(slugWithPath);
-      if (!field) {
-        if (slugWithPath.includes(".")) {
-          const path = slugWithPath.split(".");
-          const slug = path.pop();
-          throw new Error(
-            `Field "${slug}" is not present in document "${path}"`
-          );
-        }
-        throw new Error(
-          `Field "${slugWithPath}" is not present in this document`
-        );
-      }
       field.registerDependentField(this.field);
       return field;
     });

--- a/tests/unit/lib/question-test.js
+++ b/tests/unit/lib/question-test.js
@@ -81,7 +81,7 @@ module("Unit | Library | question", function(hooks) {
     assert.expect(1);
     assert.throws(
       () => this.question2.dependsOn,
-      /Field "question-nonexistent" is not present in this document/
+      /Question could not be resolved: "question-nonexistent". Available: "question1", "question2"/
     );
     this.set("question2.isHidden", "false");
   });


### PR DESCRIPTION
New: When evaluating JEXL, you can also use `root` as a path
element for your slug, which will then start at the top-level
document.

Also, improve error reporting if a path cannot be resolved:
We can now report exactly the position where it failed

Note this is the equivalent of projectcaluma/caluma#414