### PR TITLE
fix(document): add fallback if no fields

### DIFF
--- a/addon/lib/document.js
+++ b/addon/lib/document.js
@@ -141,7 +141,7 @@ export default EmberObject.extend({
     if (field.answer.value && !field.question.hidden) {
       if (field.question.__typename === "TableQuestion") {
         return (field.get("answer.value") || []).map(doc =>
-          doc.fields.reduce((obj, field) => {
+          (doc.fields || []).reduce((obj, field) => {
             return {
               ...obj,
               [field.question.slug]: field.answer.value


### PR DESCRIPTION
doc.getWithDefault() would be nice here. But I couldn't reproduce the 
error and didn't want to spend too much time on that.