### PR TITLE
fix(config): fix power select limit default config

### DIFF
--- a/addon/components/cf-field/input/powerselect.js
+++ b/addon/components/cf-field/input/powerselect.js
@@ -29,10 +29,10 @@ export default Component.extend({
   }),
 
   searchEnabled: computed("field.options.length", function () {
-    const { powerSelectEnableSearchLimit: limit } = getOwner(
-      this
-    ).resolveRegistration("config:environment")["ember-caluma"];
-    return this.get("field.options.length") > limit;
+    const config = getOwner(this).resolveRegistration("config:environment");
+    const { powerSelectEnableSearchLimit = 10 } = config["ember-caluma"] || {};
+
+    return this.get("field.options.length") > powerSelectEnableSearchLimit;
   }),
 
   placeholder: computed("multiple", function () {

--- a/config/environment.js
+++ b/config/environment.js
@@ -5,10 +5,6 @@ module.exports = function (environment) {
     modulePrefix: "ember-caluma",
     environment,
 
-    "ember-caluma": {
-      powerSelectEnableSearchLimit: 10,
-    },
-
     "ember-validated-form": {
       theme: "uikit",
       defaults: {


### PR DESCRIPTION
Apparently, the pattern with configuring a default config in
`config/environment.js` doesn't work as documented and no major ember
addon uses this pattern. This broke every app that didn't configure the
`powerSelectEnableSearchLimit` option.