### PR TITLE
chore(deps): remove obsolete dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,8 +66,6 @@
   "devDependencies": {
     "@adfinis-sygroup/semantic-release-config": "2.1.1",
     "@babel/plugin-proposal-object-rest-spread": "7.4.4",
-    "@commitlint/cli": "7.6.1",
-    "@commitlint/config-conventional": "7.6.0",
     "@ember/jquery": "0.6.0",
     "@ember/optional-features": "0.7.0",
     "babel-eslint": "10.0.1",


### PR DESCRIPTION
Those two dependencies are handled by https://github.com/adfinis-sygroup/semantic-release-config/ which is already a dependency. If we remove them we only have to maintain one dependency instead of three.

PS: `yarn.lock` didn't change because the dependency stays the same since `@adfinis-sygroup/semantic-release-config` currently references the same version we had