### PR TITLE
WIP: Move to native class syntax for the lib objects

### DIFF
--- a/addon/lib/answer.js
+++ b/addon/lib/answer.js
@@ -13,8 +13,8 @@ import { parseDocument } from "ember-caluma/lib/parsers";
  *
  * @class Answer
  */
-export default Base.extend({
-  calumaStore: service(),
+export default class Answer extends Base {
+  @service calumaStore;
 
   init() {
     assert(
@@ -26,10 +26,10 @@ export default Base.extend({
       this.set("pk", `Answer:${decodeId(this.raw.id)}`);
     }
 
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.setProperties(this.raw);
-  },
+  }
 
   /**
    * The uuid of the answer
@@ -37,9 +37,10 @@ export default Base.extend({
    * @property {String} uuid
    * @accessor
    */
-  uuid: computed("raw.id", function() {
+  @computed("raw.id")
+  get uuid() {
     return this.raw.id ? decodeId(this.raw.id) : null;
-  }),
+  }
 
   /**
    * The name of the property in which the value is stored. This depends on the
@@ -50,12 +51,13 @@ export default Base.extend({
    * @accessor
    * @private
    */
-  _valueKey: computed("__typename", function() {
+  @computed("__typename")
+  get _valueKey() {
     return (
       this.__typename &&
       `${camelize(this.__typename.replace(/Answer$/, ""))}Value`
     );
-  }),
+  }
 
   /**
    * The value of the answer, the type of this value depends on the type of the
@@ -64,7 +66,7 @@ export default Base.extend({
    * @property {String|Number|String[]|Document[]} value
    * @computed
    */
-  value: computed(
+  @computed(
     "_valueKey",
     "stringValue",
     "integerValue",
@@ -72,37 +74,35 @@ export default Base.extend({
     "listValue",
     "fileValue",
     "dateValue",
-    "tableValue",
-    {
-      get() {
-        const value = this.get(this._valueKey);
+    "tableValue"
+  )
+  get value() {
+    const value = this.get(this._valueKey);
 
-        if (this.__typename === "TableAnswer" && value) {
-          return value.map(document => {
-            const existing = this.calumaStore.find(
-              `Document:${decodeId(document.id)}`
-            );
+    if (this.__typename === "TableAnswer" && value) {
+      return value.map(document => {
+        const existing = this.calumaStore.find(
+          `Document:${decodeId(document.id)}`
+        );
 
-            return (
-              existing ||
-              Document.create(getOwner(this).ownerInjection(), {
-                raw: parseDocument(document)
-              })
-            );
-          });
-        }
-
-        return value;
-      },
-      set(_, value) {
-        if (this._valueKey) {
-          this.set(this._valueKey, value);
-        }
-
-        return value;
-      }
+        return (
+          existing ||
+          Document.create(getOwner(this).ownerInjection(), {
+            raw: parseDocument(document)
+          })
+        );
+      });
     }
-  ),
+
+    return value;
+  }
+  set value(value) {
+    if (this._valueKey) {
+      this.set(this._valueKey, value);
+    }
+
+    return value;
+  }
 
   /**
    * The value serialized for a backend request.
@@ -110,11 +110,12 @@ export default Base.extend({
    * @property {String|Number|String[]} serializedValue
    * @accessor
    */
-  serializedValue: computed("value", function() {
+  @computed("value")
+  get serializedValue() {
     if (this.__typename === "TableAnswer") {
       return (this.value || []).map(({ uuid }) => uuid);
     }
 
     return this.value;
-  })
-});
+  }
+}

--- a/addon/lib/base.js
+++ b/addon/lib/base.js
@@ -3,11 +3,11 @@ import { getOwner } from "@ember/application";
 import { assert } from "@ember/debug";
 import { inject as service } from "@ember/service";
 
-export default EmberObject.extend({
-  calumaStore: service(),
+export default class Base extends EmberObject {
+  @service calumaStore;
 
   init() {
-    this._super(...arguments);
+    super.init(...arguments);
 
     assert("Owner must be injected", getOwner(this));
 
@@ -23,7 +23,7 @@ export default EmberObject.extend({
     if (this.pk) {
       this.calumaStore.push(this);
     }
-  },
+  }
 
   willDestroy() {
     this._super(...arguments);
@@ -32,4 +32,4 @@ export default EmberObject.extend({
       this.calumaStore.delete(this.pk);
     }
   }
-});
+}

--- a/addon/lib/question.js
+++ b/addon/lib/question.js
@@ -8,7 +8,7 @@ import { expression } from "ember-caluma/utils/jexl";
  *
  * @class Question
  */
-export default Base.extend({
+export default class Question extends Base {
   init() {
     assert(
       "A graphql question `raw` must be passed",
@@ -20,11 +20,11 @@ export default Base.extend({
       value: `Question:${this.raw.slug}`
     });
 
-    this._super(...arguments);
+    super.init(...arguments);
 
     this.setProperties(this.raw);
-  },
+  }
 
-  hiddenExpression: expression("isHidden"),
-  requiredExpression: expression("isRequired")
-});
+  @expression("isHidden") hiddenExpression
+  @expression("isRequired") requiredExpression
+}

--- a/addon/lib/question.js
+++ b/addon/lib/question.js
@@ -25,6 +25,6 @@ export default class Question extends Base {
     this.setProperties(this.raw);
   }
 
-  @expression("isHidden") hiddenExpression
-  @expression("isRequired") requiredExpression
+  @expression("isHidden") hiddenExpression;
+  @expression("isRequired") requiredExpression;
 }

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "ember-cli-sri": "2.1.1",
     "ember-cli-template-lint": "1.0.0-beta.3",
     "ember-cli-uglify": "3.0.0",
+    "ember-decorators-polyfill": "^1.0.6",
     "ember-disable-prototype-extensions": "1.1.3",
     "ember-engines": "0.8.2",
     "ember-export-application-global": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7038,6 +7038,15 @@ ember-copy@^1.0.0:
     ember-cli-typescript "^2.0.1"
     ember-inflector "^3.0.0"
 
+ember-decorators-polyfill@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/ember-decorators-polyfill/-/ember-decorators-polyfill-1.0.6.tgz#93094a1eebfd8d54e85abd941f78bc330dc3f973"
+  integrity sha512-Mvrja3FBBLaZ3crmAAnrSZLz41bESWI8Tm54YUwSbp16Osqa/lPHRE8Clxn+qtjBDRpAHq0EcROILGTaBscE2g==
+  dependencies:
+    ember-cli-babel "^7.1.2"
+    ember-cli-version-checker "^3.1.3"
+    ember-compatibility-helpers "^1.2.0"
+
 ember-deep-set@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/ember-deep-set/-/ember-deep-set-0.2.0.tgz#93428b599f884c3da0550cbcc062b9ec5969a71e"
@@ -7803,7 +7812,7 @@ eslint-scope@3.7.1:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-scope@^4.0.0:
+eslint-scope@^4.0.0, eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
   integrity sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==
@@ -9976,7 +9985,7 @@ inquirer@^3.3.0:
     strip-ansi "^4.0.0"
     through "^2.3.6"
 
-inquirer@^6, inquirer@^6.2.0, inquirer@^6.4.1:
+inquirer@^6, inquirer@^6.2.0, inquirer@^6.2.2, inquirer@^6.4.1:
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.0.tgz#2303317efc9a4ea7ec2e2df6f86569b734accf42"
   integrity sha512-scfHejeG/lVZSpvCXpsB4j/wQNPM5JC8kiElOI0OUTwmc1RTpXr4H32/HOlQHcZiYl2z2VElwuCVDRG8vFmbnA==
@@ -15924,7 +15933,7 @@ strip-indent@^2.0.0:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
   integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
-strip-json-comments@2.0.1, strip-json-comments@~2.0.1:
+strip-json-comments@2.0.1, strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
   integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=


### PR DESCRIPTION
**Objects to refactor**
- [x] Base
- [x] Answer
- [ ] Document
- [ ] Field
- [ ] Fieldset
- [ ] Form
- [ ] Navigation
- [x] Question

**Other tasks**
- [ ] Step 1: Remove usage of `init()`
- [ ] Step 2: Remove dependency to `EmberObject`