### PR TITLE
fix(table): don't re-save existing rows after edit

### DIFF
--- a/addon/components/cf-field/input/table.js
+++ b/addon/components/cf-field/input/table.js
@@ -85,7 +85,6 @@ export default Component.extend(ComponentQueryManager, {
         );
       } else {
         // TODO: delete dangling document
-        yield this.onSave([...rows]);
       }
 
       this.set("showAddModal", false);


### PR DESCRIPTION
Saving the existing rows does nothing except messing up the revision history.