### PR TITLE
fix(lib): fix teardown of lib objects

### DIFF
--- a/addon/components/cf-content.js
+++ b/addon/components/cf-content.js
@@ -60,7 +60,11 @@ export default Component.extend(ComponentQueryManager, {
   willDestroy() {
     this._super(...arguments);
 
-    this.calumaStore.clear();
+    this.document.destroy();
+
+    if (this.navigation) {
+      this.navigation.destroy();
+    }
   },
 
   /**
@@ -151,8 +155,6 @@ export default Component.extend(ComponentQueryManager, {
       },
       "allForms.edges"
     )).map(({ node }) => node);
-
-    this.calumaStore.clear();
 
     return Document.create(getOwner(this).ownerInjection(), {
       raw: parseDocument({ ...answerDocument, form })

--- a/addon/lib/document.js
+++ b/addon/lib/document.js
@@ -38,7 +38,7 @@ export default Base.extend({
 
   _createRootForm() {
     const rootForm =
-      this.calumaStore.find(`Form:${this.raw.rootForm}`) ||
+      this.calumaStore.find(`Form:${this.raw.rootForm.slug}`) ||
       Form.create(getOwner(this).ownerInjection(), {
         raw: this.raw.rootForm
       });
@@ -58,6 +58,14 @@ export default Base.extend({
     });
 
     this.set("fieldsets", fieldsets);
+  },
+
+  willDestroy() {
+    this._super(...arguments);
+
+    const fieldsets = this.fieldsets;
+    this.set("fieldsets", []);
+    fieldsets.forEach(fieldset => fieldset.destroy());
   },
 
   /**

--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -94,6 +94,14 @@ export default Base.extend(ObjectQueryManager, {
     this.set("_errors", []);
   },
 
+  willDestroy() {
+    this._super(...arguments);
+
+    if (this.answer) {
+      this.answer.destroy();
+    }
+  },
+
   _createQuestion() {
     const question =
       this.calumaStore.find(`Question:${this.raw.question.slug}`) ||

--- a/addon/lib/fieldset.js
+++ b/addon/lib/fieldset.js
@@ -41,6 +41,14 @@ export default Base.extend({
     this._createFields();
   },
 
+  willDestroy() {
+    this._super(...arguments);
+
+    const fields = this.fields;
+    this.set("fields", []);
+    fields.forEach(field => field.destroy());
+  },
+
   _createForm() {
     const form =
       this.calumaStore.find(`Form:${this.raw.form.slug}`) ||


### PR DESCRIPTION
This makes sure that if `cf-content` is being destroyed it destroys all lib objects containing data or state with it in the proper order.