### PR TITLE
chore(ci): add firefox to test matrix and use more compact reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ dist: trusty
 
 addons:
   chrome: stable
+  firefox: latest
 
 cache:
   yarn: true

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -4,6 +4,7 @@ const getChannelURL = require("ember-source-channel-url");
 
 module.exports = async function() {
   return {
+    command: "ember test --silent",
     useYarn: true,
     scenarios: [
       {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "lint:js": "eslint .",
     "start": "ember serve",
     "start-proxy": "ember serve --proxy http://localhost:8000",
-    "test": "ember test",
+    "test": "ember test --silent",
     "test:all": "ember try:each",
     "update-schema": "graphql get-schema -e http://localhost:8000/graphql -o addon/mirage-graphql/schema.graphql && prettier --write addon/mirage-graphql/schema.graphql",
     "update-fragment-types": "node fetch-fragment-types.js && prettier --write addon/-private/fragment-types.js"

--- a/testem.js
+++ b/testem.js
@@ -1,7 +1,10 @@
 module.exports = {
   test_page: "tests/index.html?hidepassed",
   disable_watching: true,
-  launch_in_ci: ["Chrome"],
+  parallel: "2",
+  reporter: "dot",
+  framework: "qunit",
+  launch_in_ci: ["Chrome", "Firefox"],
   launch_in_dev: [],
   browser_args: {
     Chrome: {
@@ -16,6 +19,9 @@ module.exports = {
         "--remote-debugging-port=0",
         "--window-size=1440,900"
       ].filter(Boolean)
+    },
+    Firefox: {
+      ci: ["-headless", "--window-size=1440,900"]
     }
   }
 };


### PR DESCRIPTION
Running tests now looks like this:

![Selection_019](https://user-images.githubusercontent.com/6150577/69327490-eb6c9b80-0c4d-11ea-876d-9cd1df9c3674.png)

Failed tests would be below the dot matrix with a clear error