### PR TITLE
chore(naming): rename "static field" to "non-interactive" field

### DIFF
--- a/translations/de-de.yaml
+++ b/translations/de-de.yaml
@@ -115,7 +115,7 @@ caluma:
         TableQuestion: "Tabelle"
         FormQuestion: "Formular"
         FileQuestion: "Datei"
-        StaticQuestion: "Statischer Inhalt"
+        StaticQuestion: "Nichtinteraktiver Inhalt"
         DateQuestion: "Datum"
         DynamicMultipleChoiceQuestion: "Dynamische Mehrfachauswahl"
         DynamicChoiceQuestion: "Dynamische Einzelauswahl"

--- a/translations/en-us.yaml
+++ b/translations/en-us.yaml
@@ -115,7 +115,7 @@ caluma:
         TableQuestion: "Table"
         FormQuestion: "Form"
         FileQuestion: "File"
-        StaticQuestion: "Static content"
+        StaticQuestion: "Non-interactive content"
         DateQuestion: "Date"
         DynamicMultipleChoiceQuestion: "Dynamic Choices"
         DynamicChoiceQuestion: "Dynamic Choice"


### PR DESCRIPTION
Because those fields are supposed to be used not only for static
content, but also for custom component overrides. Calling it "Non-interactive"
hopefully makes this more obvious.