### PR TITLE
fix: change disabled to readonly where applicable

### DIFF
--- a/addon/components/cf-field/input/float.js
+++ b/addon/components/cf-field/input/float.js
@@ -9,11 +9,11 @@ import Component from "@ember/component";
 export default Component.extend({
   tagName: "input",
   classNames: ["uk-input"],
-  classNameBindings: ["field.isInvalid:uk-form-danger"],
+  classNameBindings: ["field.isInvalid:uk-form-danger", "disabled:uk-disabled"],
   attributeBindings: [
     "type",
     "step",
-    "disabled",
+    "disabled:readonly",
     "field.pk:name",
     "field.answer.value:value",
     "field.question.floatMinValue:min",

--- a/addon/components/cf-field/input/integer.js
+++ b/addon/components/cf-field/input/integer.js
@@ -9,11 +9,11 @@ import Component from "@ember/component";
 export default Component.extend({
   tagName: "input",
   classNames: ["uk-input"],
-  classNameBindings: ["field.isInvalid:uk-form-danger"],
+  classNameBindings: ["field.isInvalid:uk-form-danger", "disabled:uk-disabled"],
   attributeBindings: [
     "type",
     "step",
-    "disabled",
+    "disabled:readonly",
     "field.pk:name",
     "field.answer.value:value",
     "field.question.integerMinValue:min",

--- a/addon/components/cf-field/input/text.js
+++ b/addon/components/cf-field/input/text.js
@@ -9,10 +9,10 @@ import Component from "@ember/component";
 export default Component.extend({
   tagName: "input",
   classNames: ["uk-input"],
-  classNameBindings: ["field.isInvalid:uk-form-danger"],
+  classNameBindings: ["field.isInvalid:uk-form-danger", "disabled:uk-disabled"],
   attributeBindings: [
     "type",
-    "disabled",
+    "disabled:readonly",
     "field.pk:name",
     "field.answer.value:value",
     "field.question.placeholder:placeholder"

--- a/addon/components/cf-field/input/textarea.js
+++ b/addon/components/cf-field/input/textarea.js
@@ -9,9 +9,9 @@ import Component from "@ember/component";
 export default Component.extend({
   tagName: "textarea",
   classNames: ["uk-textarea"],
-  classNameBindings: ["field.isInvalid:uk-form-danger"],
+  classNameBindings: ["field.isInvalid:uk-form-danger", "disabled:uk-disabled"],
   attributeBindings: [
-    "disabled",
+    "disabled:readonly",
     "field.pk:name",
     "field.answer.value:value",
     "field.question.textareaMaxLength:maxlength"

--- a/addon/templates/components/cf-field/input/file.hbs
+++ b/addon/templates/components/cf-field/input/file.hbs
@@ -1,19 +1,21 @@
-<div
-  class="uk-width-1-1"
-  uk-form-custom="target: true">
+{{#unless disabled}}
+  <div
+    class="uk-width-1-1"
+    uk-form-custom="target: true">
 
-  <input
-    type="file"
-    name={{field.pk}}
-    onchange={{action "save"}}>
+    <input
+      type="file"
+      name={{field.pk}}
+      onchange={{action "save"}}>
 
-  <input
-    class="uk-input"
-    type="text"
-    placeholder={{placeholder}}
-    readonly>
+    <input
+      class="uk-input"
+      type="text"
+      placeholder={{placeholder}}
+      readonly>
 
-</div>
+  </div>
+{{/unless}}
 
 {{#if (and downloadUrl downloadName)}}
   {{#uk-button color="link" on-click=(action "download")}}

--- a/addon/templates/components/cf-field/input/table.hbs
+++ b/addon/templates/components/cf-field/input/table.hbs
@@ -49,16 +49,23 @@
     bgClose=false
   }}
     {{#if documentToEdit}}
-      {{cf-form-wrapper document=documentToEdit fieldset=(object-at 0 documentToEdit.fieldsets) disabled=disabled}}
-    {{/if}}
-    <p class="uk-text-right">
-      {{uk-button
-        label=(t "caluma.form.save")
-        disabled=save.isRunning
-        loading=save.isRunning
-        on-click=(perform save)
+      {{cf-form-wrapper
+        document=documentToEdit
+        fieldset=(object-at 0 documentToEdit.fieldsets)
+        disabled=disabled
       }}
-    </p>
+    {{/if}}
+
+    {{#unless disabled}}
+      <p class="uk-text-right">
+        {{uk-button
+          label=(t "caluma.form.save")
+          disabled=save.isRunning
+          loading=save.isRunning
+          on-click=(perform save)
+        }}
+      </p>
+    {{/unless}}
   {{/uk-modal}}
 
   {{#uk-modal

--- a/app/styles/_uikit-overwrites.scss
+++ b/app/styles/_uikit-overwrites.scss
@@ -1,0 +1,46 @@
+// UIkit overwrites
+// ----------------
+// These styles amend UIkit so that disabled form elements can be styled as
+// disabled with a class instead of just by the element's disabled property.
+//
+// There is an open pull request upstream:
+// https://github.com/uikit/uikit/pull/3990
+
+.uk-radio.uk-disabled,
+.uk-checkbox.uk-disabled {
+  cursor: default;
+}
+
+.uk-input.uk-disabled,
+.uk-select.uk-disabled,
+.uk-textarea.uk-disabled {
+  background-color: $form-disabled-background;
+  color: $form-disabled-color;
+  @if(mixin-exists(hook-form-disabled)) {@include hook-form-disabled();}
+}
+
+.uk-select:not([multiple]):not([size]).uk-disabled {
+  @include svg-fill($internal-form-select-image, "#000", $form-select-disabled-icon-color);
+}
+
+.uk-radio.uk-disabled,
+.uk-checkbox.uk-disabled {
+  background-color: $form-radio-disabled-background;
+  @if(mixin-exists(hook-form-radio-disabled)) {@include hook-form-radio-disabled();}
+}
+
+.uk-radio.uk-disabled:checked {
+  @include svg-fill($internal-form-radio-image, "#000", $form-radio-disabled-icon-color);
+}
+
+.uk-checkbox.uk-disabled:checked {
+  @include svg-fill($internal-form-checkbox-image, "#000", $form-radio-disabled-icon-color);
+}
+
+.uk-checkbox.uk-disabled:indeterminate {
+  @include svg-fill($internal-form-checkbox-indeterminate-image, "#000", $form-radio-disabled-icon-color);
+}
+
+.uk-disabled[readonly] {
+  pointer-events: all;
+}

--- a/app/styles/ember-caluma.scss
+++ b/app/styles/ember-caluma.scss
@@ -8,6 +8,8 @@
 @import "cf-field";
 @import "cf-navigation";
 
+@import "_uikit-overwrites";
+
 .cfb-pointer {
   cursor: pointer;
 }

--- a/tests/integration/components/cf-content-test.js
+++ b/tests/integration/components/cf-content-test.js
@@ -111,7 +111,8 @@ module("Integration | Component | cf-content", function(hooks) {
               .isDisabled();
           });
       } else {
-        assert.dom(`[name="${id}"]`).isDisabled();
+        assert.dom(`[name="${id}"]`).hasAttribute("readonly");
+        assert.dom(`[name="${id}"]`).hasClass("uk-disabled");
       }
     });
   });

--- a/tests/integration/components/cf-field-test.js
+++ b/tests/integration/components/cf-field-test.js
@@ -95,11 +95,12 @@ module("Integration | Component | cf-field", function(hooks) {
   });
 
   test("it renders disabled fields", async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     await render(hbs`{{cf-field field=field disabled=true}}`);
 
-    assert.dom("input[type=text]").isDisabled();
+    assert.dom("input[type=text]").hasAttribute("readonly");
+    assert.dom("input[type=text]").hasClass("uk-disabled");
   });
 
   test("it validates input", async function(assert) {

--- a/tests/integration/components/cf-field/input-test.js
+++ b/tests/integration/components/cf-field/input-test.js
@@ -136,7 +136,7 @@ module("Integration | Component | cf-field/input", function(hooks) {
   });
 
   test("it renders disabled fields", async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     await render(hbs`
       {{cf-field/input
@@ -149,6 +149,7 @@ module("Integration | Component | cf-field/input", function(hooks) {
       }}
     `);
 
-    assert.dom("input[type=text]").isDisabled();
+    assert.dom("input[type=text]").hasAttribute("readonly");
+    assert.dom("input[type=text]").hasClass("uk-disabled");
   });
 });

--- a/tests/integration/components/cf-field/input/float-test.js
+++ b/tests/integration/components/cf-field/input/float-test.js
@@ -34,11 +34,12 @@ module("Integration | Component | cf-field/input/float", function(hooks) {
   });
 
   test("it can be disabled", async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     await render(hbs`{{cf-field/input/float disabled=true}}`);
 
-    assert.dom("input").isDisabled();
+    assert.dom("input").hasAttribute("readonly");
+    assert.dom("input").hasClass("uk-disabled");
   });
 
   test("it triggers save on input", async function(assert) {

--- a/tests/integration/components/cf-field/input/integer-test.js
+++ b/tests/integration/components/cf-field/input/integer-test.js
@@ -34,11 +34,12 @@ module("Integration | Component | cf-field/input/integer", function(hooks) {
   });
 
   test("it can be disabled", async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     await render(hbs`{{cf-field/input/integer disabled=true}}`);
 
-    assert.dom("input").isDisabled();
+    assert.dom("input").hasAttribute("readonly");
+    assert.dom("input").hasClass("uk-disabled");
   });
 
   test("it triggers save on input", async function(assert) {

--- a/tests/integration/components/cf-field/input/text-test.js
+++ b/tests/integration/components/cf-field/input/text-test.js
@@ -30,11 +30,12 @@ module("Integration | Component | cf-field/input/text", function(hooks) {
   });
 
   test("it can be disabled", async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     await render(hbs`{{cf-field/input/text disabled=true}}`);
 
-    assert.dom("input").isDisabled();
+    assert.dom("input").hasAttribute("readonly");
+    assert.dom("input").hasClass("uk-disabled");
   });
 
   test("it triggers save on input", async function(assert) {

--- a/tests/integration/components/cf-field/input/textarea-test.js
+++ b/tests/integration/components/cf-field/input/textarea-test.js
@@ -30,11 +30,12 @@ module("Integration | Component | cf-field/input/textarea", function(hooks) {
   });
 
   test("it can be disabled", async function(assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     await render(hbs`{{cf-field/input/textarea disabled=true}}`);
 
-    assert.dom("textarea").isDisabled();
+    assert.dom("textarea").hasAttribute("readonly");
+    assert.dom("textarea").hasClass("uk-disabled");
   });
 
   test("it triggers save on input", async function(assert) {


### PR DESCRIPTION
IIRC, the reasoning for this one goes like this:

* it’s impossible to copy text out of a disabled field in Firefox, which is problematic in one of our projects
* readonly fields look like they can be edited, which is bad UX

-> this is changing disabled fields to readonly ones, but styles them like disabled fields.