### PR TITLE
fix(cf-navigation): add compute watcher on hidden state

### DIFF
--- a/addon/lib/document.js
+++ b/addon/lib/document.js
@@ -178,13 +178,13 @@ export default EmberObject.extend({
   ),
 
   ownState: computed(
-    "fields.@each.{isNew,isValid,_errors,question,childDocument}",
+    "fields.@each.{isNew,isValid,_errors,hidden,question,childDocument}",
     function() {
       if (this.fields.every(f => f.isNew)) {
         return "untouched";
       }
 
-      const visibleFields = this.fields.filter(f => !f.question.hidden);
+      const visibleFields = this.fields.filter(f => !f.hidden);
       const requiredFields = visibleFields.filter(f => !f.question.optional);
 
       if (


### PR DESCRIPTION
Without this, the hidden state of fields considered in the "state"
computation of navigation entries "lags" behind it's actual value.