### PR TITLE
fix(blueprints): add ember-composable-helpers to host app dependencies

### DIFF
--- a/blueprints/ember-caluma/index.js
+++ b/blueprints/ember-caluma/index.js
@@ -12,6 +12,7 @@ module.exports = {
         { name: "ember-math-helpers" },
         { name: "ember-cli-showdown" },
         { name: "ember-pikaday" },
+        { name: "ember-composable-helpers" },
       ],
     });
   },


### PR DESCRIPTION
This is required so we can use the helpers from ember-composable-helpers.
Im not sure why this is needed in the first place. The same was already
done in commit 8319c63 for other dependencies.