### PR TITLE
chore(release): 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [6.4.0](https://github.com/projectcaluma/ember-caluma/compare/v6.3.0...v6.4.0) (2020-10-19)
+
+
+### Features
+
+* **caluma-query:** allow `queryOptions` to be set on `fetch` ([547d08d](https://github.com/projectcaluma/ember-caluma/commit/547d08d7897d85242a8524b61bc0d2a494f4cfa8))
+
 # [6.3.0](https://github.com/projectcaluma/ember-caluma/compare/v6.2.1...v6.3.0) (2020-10-06)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-caluma",
-  "version": "6.3.0",
+  "version": "6.4.0",
   "description": "The Ember.js addon for Caluma",
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
# [6.4.0](https://github.com/projectcaluma/ember-caluma/compare/v6.3.0...v6.4.0) (2020-10-19)

### Features

* **caluma-query:** allow `queryOptions` to be set on `fetch` ([547d08d](https://github.com/projectcaluma/ember-caluma/commit/547d08d7897d85242a8524b61bc0d2a494f4cfa8))