### PR TITLE
fix(info): replace drop by modal

### DIFF
--- a/addon/templates/components/cf-field/info.hbs
+++ b/addon/templates/components/cf-field/info.hbs
@@ -1,7 +1,5 @@
-<button type="button" class="uk-icon-button" uk-icon="info"></button>
+<button type="button" class="uk-icon-button" uk-icon="info" {{action (mut showModal) true}}></button>
 
-<div uk-drop="pos: bottom-justify; boundary: .uk-form-controls; boundary-align: true">
-  <div class="uk-card uk-card-body uk-card-default">
-    {{markdown-to-html text}}
-  </div>
-</div>
+{{#uk-modal visible=showModal}}
+  {{markdown-to-html text}}
+{{/uk-modal}}


### PR DESCRIPTION
We had some issues with the "drop" element (positioning, width), so
we'll go with the slightly less elegant but also more stable modal.