### PR TITLE
REMOVE custom z-index

### DIFF
--- a/addon/styles/addon.scss
+++ b/addon/styles/addon.scss
@@ -13,7 +13,3 @@
 .jexl-textarea textarea {
   font-family: monospace;
 }
-
-.pika-single {
-  z-index: 1;
-}


### PR DESCRIPTION
Falling back to the default Pikaday z-index of `9999`.

Rather bad practice but let's fix the z-indexes when we have more time.