### PR TITLE
fix(field): don't delete non-existent answers

### DIFF
--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -329,7 +329,7 @@ export default Base.extend(ObjectQueryManager, {
     let response;
 
     if (value === null || value.length === 0) {
-      if (!this.answer.uuid) {
+      if (this.isNew) {
         return;
       }
 

--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -329,6 +329,10 @@ export default Base.extend(ObjectQueryManager, {
     let response;
 
     if (value === null || value.length === 0) {
+      if (!this.answer.uuid) {
+        return;
+      }
+
       response = yield this.apollo.mutate(
         {
           mutation: removeAnswerMutation,


### PR DESCRIPTION
Currently, saving an empty value in a field with no previous value errors.