### PR TITLE
chore: remove support for ember 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,7 @@ jobs:
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
     - stage: "Additional Tests"
-      env: EMBER_TRY_SCENARIO=ember-lts-3.8
-    - env: EMBER_TRY_SCENARIO=ember-lts-3.12
+      env: EMBER_TRY_SCENARIO=ember-lts-3.12
     - env: EMBER_TRY_SCENARIO=ember-release
 
     - stage: "Release"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ The Ember.js addon for [Caluma](https://projectcaluma.github.io) - a collaborati
 
 You can find the interactive documentation [here](https://projectcaluma.github.io/ember-caluma).
 
+## Compatibility
+
+`ember-caluma` is guaranteed to work with the **last LTS version** of Ember.js (currently 3.12).
+
 ## Contributing
 
 ### Installation

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -7,20 +7,6 @@ module.exports = async function() {
     useYarn: true,
     scenarios: [
       {
-        name: "ember-lts-3.8",
-        env: {
-          EMBER_OPTIONAL_FEATURES: JSON.stringify({
-            "jquery-integration": true
-          })
-        },
-        npm: {
-          devDependencies: {
-            "@ember/jquery": "^0.5.1",
-            "ember-source": "~3.8.0"
-          }
-        }
-      },
-      {
         name: "ember-lts-3.12",
         env: {
           EMBER_OPTIONAL_FEATURES: JSON.stringify({


### PR DESCRIPTION
BREAKING CHANGE: This will remove the support for the second last LTS
version of ember, since we support only the last LTS version which is
3.12 now.