### PR TITLE
chore(ci): add dependency linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,17 +15,22 @@ jobs:
   lint:
     name: Lint
     runs-on: [ubuntu-latest]
+
+    strategy:
+      matrix:
+        target: [js, hbs, deps]
+
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v1
         with:
           node-version: 10
 
-      - name: Install Dependencies
+      - name: Install dependencies
         run: yarn install
 
-      - name: Lint Handlebars
-        run: yarn lint
+      - name: Lint ${{ matrix.target }}
+        run: yarn lint:${{ matrix.target }}
 
   test:
     name: Tests

--- a/config/dependency-lint.js
+++ b/config/dependency-lint.js
@@ -1,0 +1,13 @@
+"use strict";
+
+module.exports = {
+  generateTests: false,
+  allowedVersions: {
+    // https://github.com/jasonmit/ember-cli-moment-shim/issues/183
+    moment: "2.24.0",
+
+    // EC v3+ heavily relies on Proxy which is not supported by IE11
+    "ember-changeset": "^2.2.4",
+    "ember-changeset-validations": "^2.2.1",
+  },
+};

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "lint": "npm-run-all --aggregate-output --continue-on-error --parallel lint:*",
     "lint:hbs": "ember-template-lint .",
     "lint:js": "eslint .",
+    "lint:deps": "ember dependency-lint",
     "start": "ember serve",
     "start-proxy": "ember serve --proxy http://localhost:8000",
     "test": "npm-run-all lint:* test:*",
@@ -77,6 +78,7 @@
     "ember-cli-browserstack": "1.1.0",
     "ember-cli-code-coverage": "1.0.0-beta.9",
     "ember-cli-dependency-checker": "3.2.0",
+    "ember-cli-dependency-lint": "^1.1.3",
     "ember-cli-deploy": "1.0.2",
     "ember-cli-deploy-build": "2.0.0",
     "ember-cli-deploy-git": "1.3.4",
@@ -115,6 +117,10 @@
     "testem-failure-only-reporter": "0.0.1",
     "typeface-oxygen": "0.0.72",
     "typeface-oxygen-mono": "0.0.72"
+  },
+  "resolutions": {
+    "**/ember-test-waiters": "^2.1.3",
+    "ember-changeset-validations/ember-changeset": "^2.2.5"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2873,7 +2873,7 @@ aproba@^1.0.3, aproba@^1.1.1, aproba@^1.1.2:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-2.0.0.tgz#52520b8ae5b569215b354efc0caa3fe1e45a8adc"
   integrity sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ==
 
-archy@~1.0.0:
+archy@^1.0.0, archy@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/archy/-/archy-1.0.0.tgz#f9c8c13757cc1dd7bc379ac77b2c62a5c2868c40"
   integrity sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=
@@ -6967,15 +6967,7 @@ ember-changeset-validations@^2.2.1:
     ember-get-config "^0.2.4"
     ember-validators "^2.0.0"
 
-ember-changeset@2.2.4:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/ember-changeset/-/ember-changeset-2.2.4.tgz#2bf8c67815a57ee2e7ff76e6b58fc63bd3bdf1b9"
-  integrity sha512-JRcX/o8TpDhCkMwxcFxFepZ1nMJHFVwvEGXkZCdO1YZCzDkdkFCieaDQD+5S+B8kTRCLiiXPeClhG8XQOzcEkg==
-  dependencies:
-    ember-cli-babel "^7.1.2"
-    ember-deep-set "^0.2.0"
-
-ember-changeset@^2.2.5:
+ember-changeset@2.2.4, ember-changeset@^2.2.5:
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/ember-changeset/-/ember-changeset-2.2.5.tgz#2d91edec5082db0b25536d0b2cc64b509f9c3a5d"
   integrity sha512-cCccfzpQSeN5dOXs7cG9YWMOSDAarSz6PMmLrwWBZ8+J0ZcRTPKGnEQN6Cdn61JlESrYJaFp9xshd1zf4zuprA==
@@ -7189,6 +7181,16 @@ ember-cli-dependency-checker@3.2.0:
     is-git-url "^1.0.0"
     resolve "^1.5.0"
     semver "^5.3.0"
+
+ember-cli-dependency-lint@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/ember-cli-dependency-lint/-/ember-cli-dependency-lint-1.1.3.tgz#ece5a319734d0b0462c12fd7a93d322e1f9fe60f"
+  integrity sha512-v836nMZuYhnvZ7MvIwGkwJkFhx7gc7RrlNcD90IHdBpR7kWBXIljLgSNIae84qKn1V1UqHImBTMnJvJCe2qvQw==
+  dependencies:
+    archy "^1.0.0"
+    broccoli-plugin "^1.3.0"
+    chalk "^2.3.0"
+    semver "^5.5.0"
 
 ember-cli-deploy-build@2.0.0:
   version "2.0.0"
@@ -8260,15 +8262,7 @@ ember-test-selectors@^4.1.0:
     ember-cli-babel "^7.19.0"
     ember-cli-version-checker "^5.0.2"
 
-ember-test-waiters@^1.1.1:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/ember-test-waiters/-/ember-test-waiters-1.2.0.tgz#c12ead4313934c24cff41857020cacdbf8e6effe"
-  integrity sha512-aEw7YuutLuJT4NUuPTNiGFwgTYl23ThqmBxSkfFimQAn+keWjAftykk3dlFELuhsJhYW/S8YoVjN0bSAQRLNtw==
-  dependencies:
-    ember-cli-babel "^7.11.0"
-    semver "^6.3.0"
-
-ember-test-waiters@^2.0.0:
+ember-test-waiters@^1.1.1, ember-test-waiters@^2.0.0, ember-test-waiters@^2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/ember-test-waiters/-/ember-test-waiters-2.1.3.tgz#40fe7b674d5ef1005f665e0e040753f88c5a2175"
   integrity sha512-xDjvq8/1C3b9z3NGpez7aslbq5gsLrxsdjD3apyziHkImh/PTeXZr2bxo/YAUgOwGOtpZ1So0fIsppiSN0u1Ng==


### PR DESCRIPTION
Depends on #1003 

This tool makes sure that only one version of a dependency is installed. It can also be used to say what version. This will help us maintain this addon since the dependency problem already bit us in the ass a couple of times..