### PR TITLE
fix(deps): downgrade to jexl 1.x for IE 11 compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
   },
   "//": [
     "-- Documentation of blocked dependency updates --",
-    "ember-apollo-client: https://github.com/bgentry/ember-apollo-client/issues/279"
+    "ember-apollo-client: https://github.com/bgentry/ember-apollo-client/issues/279",
+    "jexl: 2.x release is blocked due to https://github.com/ef4/ember-auto-import/issues/41",
+    "jexl: Using custom 1.x commit due to missing whitespace support (https://github.com/TomFrost/Jexl/pull/54)"
   ],
   "dependencies": {
     "apollo-link-context": "^1.0.17",
@@ -55,7 +57,7 @@
     "graphql-iso-date": "^3.6.1",
     "graphql-tag": "^2.10.1",
     "graphql-tools": "^4.0.4",
-    "jexl": "czosel/Jexl#allow-arbitrary-whitespace",
+    "jexl": "TomFrost/Jexl#2866a4aca9c46114ecc0d342942a7732763fd151",
     "liquid-fire": "^0.29.5",
     "sass": "^1.18.0",
     "slugify": "^1.3.4",

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -40,7 +40,7 @@ export default Route.extend(RouteQueryManager, {
       {
         query: gql`
           query {
-            allDocuments {
+            allDocuments(form: "main", orderBy: CREATED_AT_DESC) {
               edges {
                 node {
                   id

--- a/tests/dummy/app/routes/nested.js
+++ b/tests/dummy/app/routes/nested.js
@@ -21,7 +21,7 @@ export default Route.extend(RouteQueryManager, {
       {
         query: gql`
           query AllDocsToFindFirst {
-            allDocuments {
+            allDocuments(form: "main") {
               edges {
                 node {
                   id

--- a/yarn.lock
+++ b/yarn.lock
@@ -5992,16 +5992,7 @@ ember-concurrency@^0.10.0:
     ember-compatibility-helpers "^1.2.0"
     ember-maybe-import-regenerator "^0.1.5"
 
-ember-concurrency@^0.8.26:
-  version "0.8.27"
-  resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.8.27.tgz#6dd1b9928cf5d13d5ae9c8cd3d5869f6ff81a9a9"
-  integrity sha512-2IujJ0Y79a+sHvEOPhUtZ7Ga8HDrwjbQqO7aZ88b0KCsXPro7birQFB508njQSQ0mxrsR9qzDv/KS5V67Cy5dA==
-  dependencies:
-    babel-core "^6.24.1"
-    ember-cli-babel "^6.8.2"
-    ember-maybe-import-regenerator "^0.1.5"
-
-ember-concurrency@^0.9.0:
+"ember-concurrency@^0.8.27 || ^0.9.0", ember-concurrency@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-0.9.0.tgz#0016652ff780fb665842e7f47815ee0601122ea1"
   integrity sha512-JDjvwSlZBUQwv1+qUj6YUqXXe0Y0/to4ppUTNXQ1EEiEAopkHJXQUn0ZcFOiQpEinrYp34Vg6+lUNskoJFL2Vg==
@@ -6300,15 +6291,15 @@ ember-pikaday@2.3.1:
     fastboot-transform "^0.1.1"
     pikaday "^1.5.1"
 
-ember-power-select@2.2.3:
-  version "2.2.3"
-  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-2.2.3.tgz#ab23ba0c1bcf743b60703afb0655788ccb0912e4"
-  integrity sha512-Y1sgUD7e78szL5bSdmqIFI175NNF1iw92JsDFY56AxYXQk/0se58P07fiyHgWQ5YgC5ilS3bHmkWJ6hAw6Q1lA==
+ember-power-select@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/ember-power-select/-/ember-power-select-2.3.1.tgz#d6b6161155bedfb7ce0b6d40192aed3e2eae4b1b"
+  integrity sha512-HaZ8Kf9hLPGrtcAXsBAPe15nhWPVKzT2qSOIHFNQXWtcbHWtMkwmF44hyMmSb061HhAcJiySzBd8oAlVOkugAg==
   dependencies:
     ember-basic-dropdown "^1.1.0"
     ember-cli-babel "^7.2.0"
     ember-cli-htmlbars "^3.0.1"
-    ember-concurrency "^0.8.26"
+    ember-concurrency "^0.8.27 || ^0.9.0"
     ember-text-measurer "^0.5.0"
     ember-truth-helpers "^2.1.0"
 
@@ -9183,9 +9174,9 @@ jest-docblock@^21.0.0:
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-21.2.0.tgz#51529c3b30d5fd159da60c27ceedc195faf8d414"
   integrity sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==
 
-jexl@czosel/Jexl#allow-arbitrary-whitespace:
-  version "2.1.1"
-  resolved "https://codeload.github.com/czosel/Jexl/tar.gz/6b3eb2f6177b1e042e06bfc5d958a7272d6bb39d"
+jexl@TomFrost/Jexl#2866a4aca9c46114ecc0d342942a7732763fd151:
+  version "1.1.4"
+  resolved "https://codeload.github.com/TomFrost/Jexl/tar.gz/2866a4aca9c46114ecc0d342942a7732763fd151"
 
 joi@^12.0.0:
   version "12.0.0"


### PR DESCRIPTION
After wasting _way_ too much time with trying to get ember-auto-import to transpile jexl automatically, I decided to take the easy way out by downgrading Jexl to the latest 1.x commit that also contains the PR introducing whitespace support.