### PR TITLE
fix(cli): prepare apollo-client for next version

### DIFF
--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -8,9 +8,8 @@ module.exports = function(defaults) {
   const app = new EmberAddon(defaults, {
     sassOptions: { implementation: sass },
     snippetPaths: ["tests/dummy/app/snippets"],
-    babel: {
-      plugins: ["@babel/plugin-proposal-object-rest-spread"]
-    }
+    babel: { plugins: ["@babel/plugin-proposal-object-rest-spread"] },
+    emberApolloClient: { keepGraphqlFileExtension: false }
   });
 
   app.import("node_modules/moment/locale/de.js");


### PR DESCRIPTION
> DEPRECATION: [ember-apollo-client] Deprecation:
>         The configuration option keepGraphqlFileExtension was not defined.
>         The current default is 'false', but it will change to 'true' after the next major release.