### PR TITLE
fix(ie11): remove usage of queryManager which breaks in IE11

### DIFF
--- a/addon/components/cf-content.js
+++ b/addon/components/cf-content.js
@@ -4,7 +4,7 @@ import { reads } from "@ember/object/computed";
 import { assert } from "@ember/debug";
 import { computed } from "@ember/object";
 import { inject as service } from "@ember/service";
-import { queryManager } from "ember-apollo-client";
+import { ComponentQueryManager } from "ember-apollo-client";
 import { task } from "ember-concurrency";
 
 import Document from "ember-caluma/lib/document";
@@ -42,10 +42,9 @@ import getDocumentFormsQuery from "ember-caluma/gql/queries/get-document-forms";
  * @yield {CfNavigationComponent} content.navigation
  * @yield {CfPaginationComponent} content.pagination
  */
-export default Component.extend({
+export default Component.extend(ComponentQueryManager, {
   layout,
 
-  apollo: queryManager(),
   router: service(),
   calumaStore: service(),
 

--- a/addon/components/cf-field-value.js
+++ b/addon/components/cf-field-value.js
@@ -3,17 +3,15 @@ import Component from "@ember/component";
 import layout from "../templates/components/cf-field-value";
 import { computed } from "@ember/object";
 import { camelize } from "@ember/string";
-import { queryManager } from "ember-apollo-client";
+import { ComponentQueryManager } from "ember-apollo-client";
 import getFileAnswerInfoQuery from "ember-caluma/gql/queries/get-fileanswer-info";
 
 function getOptionKey(questionType) {
   return `${camelize(questionType.replace(/Question$/, ""))}Options`;
 }
 
-export default Component.extend({
+export default Component.extend(ComponentQueryManager, {
   layout,
-
-  apollo: queryManager(),
 
   tagName: "span",
 

--- a/addon/components/cf-field/input/file.js
+++ b/addon/components/cf-field/input/file.js
@@ -2,16 +2,14 @@ import Component from "@ember/component";
 import { computed } from "@ember/object";
 import { reads } from "@ember/object/computed";
 import { inject as service } from "@ember/service";
-import { queryManager } from "ember-apollo-client";
+import { ComponentQueryManager } from "ember-apollo-client";
 
 import getFileAnswerInfoQuery from "ember-caluma/gql/queries/get-fileanswer-info";
 import layout from "../../../templates/components/cf-field/input/file";
 
-export default Component.extend({
+export default Component.extend(ComponentQueryManager, {
   layout,
   tagName: "",
-
-  apollo: queryManager(),
 
   intl: service(),
 

--- a/addon/components/cf-field/input/powerselect.js
+++ b/addon/components/cf-field/input/powerselect.js
@@ -2,7 +2,7 @@ import Component from "@ember/component";
 import { computed } from "@ember/object";
 import { inject as service } from "@ember/service";
 import layout from "../../../templates/components/cf-field/input/powerselect";
-import { queryManager } from "ember-apollo-client";
+import { ComponentQueryManager } from "ember-apollo-client";
 
 /**
  * Dropdown component for the single and multiple choice question type
@@ -10,12 +10,10 @@ import { queryManager } from "ember-apollo-client";
  * @class CfFieldInputPowerSelectComponent
  * @argument {Field} field The field for this input type
  */
-export default Component.extend({
+export default Component.extend(ComponentQueryManager, {
   layout,
 
   tagName: "",
-
-  apollo: queryManager(),
 
   intl: service(),
 

--- a/addon/components/cf-field/input/table.js
+++ b/addon/components/cf-field/input/table.js
@@ -3,16 +3,14 @@ import layout from "../../../templates/components/cf-field/input/table";
 import { task, all } from "ember-concurrency";
 import saveDocumentMutation from "ember-caluma/gql/mutations/save-document";
 import { inject as service } from "@ember/service";
-import { queryManager } from "ember-apollo-client";
+import { ComponentQueryManager } from "ember-apollo-client";
 import { computed } from "@ember/object";
 import { getOwner } from "@ember/application";
 import Document from "ember-caluma/lib/document";
 import { parseDocument } from "ember-caluma/lib/parsers";
 
-export default Component.extend({
+export default Component.extend(ComponentQueryManager, {
   layout,
-
-  apollo: queryManager(),
 
   notification: service(),
   intl: service(),

--- a/addon/components/cf-form.js
+++ b/addon/components/cf-form.js
@@ -1,5 +1,4 @@
 import Component from "@ember/component";
-import { queryManager } from "ember-apollo-client";
 import layout from "../templates/components/cf-form";
 import { assert } from "@ember/debug";
 
@@ -17,8 +16,6 @@ export default Component.extend({
   tagName: "form",
   attributeBindings: ["novalidate"],
   novalidate: "novalidate",
-
-  apollo: queryManager(),
 
   didReceiveAttrs() {
     this._super(...arguments);

--- a/addon/components/cfb-form-editor/general.js
+++ b/addon/components/cfb-form-editor/general.js
@@ -3,7 +3,7 @@ import { inject as service } from "@ember/service";
 import { computed } from "@ember/object";
 import layout from "../../templates/components/cfb-form-editor/general";
 import { task, timeout } from "ember-concurrency";
-import { queryManager } from "ember-apollo-client";
+import { ComponentQueryManager } from "ember-apollo-client";
 import validations from "../../validations/form";
 import v4 from "uuid/v4";
 import slugify from "ember-caluma/utils/slugify";
@@ -15,11 +15,9 @@ import checkFormSlugQuery from "ember-caluma/gql/queries/check-form-slug";
 import formEditorGeneralQuery from "ember-caluma/gql/queries/form-editor-general";
 import saveFormMutation from "ember-caluma/gql/mutations/save-form";
 
-export default Component.extend({
+export default Component.extend(ComponentQueryManager, {
   layout,
   validations,
-
-  apollo: queryManager(),
 
   notification: service(),
   intl: service(),

--- a/addon/components/cfb-form-editor/question-list.js
+++ b/addon/components/cfb-form-editor/question-list.js
@@ -4,7 +4,7 @@ import UIkit from "uikit";
 import { run } from "@ember/runloop";
 import { optional } from "ember-composable-helpers/helpers/optional";
 import { task, timeout } from "ember-concurrency";
-import { queryManager } from "ember-apollo-client";
+import { ComponentQueryManager } from "ember-apollo-client";
 import { computed } from "@ember/object";
 import v4 from "uuid/v4";
 import { inject as service } from "@ember/service";
@@ -15,11 +15,9 @@ import reorderFormQuestionsMutation from "ember-caluma/gql/mutations/reorder-for
 import addFormQuestionMutation from "ember-caluma/gql/mutations/add-form-question";
 import removeFormQuestionMutation from "ember-caluma/gql/mutations/remove-form-question";
 
-export default Component.extend({
+export default Component.extend(ComponentQueryManager, {
   layout,
   tagName: "div",
-
-  apollo: queryManager(),
 
   notification: service(),
   intl: service(),

--- a/addon/components/cfb-form-editor/question.js
+++ b/addon/components/cfb-form-editor/question.js
@@ -2,7 +2,7 @@ import Component from "@ember/component";
 import { inject as service } from "@ember/service";
 import layout from "../../templates/components/cfb-form-editor/question";
 import { task, timeout } from "ember-concurrency";
-import { queryManager } from "ember-apollo-client";
+import { ComponentQueryManager } from "ember-apollo-client";
 import v4 from "uuid/v4";
 import { optional } from "ember-composable-helpers/helpers/optional";
 import { computed, getWithDefault } from "@ember/object";
@@ -51,11 +51,9 @@ export const TYPES = {
   DateQuestion: saveDateQuestionMutation
 };
 
-export default Component.extend({
+export default Component.extend(ComponentQueryManager, {
   layout,
   validations,
-
-  apollo: queryManager(),
 
   notification: service(),
   intl: service(),

--- a/addon/components/cfb-form-editor/question/validation.js
+++ b/addon/components/cfb-form-editor/question/validation.js
@@ -2,13 +2,11 @@ import Component from "@ember/component";
 import { computed } from "@ember/object";
 import { task } from "ember-concurrency";
 import layout from "../../../templates/components/cfb-form-editor/question/validation";
-import { queryManager } from "ember-apollo-client";
+import { ComponentQueryManager } from "ember-apollo-client";
 import allFormatValidatorsQuery from "ember-caluma/gql/queries/all-format-validators";
 
-export default Component.extend({
+export default Component.extend(ComponentQueryManager, {
   layout,
-
-  apollo: queryManager(),
 
   init() {
     this._super(...arguments);

--- a/addon/components/cfb-form-list.js
+++ b/addon/components/cfb-form-list.js
@@ -1,13 +1,11 @@
 import Component from "@ember/component";
 import layout from "../templates/components/cfb-form-list";
 import { task } from "ember-concurrency";
-import { queryManager } from "ember-apollo-client";
+import { ComponentQueryManager } from "ember-apollo-client";
 import formListQuery from "ember-caluma/gql/queries/form-list";
 
-export default Component.extend({
+export default Component.extend(ComponentQueryManager, {
   layout,
-
-  apollo: queryManager(),
 
   didReceiveAttrs() {
     this._super(...arguments);

--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -8,7 +8,7 @@ import { camelize } from "@ember/string";
 import { task } from "ember-concurrency";
 import { all, resolve } from "rsvp";
 import { validate } from "ember-validators";
-import { queryManager } from "ember-apollo-client";
+import { ObjectQueryManager } from "ember-apollo-client";
 
 import Answer from "ember-caluma/lib/answer";
 import Question from "ember-caluma/lib/question";
@@ -63,7 +63,7 @@ const getDependenciesFromJexl = expression => {
  *
  * @class Field
  */
-export default Base.extend({
+export default Base.extend(ObjectQueryManager, {
   saveDocumentFloatAnswerMutation,
   saveDocumentIntegerAnswerMutation,
   saveDocumentStringAnswerMutation,
@@ -71,8 +71,6 @@ export default Base.extend({
   saveDocumentFileAnswerMutation,
   saveDocumentDateAnswerMutation,
   saveDocumentTableAnswerMutation,
-
-  apollo: queryManager(),
 
   intl: service(),
   calumaStore: service(),

--- a/addon/routes/edit.js
+++ b/addon/routes/edit.js
@@ -3,12 +3,10 @@ import { inject as service } from "@ember/service";
 import NavigationRouteMixin from "ember-caluma/mixins/navigation-route";
 import { task } from "ember-concurrency";
 import gql from "graphql-tag";
-import { queryManager } from "ember-apollo-client";
+import { RouteQueryManager } from "ember-apollo-client";
 import { reads } from "@ember/object/computed";
 
-export default Route.extend(NavigationRouteMixin, {
-  apollo: queryManager(),
-
+export default Route.extend(NavigationRouteMixin, RouteQueryManager, {
   intl: service(),
 
   title: reads("fetchName.lastSuccessful.value.firstObject.node.name"),

--- a/addon/routes/edit/questions/edit.js
+++ b/addon/routes/edit/questions/edit.js
@@ -3,12 +3,10 @@ import { inject as service } from "@ember/service";
 import NavigationRouteMixin from "ember-caluma/mixins/navigation-route";
 import { task } from "ember-concurrency";
 import gql from "graphql-tag";
-import { queryManager } from "ember-apollo-client";
+import { RouteQueryManager } from "ember-apollo-client";
 import { reads } from "@ember/object/computed";
 
-export default Route.extend(NavigationRouteMixin, {
-  apollo: queryManager(),
-
+export default Route.extend(NavigationRouteMixin, RouteQueryManager, {
   intl: service(),
 
   title: reads("fetchLabel.lastSuccessful.value.firstObject.node.label"),

--- a/addon/services/validator.js
+++ b/addon/services/validator.js
@@ -2,11 +2,9 @@ import Service from "@ember/service";
 import { task } from "ember-concurrency";
 import allFormatValidatorsQuery from "ember-caluma/gql/queries/all-format-validators";
 import { assert } from "@ember/debug";
-import { queryManager } from "ember-apollo-client";
+import { ObjectQueryManager } from "ember-apollo-client";
 
-export default Service.extend({
-  apollo: queryManager(),
-
+export default Service.extend(ObjectQueryManager, {
   /**
    * Tests a value against one or multiple regular expressions.
    *

--- a/tests/dummy/app/routes/demo/form.js
+++ b/tests/dummy/app/routes/demo/form.js
@@ -1,10 +1,8 @@
 import Route from "@ember/routing/route";
-import { queryManager } from "ember-apollo-client";
+import { RouteQueryManager } from "ember-apollo-client";
 import gql from "graphql-tag";
 
-export default Route.extend({
-  apollo: queryManager(),
-
+export default Route.extend(RouteQueryManager, {
   async model() {
     const documents = await this.apollo.query(
       {

--- a/tests/dummy/app/routes/index.js
+++ b/tests/dummy/app/routes/index.js
@@ -1,14 +1,12 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 import { get } from "@ember/object";
-import { queryManager } from "ember-apollo-client";
+import { RouteQueryManager } from "ember-apollo-client";
 import gql from "graphql-tag";
 import { decodeId } from "ember-caluma/helpers/decode-id";
 import ENV from "ember-caluma/config/environment";
 
-export default Route.extend({
-  apollo: queryManager(),
-
+export default Route.extend(RouteQueryManager, {
   intl: service(),
   calumaOptions: service(),
 


### PR DESCRIPTION
`ember-apollo-client`'s `queryManager` breaks IE11 currently. To fix
this we now use the deprecated mixins. This can be reverted, as soon as
https://github.com/ember-graphql/ember-apollo-client/issues/303 is
resolved.