### PR TITLE
fix(form): don't throw when typename is undefined in cf-field/input

### DIFF
--- a/addon/components/cf-field/input.js
+++ b/addon/components/cf-field/input.js
@@ -28,8 +28,8 @@ export default Component.extend({
     const typename = get(this, "field.question.__typename");
 
     return (
-      (typename && mapping[typename]) ||
-      typename.replace(/Question$/, "").toLowerCase()
+      typename &&
+      (mapping[typename] || typename.replace(/Question$/, "").toLowerCase())
     );
   }).readOnly(),
 });

--- a/addon/helpers/get-widget.js
+++ b/addon/helpers/get-widget.js
@@ -28,6 +28,9 @@ export default Helper.extend({
   compute(params, { default: defaultWidget = "cf-field/input" }) {
     for (let obj of params) {
       const widget = obj && get(obj, "meta.widgetOverride");
+      if (!widget) {
+        continue;
+      }
       const override =
         widget &&
         this.calumaOptions
@@ -36,7 +39,7 @@ export default Helper.extend({
 
       warn(
         `Widget override "${widget}" is not registered. Please register it by calling \`calumaOptions.registerComponentOverride\``,
-        !override,
+        override,
         { id: "ember-caluma.unregistered-override" }
       );
 


### PR DESCRIPTION
In one of our projects we ran into the issue that `typename` was
undefined during the loading of the page. This fix makes sure that we
don't fail in this situation.

This also includes a drive-by fix that prevents incorrect component
registration warnings.