### PR TITLE
fix(form): transform empty string answers to null

### DIFF
--- a/addon/lib/answer.js
+++ b/addon/lib/answer.js
@@ -95,6 +95,8 @@ export default Base.extend({
         return value;
       },
       set(_, value) {
+        value = [undefined, ""].includes(value) ? null : value;
+
         if (this._valueKey) {
           this.set(this._valueKey, value);
         }

--- a/tests/integration/components/cf-field-test.js
+++ b/tests/integration/components/cf-field-test.js
@@ -78,7 +78,7 @@ module("Integration | Component | cf-field", function(hooks) {
     this.set("field.answer.value", "Test");
 
     await fillIn("input", "");
-    assert.equal(this.field.answer.value, "", "Value was removed.");
+    assert.equal(this.field.answer.value, null, "Value was removed.");
   });
 
   test("it renders", async function(assert) {


### PR DESCRIPTION
StringAnswer is the only answer type that could have multiple types of
empty answers:

- empty string
- null

Since every other answer type can only have null as empty answer we now
transform empty strings to null to be consistent.