### PR TITLE
feat(form): allow empty values for answers

### DIFF
--- a/addon/gql/mutations/remove-answer.graphql
+++ b/addon/gql/mutations/remove-answer.graphql
@@ -1,5 +1,0 @@
-mutation($input: RemoveAnswerInput!) {
-  removeAnswer(input: $input) {
-    clientMutationId
-  }
-}

--- a/addon/mirage-graphql/schema.graphql
+++ b/addon/mirage-graphql/schema.graphql
@@ -1,5 +1,5 @@
 # source: http://localhost:8000/graphql
-# timestamp: Wed Nov 06 2019 13:15:23 GMT+0100 (Central European Standard Time)
+# timestamp: Wed Nov 20 2019 16:33:51 GMT+0100 (Central European Standard Time)
 
 input AddFormQuestionInput {
   form: ID!
@@ -88,6 +88,7 @@ enum AnswerLookupMode {
   CONTAINS
   ICONTAINS
   INTERSECTS
+  ISNULL
   GTE
   GT
   LTE
@@ -190,6 +191,9 @@ type Case implements Node {
     status: WorkItemStatusArgument
     task: ID
     case: ID
+    createdAt: DateTime
+    closedAt: DateTime
+    modifiedAt: DateTime
 
     """
     WorkItemOrdering
@@ -624,7 +628,7 @@ type DateAnswer implements Answer & Node {
   """
   id: ID!
   question: Question!
-  value: Date!
+  value: Date
   meta: GenericScalar!
   date: Date
 }
@@ -1173,7 +1177,7 @@ type FloatAnswer implements Answer & Node {
   """
   id: ID!
   question: Question!
-  value: Float!
+  value: Float
   meta: GenericScalar!
 }
 
@@ -1551,10 +1555,12 @@ scalar GroupJexl
 
 """
 Lookup type to search document structures.
+
+When using lookup `ISNULL`, the provided `value` will be ignored.
 """
 input HasAnswerFilterType {
   question: ID!
-  value: GenericScalar!
+  value: GenericScalar
   lookup: AnswerLookupMode
   hierarchy: AnswerHierarchyMode
 }
@@ -1570,7 +1576,7 @@ type IntegerAnswer implements Answer & Node {
   """
   id: ID!
   question: Question!
-  value: Int!
+  value: Int
   meta: GenericScalar!
 }
 
@@ -1659,7 +1665,7 @@ type ListAnswer implements Answer & Node {
   """
   id: ID!
   question: Question!
-  value: [String]!
+  value: [String]
   meta: GenericScalar!
 }
 
@@ -2060,6 +2066,9 @@ type Query {
     caseMetaValue: [JSONValueFilterType]
     task: ID
     case: ID
+    createdAt: DateTime
+    closedAt: DateTime
+    modifiedAt: DateTime
     createdByUser: String
     createdByGroup: String
     metaHasKey: String
@@ -2503,7 +2512,7 @@ input SaveDocumentDateAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: Date!
+  value: Date
   clientMutationId: String
 }
 
@@ -2516,7 +2525,7 @@ input SaveDocumentFileAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: String!
+  value: String
   valueId: ID
   clientMutationId: String
 }
@@ -2530,7 +2539,7 @@ input SaveDocumentFloatAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: Float!
+  value: Float
   clientMutationId: String
 }
 
@@ -2550,7 +2559,7 @@ input SaveDocumentIntegerAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: Int!
+  value: Int
   clientMutationId: String
 }
 
@@ -2563,7 +2572,7 @@ input SaveDocumentListAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: [String]!
+  value: [String]
   clientMutationId: String
 }
 
@@ -2581,7 +2590,7 @@ input SaveDocumentStringAnswerInput {
   question: ID!
   document: ID!
   meta: JSONString
-  value: String!
+  value: String
   clientMutationId: String
 }
 
@@ -2598,7 +2607,7 @@ input SaveDocumentTableAnswerInput {
   """
   List of document IDs representing the rows in the table.
   """
-  value: [ID]!
+  value: [ID]
   clientMutationId: String
 }
 
@@ -3049,6 +3058,9 @@ enum SortableWorkItemAttributes {
   CREATED_BY_GROUP
   CREATED_BY_USER
   DESCRIPTION
+  CREATED_AT
+  MODIFIED_AT
+  CLOSED_AT
   IS_ARCHIVED
   IS_PUBLISHED
   NAME
@@ -3154,7 +3166,7 @@ type StringAnswer implements Answer & Node {
   """
   id: ID!
   question: Question!
-  value: String!
+  value: String
   meta: GenericScalar!
 }
 
@@ -3169,7 +3181,7 @@ type TableAnswer implements Answer & Node {
   """
   id: ID!
   question: Question!
-  value: [Document]!
+  value: [Document]
   meta: GenericScalar!
   document: Document!
 }
@@ -3778,6 +3790,9 @@ input WorkItemFilterSetType {
   status: Status
   task: ID
   case: ID
+  createdAt: DateTime
+  closedAt: DateTime
+  modifiedAt: DateTime
   createdByUser: String
   createdByGroup: String
   metaHasKey: String


### PR DESCRIPTION
This adds compatibility for
https://github.com/projectcaluma/caluma/pull/791. Instead of removing
answers with an empty value, we now save the empty value.

BREAKING CHANGE: Only works with caluma v4.0.0 (https://github.com/projectcaluma/caluma/pull/791)