### PR TITLE
chore(ci): do not run browserstack tests on forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ jobs:
         - bash <(curl -s https://codecov.io/bash) -f coverage/lcov.info
 
     - name: Tests (Browserstack)
+      if: fork = false
       env:
         - BROWSERSTACK_USERNAME=caluma1
         - secure: "mKthlQkNc/tI3reQogz6KHdhicbEnaW1e6ZSndDtmgdumoYqj5Wn+4X1pqFoG/Bc5Ga86Jkkp7gpQwPcj4CPE8iUAoqNTYqibC9weTdCBNn0NNjlUBbXvsq5cVj7Eq0ssSuENzqGfsbfMZ1aeQEZHDOUFYTtggAtzj+7InpuaJ0kNmmBrMgdoReztMGbaTqqIaAv73cLlndeU3yObBRGIzeq4whntGvXCdNK9ei0AxHuhJg86P7rYpN3K6HvW2omoeMmHY4Z6wt0mQkiWa4HxAHT9uh5rLa1hbrjPlQEHmcay+iEspGNfQnAHoUjVJ9OtHSV82ujlZKeLAL0/kMBBREzKPXulaJ4JO9bTs5iLSbSjuaSu+No6EeDeqlq6/JpSJh1VwN3hin9HldmozMOn6M6P2jt9ZB288tLSRcP6Dr/Ss837wsd+KXRftt6YceiTL5QI0IWbdnjaHr2l/vHhh0+EOdfVWe4xr+s0IOtfFpLGhg+WNCm34V8VdVgXCAeBmeI9PgT5cPUuCuPVf/VmEQTYLdjNa0POmjhLhR4ukD7REiyz4n5Q4EfU+IV0YM6+dl+I6BdMNGQKjvyoD8uMTzyDXYETfb3eFz9DhugvEV+Keo0lI3eVQZCwtGIpfZKtrgaA5fC4Q8nGgPG4c5ni4Kf6eDZyGiB9GQwkZnIdQ8="


### PR DESCRIPTION
Secret variables can't be used in jobs triggered by PRs of forks.
Therefore the browserstack tests will fail because the connection fails.

https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml