### PR TITLE
fix(embed): render power select in place

### DIFF
--- a/addon/templates/components/cf-field/input/powerselect.hbs
+++ b/addon/templates/components/cf-field/input/powerselect.hbs
@@ -10,7 +10,7 @@
     @searchEnabled={{searchEnabled}}
     @searchField="label"
     @triggerId={{field.pk}}
-
+    @renderInPlace={{true}}
     @placeholder={{placeholder}}
     @loadingMessage={{t "caluma.form.power-select.options-loading"}}
     @searchMessage={{t "caluma.form.power-select.options-empty"}}


### PR DESCRIPTION
Without this no options are rendered if ember-caluma is embedded.