### PR TITLE
chore(jexl): remove obsolete jexl cleaning functions

### DIFF
--- a/addon/components/cfb-form-editor/question-list/item.js
+++ b/addon/components/cfb-form-editor/question-list/item.js
@@ -5,7 +5,6 @@ import { reads } from "@ember/object/computed";
 import { task } from "ember-concurrency";
 import jexl from "jexl";
 import { computed } from "@ember/object";
-import { cleanExpression } from "ember-caluma/utils/jexl";
 
 export default Component.extend({
   layout,
@@ -26,7 +25,7 @@ export default Component.extend({
     return tsk;
   }),
   _requiredTask: task(function*() {
-    return yield jexl.eval(cleanExpression(this.get("question.isRequired")));
+    return yield jexl.eval(this.get("question.isRequired"));
   }),
 
   didInsertElement() {

--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -218,20 +218,18 @@ export default Base.extend({
    */
   hiddenDependencies: computed(
     "document.fields.[]",
-    "question.hiddenExpression",
+    "question.isHidden",
     function() {
-      return getDependenciesFromJexl(this.question.hiddenExpression).map(
-        slug => {
-          const f = this.document.findField(slug);
+      return getDependenciesFromJexl(this.question.isHidden).map(slug => {
+        const f = this.document.findField(slug);
 
-          assert(
-            `Field for question \`${slug}\` was not found in this document. Please check the \`isHidden\` jexl expression: \`${this.question.hiddenExpression}\`.`,
-            f
-          );
+        assert(
+          `Field for question \`${slug}\` was not found in this document. Please check the \`isHidden\` jexl expression: \`${this.question.isHidden}\`.`,
+          f
+        );
 
-          return f;
-        }
-      );
+        return f;
+      });
     }
   ),
 
@@ -246,20 +244,18 @@ export default Base.extend({
    */
   optionalDependencies: computed(
     "document.fields.[]",
-    "question.requiredExpression",
+    "question.isRequired",
     function() {
-      return getDependenciesFromJexl(this.question.requiredExpression).map(
-        slug => {
-          const f = this.document.findField(slug);
+      return getDependenciesFromJexl(this.question.isRequired).map(slug => {
+        const f = this.document.findField(slug);
 
-          assert(
-            `Field for question \`${slug}\` was not found in this document. Please check the \`isRequired\` jexl expression: \`${this.question.requiredExpression}\`.`,
-            f
-          );
+        assert(
+          `Field for question \`${slug}\` was not found in this document. Please check the \`isRequired\` jexl expression: \`${this.question.isRequired}\`.`,
+          f
+        );
 
-          return f;
-        }
-      );
+        return f;
+      });
     }
   ),
 
@@ -282,7 +278,7 @@ export default Base.extend({
         (this.hiddenDependencies.length &&
           this.hiddenDependencies.every(fieldIsHidden)) ||
         this.document.jexl.evalSync(
-          this.question.hiddenExpression,
+          this.question.isHidden,
           this.document.jexlContext
         )
       );
@@ -308,7 +304,7 @@ export default Base.extend({
         (this.optionalDependencies.length &&
           this.optionalDependencies.every(fieldIsHidden)) ||
         !this.document.jexl.evalSync(
-          this.question.requiredExpression,
+          this.question.isRequired,
           this.document.jexlContext
         )
       );

--- a/addon/lib/question.js
+++ b/addon/lib/question.js
@@ -1,7 +1,6 @@
 import Base from "ember-caluma/lib/base";
 import { defineProperty } from "@ember/object";
 import { assert } from "@ember/debug";
-import { expression } from "ember-caluma/utils/jexl";
 
 /**
  * Object which represents a question in context of a field
@@ -23,8 +22,5 @@ export default Base.extend({
     this._super(...arguments);
 
     this.setProperties(this.raw);
-  },
-
-  hiddenExpression: expression("isHidden"),
-  requiredExpression: expression("isRequired")
+  }
 });

--- a/addon/utils/jexl.js
+++ b/addon/utils/jexl.js
@@ -1,4 +1,3 @@
-import { computed } from "@ember/object";
 import jexl from "jexl";
 
 export const intersects = (left, right) =>
@@ -58,32 +57,4 @@ export const getTransforms = tree => {
   return transforms;
 };
 
-/**
- * Function to clean all whitespace characters of a jexl expression
- *
- * @function cleanExpression
- * @param {String} expression The raw expression
- * @return {String} The cleaned expression
- *
- * @todo Remove this when https://github.com/TomFrost/Jexl/pull/54/ is merged
- */
-export const cleanExpression = expression => {
-  return expression.replace(/\s+/g, " ").trim();
-};
-
-/**
- * Computed property macro for automatically cleaning expression's whitespace
- * characters.
- *
- * @function expression
- * @param {String} key Key of the property holding the raw expression
- * @return {Function} The computed property
- *
- * @todo Remove this when https://github.com/TomFrost/Jexl/pull/54/ is merged
- */
-export const expression = key =>
-  computed(key, function() {
-    return cleanExpression(this.get(key));
-  });
-
-export default { getTransforms, getAST, cleanExpression, expression };
+export default { getTransforms, getAST };

--- a/tests/unit/utils/jexl-test.js
+++ b/tests/unit/utils/jexl-test.js
@@ -1,12 +1,6 @@
-import {
-  getAST,
-  getTransforms,
-  cleanExpression,
-  expression
-} from "ember-caluma/utils/jexl";
+import { getAST, getTransforms } from "ember-caluma/utils/jexl";
 import { module, test } from "qunit";
 import { setupTest } from "ember-qunit";
-import EmberObject from "@ember/object";
 
 module("Unit | Utility | jexl", function(hooks) {
   setupTest(hooks);
@@ -85,19 +79,5 @@ module("Unit | Utility | jexl", function(hooks) {
       },
       type: "BinaryExpression"
     });
-  });
-
-  test("clean expression and expression computed macro works", async function(assert) {
-    assert.expect(2);
-
-    const whitespaced = "(\n  1 == 1\r    &&\r    2 == 2\n)";
-    const cleaned = "( 1 == 1 && 2 == 2 )";
-
-    const obj = EmberObject.extend({
-      cleaned: expression("whitespaced")
-    }).create({ whitespaced });
-
-    assert.equal(cleanExpression(whitespaced), cleaned);
-    assert.equal(obj.cleaned, cleaned);
   });
 });


### PR DESCRIPTION
This is now possible since whitespace support was added in the latest
version