### PR TITLE
fix(table): skip empty dates in table view

### DIFF
--- a/addon/components/cf-field-value.js
+++ b/addon/components/cf-field-value.js
@@ -49,7 +49,7 @@ export default Component.extend(ComponentQueryManager, {
       }
       case "DateQuestion": {
         return {
-          label: moment(field.answer.value).format("L")
+          label: field.answer.value && moment(field.answer.value).format("L")
         };
       }
 


### PR DESCRIPTION
Currently, an empty/missing date is displayed as "Invalid Date".