### PR TITLE
fix(cfb-options): options cannot be deleted from db

### DIFF
--- a/addon/templates/components/cfb-form-editor/question/options.hbs
+++ b/addon/templates/components/cfb-form-editor/question/options.hbs
@@ -8,7 +8,7 @@
       model=row
     as |f|}}
       <div uk-grid class="uk-grid-small uk-flex">
-        {{#if (gt optionRows.length 1)}}
+        {{#if (and row.isNew (gt optionRows.length 1))}}
           <div class="uk-width-auto">
             <button
               data-test-delete-row

--- a/tests/integration/components/cfb-form-editor/question/options-test.js
+++ b/tests/integration/components/cfb-form-editor/question/options-test.js
@@ -65,7 +65,7 @@ module("Integration | Component | cfb-form-editor/question/options", function(
     assert.dom("li").exists({ count: 3 });
   });
 
-  test("it can delete row", async function(assert) {
+  test("it can delete unsaved row", async function(assert) {
     assert.expect(3);
 
     this.set("model", { slug: "prefix" });
@@ -83,10 +83,11 @@ module("Integration | Component | cfb-form-editor/question/options", function(
 
     assert.dom("li").exists({ count: 3 });
 
-    await click("[data-test-row=option-2] [data-test-delete-row]");
+    await click("[data-test-add-row]");
+    await click("[data-test-row=option-3] [data-test-delete-row]");
 
-    assert.dom("li").exists({ count: 2 });
-    assert.dom("[data-test-row=option-2]").doesNotExist();
+    assert.dom("li").exists({ count: 3 });
+    assert.dom("[data-test-row=option-3]").doesNotExist();
   });
 
   test("it can update", async function(assert) {


### PR DESCRIPTION
This change only presents the possibility to delete options as long as they are not saved to the database.

PS: This PR will not work as-is. It needs the changes from #515 