### PR TITLE
feat(cf-form): allow passing context information to cf-form, cf-navigation

### DIFF
--- a/addon/components/cf-form.js
+++ b/addon/components/cf-form.js
@@ -54,6 +54,14 @@ export default Component.extend(ComponentQueryManager, {
    */
   overrides: null,
 
+  /**
+   * Can be used to pass "context" information from the outside through
+   * to custom overrides.
+   *
+   * @argument {*} overrides
+   */
+  context: null,
+
   didReceiveAttrs() {
     this._super(...arguments);
     if (this.documentId) {

--- a/addon/components/cf-navigation.js
+++ b/addon/components/cf-navigation.js
@@ -29,7 +29,7 @@ export default Component.extend(ComponentQueryManager, {
    * Can be used to pass "context" information from the outside through
    * to custom overrides.
    *
-   * @argument {*} overrides
+   * @argument {*} context
    */
   context: null,
 

--- a/addon/components/cf-navigation.js
+++ b/addon/components/cf-navigation.js
@@ -6,12 +6,46 @@ import { ComponentQueryManager } from "ember-apollo-client";
 import { task } from "ember-concurrency";
 import getNavigationQuery from "ember-caluma/gql/queries/get-navigation";
 
+/**
+ * Component to display a nested form including navigation.
+ *
+ * ```hbs
+ * {{cf-navigation documentId="myDocId" section=section subSection=subSection}}
+ * ```
+ *
+ * @class CfFormComponent
+ */
 export default Component.extend(ComponentQueryManager, {
   layout,
   documentStore: service(),
 
+  /**
+   * The ID of the nested document to display the navigation for
+   * @argument {String} documentId
+   */
   documentId: null,
-  activeDocumentId: null,
+
+  /**
+   * Can be used to pass "context" information from the outside through
+   * to custom overrides.
+   *
+   * @argument {*} overrides
+   */
+  context: null,
+
+  /**
+   * Form slug of currently visible section
+   *
+   * @argument {String} section
+   */
+  section: null,
+
+  /**
+   * Form slug of currently visible sub-section
+   *
+   * @argument {String} subSection
+   */
+  subSection: null,
 
   _currentDocumentId: null,
 

--- a/addon/templates/components/cf-field.hbs
+++ b/addon/templates/components/cf-field.hbs
@@ -5,7 +5,7 @@
   <div class="uk-flex">
     <div class="uk-width-expand">
       {{#if componentOverride}}
-        {{component componentOverride field=field disabled=disabled onSave=(perform save)}}
+        {{component componentOverride field=field disabled=disabled context=context onSave=(perform save)}}
       {{else}}
         {{cf-field/input field=field disabled=disabled onSave=(perform save)}}
       {{/if}}

--- a/addon/templates/components/cf-form.hbs
+++ b/addon/templates/components/cf-form.hbs
@@ -1,3 +1,3 @@
 {{#each _document.fields as |field|}}
-  {{cf-field field=field disabled=disabled}}
+  {{cf-field field=field disabled=disabled context=context}}
 {{/each}}

--- a/addon/templates/components/cf-navigation.hbs
+++ b/addon/templates/components/cf-navigation.hbs
@@ -33,7 +33,7 @@
     </div>
 
     <div class="uk-width-1-1 uk-width-2-3@m">
-      {{cf-form document=displayedDocument}}
+      {{cf-form document=displayedDocument context=context}}
     </div>
   {{/if}}
 </div>


### PR DESCRIPTION
This is useful to allow passing "context" data to custom components.