### PR TITLE
fix(form): fix removing of empty answers

### DIFF
--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -356,6 +356,7 @@ export default Base.extend(Evented, {
     }
 
     this.set("raw.answer", response);
+    this.set("answer.raw", response);
 
     return response;
   }).restartable(),


### PR DESCRIPTION
This makes sure that the answer has a uuid property which computes to `answer.raw.id`