### PR TITLE
feat(jexl): add info object to context

### DIFF
--- a/addon/lib/document.js
+++ b/addon/lib/document.js
@@ -139,7 +139,7 @@ export default Base.extend({
 
       return {
         form: this.rootForm.slug,
-        info: { root: { form: this.rootForm.slug } }
+        info: { root: { form: this.rootForm.slug } },
       };
     }
   ),

--- a/addon/lib/document.js
+++ b/addon/lib/document.js
@@ -137,7 +137,10 @@ export default Base.extend({
     function () {
       if (this.parentDocument) return this.parentDocument.jexlContext;
 
-      return { form: this.rootForm.slug };
+      return {
+        form: this.rootForm.slug,
+        info: { root: { form: this.rootForm.slug } }
+      };
     }
   ),
 

--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -339,12 +339,15 @@ export default Base.extend({
    * - `info.form`: The form this question is attached to.
    * - `info.parent.form`: The parent form if applicable.
    * - `info.root.form`: The new property for the root form.
+   *
+   * @property {Object} jexlContext
+   * @accessor
    */
   jexlContext: computed(
     "document.jexlContext.{form,info.root.form}",
     "fieldset.{form.slug,field.fieldset.form.slug}",
     "question.{isHidden,isRequired}",
-    function() {
+    function () {
       const context = cloneDeep(this.document.jexlContext);
       context.info.form = this.get("fieldset.form.slug");
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "graphql-tag": "^2.10.3",
     "graphql-tools": "^4.0.7",
     "jexl": "^2.2.0",
+    "lodash.clonedeep": "^4.5.0",
     "sass": "^1.26.3",
     "slugify": "^1.4.0",
     "uuid": "^7.0.2"

--- a/tests/unit/lib/document-test.js
+++ b/tests/unit/lib/document-test.js
@@ -126,7 +126,10 @@ module("Unit | Library | document", function (hooks) {
   test("computes the correct jexl context", async function (assert) {
     assert.expect(1);
 
-    assert.deepEqual(this.document.jexlContext, { form: "form" });
+    assert.deepEqual(this.document.jexlContext, {
+      form: "form",
+      info: { root: { form: "form" } }
+    });
   });
 
   skip("it recomputes hidden on hidden change of parent fieldset", async function () {});

--- a/tests/unit/lib/document-test.js
+++ b/tests/unit/lib/document-test.js
@@ -128,7 +128,7 @@ module("Unit | Library | document", function (hooks) {
 
     assert.deepEqual(this.document.jexlContext, {
       form: "form",
-      info: { root: { form: "form" } }
+      info: { root: { form: "form" } },
     });
   });
 

--- a/tests/unit/lib/field-test.js
+++ b/tests/unit/lib/field-test.js
@@ -110,7 +110,7 @@ module("Unit | Library | field", function (hooks) {
     assert.deepEqual(field.optionalDependencies, [dependentField]);
   });
 
-  test("computes the correct Jexl context", async function(assert) {
+  test("computes the correct Jexl context", async function (assert) {
     assert.expect(1);
 
     const field = this.document.findField("question-1");
@@ -120,12 +120,12 @@ module("Unit | Library | field", function (hooks) {
       info: {
         form: "form",
         parent: null,
-        root: { form: "form" }
-      }
+        root: { form: "form" },
+      },
     });
   });
 
-  test("it can handle newlines in Jexl expressions", async function(assert) {
+  test("it can handle newlines in Jexl expressions", async function (assert) {
     assert.expect(2);
 
     const field = this.document.findField("question-2");

--- a/tests/unit/lib/field-test.js
+++ b/tests/unit/lib/field-test.js
@@ -110,7 +110,22 @@ module("Unit | Library | field", function (hooks) {
     assert.deepEqual(field.optionalDependencies, [dependentField]);
   });
 
-  test("it can handle newlines in JEXL expressions", async function (assert) {
+  test("computes the correct Jexl context", async function(assert) {
+    assert.expect(1);
+
+    const field = this.document.findField("question-1");
+
+    assert.deepEqual(field.jexlContext, {
+      form: "form",
+      info: {
+        form: "form",
+        parent: null,
+        root: { form: "form" }
+      }
+    });
+  });
+
+  test("it can handle newlines in Jexl expressions", async function(assert) {
     assert.expect(2);
 
     const field = this.document.findField("question-2");


### PR DESCRIPTION
Depends on https://github.com/projectcaluma/caluma/pull/978

```js
{
  form: rootFormSlug,
  info: {
    form: currentFormSlug,
    parent: { form: parentFormSlug },
    root: { form: rootFormSlug }
  }
}
```

`info.root.form == "root-form"`
`info.parent.form == "parent-form"`
`info.form == "current-form"`

Legacy JEXL expressions will still work through:
`form == "root-form"`