### PR TITLE
Scroll to top on document change

### DIFF
--- a/addon/components/cf-navigation.js
+++ b/addon/components/cf-navigation.js
@@ -67,6 +67,8 @@ export default Component.extend(ComponentQueryManager, {
         // eslint-disable-next-line no-console
         console.error(e);
         return null;
+      } finally {
+        window.scrollTo(0, 0);
       }
     }
   ),


### PR DESCRIPTION
Not sure if `finally` is the right place.

The reasoning is that I cannot add it at the end of the `try` block as there are `return`s before that. My problem with `finally` is that it will scroll on error which might be confusing.