### PR TITLE
fix: remove FormAnswer

### DIFF
--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -34,7 +34,7 @@ const TYPE_MAP = {
   DynamicMultipleChoiceQuestion: "ListAnswer",
   DynamicChoiceQuestion: "StringAnswer",
   TableQuestion: "TableAnswer",
-  FormQuestion: "FormAnswer",
+  FormQuestion: null,
   FileQuestion: "FileAnswer",
   StaticQuestion: null,
   DateQuestion: "DateAnswer"


### PR DESCRIPTION
FormAnswer was removed from Caluma, so no reason to still use it.