### PR TITLE
feat(options): hide archived options

### DIFF
--- a/addon-mirage-support/factories/option.js
+++ b/addon-mirage-support/factories/option.js
@@ -3,5 +3,6 @@ import { Factory } from "ember-cli-mirage";
 export default Factory.extend({
   slug: i => `option-${i + 1}`,
   label: i => `Option ${i + 1}`,
-  meta: () => ({})
+  meta: () => ({}),
+  isArchived: false
 });

--- a/addon/components/cf-field/input/radio.js
+++ b/addon/components/cf-field/input/radio.js
@@ -15,10 +15,11 @@ export default Component.extend({
   choices: computed(
     "field.question.{choiceOptions,dynamicChoiceOptions}.edges",
     function() {
-      if (this.get("field.question.__typename").includes("Dynamic")) {
-        return this.get("field.question.dynamicChoiceOptions.edges");
-      }
-      return this.get("field.question.choiceOptions.edges");
+      const options = this.get("field.question.__typename").includes("Dynamic")
+        ? this.get("field.question.dynamicChoiceOptions.edges")
+        : this.get("field.question.choiceOptions.edges");
+
+      return options.filter(option => !option.node.isArchived);
     }
   )
 });

--- a/addon/gql/fragments/field-question.graphql
+++ b/addon/gql/fragments/field-question.graphql
@@ -29,6 +29,7 @@ fragment SimpleQuestion on Question {
         node {
           slug
           label
+          isArchived
         }
       }
     }
@@ -39,6 +40,7 @@ fragment SimpleQuestion on Question {
         node {
           slug
           label
+          isArchived
         }
       }
     }

--- a/tests/dummy/mirage/scenarios/default.js
+++ b/tests/dummy/mirage/scenarios/default.js
@@ -39,7 +39,8 @@ export default function(server) {
     formIds: [form.id],
     options: [
       server.create("option", { label: "Yes" }),
-      server.create("option", { label: "Hell yes" })
+      server.create("option", { label: "Hell yes" }),
+      server.create("option", { label: "Certainly", isArchived: true })
     ]
   });
   server.create("question", {

--- a/tests/integration/components/cf-content-test.js
+++ b/tests/integration/components/cf-content-test.js
@@ -73,7 +73,8 @@ module("Integration | Component | cf-content", function(hooks) {
       });
 
       if (question.type === "CHOICE") {
-        assert.dom(`[name="${id}"][value="${answer.value}"]`).isChecked();
+        const test = question.isArchived ? "isNotChecked" : "isChecked";
+        assert.dom(`[name="${id}"][value="${answer.value}"]`)[test]();
       } else if (question.type === "MULTIPLE_CHOICE") {
         // checkbox options have their option slug postfixed to the name in
         // order to support IE11
@@ -96,15 +97,19 @@ module("Integration | Component | cf-content", function(hooks) {
       );
 
       if (question.type === "CHOICE") {
-        options.forEach(({ slug }) => {
-          assert.dom(`[name="${id}"][value="${slug}"]`).isDisabled();
-        });
+        options
+          .filter(option => !option.isArchived)
+          .forEach(({ slug }) => {
+            assert.dom(`[name="${id}"][value="${slug}"]`).isDisabled();
+          });
       } else if (question.type === "MULTIPLE_CHOICE") {
-        options.forEach(({ slug }) => {
-          assert
-            .dom(`[name="${id}:Option:${slug}"][value="${slug}"]`)
-            .isDisabled();
-        });
+        options
+          .filter(option => !option.isArchived)
+          .forEach(({ slug }) => {
+            assert
+              .dom(`[name="${id}:Option:${slug}"][value="${slug}"]`)
+              .isDisabled();
+          });
       } else {
         assert.dom(`[name="${id}"]`).isDisabled();
       }


### PR DESCRIPTION
This change will hide archived options from the public forms.

The changes for the form-builder will come in a different PR: