### PR TITLE
fix(field): don't pass `value` to save mutation if null

### DIFF
--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -451,7 +451,9 @@ export default Base.extend({
           input: {
             question: this.question.slug,
             document: this.document.uuid,
-            value: this.answer.serializedValue
+            ...(this.answer.serializedValue !== null
+              ? { value: this.answer.serializedValue }
+              : {})
           }
         }
       },


### PR DESCRIPTION
See
https://github.com/projectcaluma/caluma/commit/81cbe9aae553ed91a86c1813a47085fb3b386713

> Since graphql-core doesn't support `null` literals yet, the way for
setting the value of an Answer to `None` is to omit the `value` field
altogether.