### PR TITLE
feat(cfb): add input for default values

### DIFF
--- a/addon/gql/mutations/remove-default-answer.graphql
+++ b/addon/gql/mutations/remove-default-answer.graphql
@@ -1,0 +1,5 @@
+mutation RemoveDefaultAnswer($input: RemoveDefaultAnswerInput!) {
+  removeDefaultAnswer(input: $input) {
+    clientMutationId
+  }
+}

--- a/addon/gql/mutations/save-default-date-answer.graphql
+++ b/addon/gql/mutations/save-default-date-answer.graphql
@@ -1,0 +1,9 @@
+# import * from 'ember-caluma/gql/fragments/field-answer'
+
+mutation($input: SaveDefaultDateAnswerInput!) {
+  saveDefaultDateAnswer(input: $input) {
+    answer {
+      ...FieldAnswer
+    }
+  }
+}

--- a/addon/gql/mutations/save-default-float-answer.graphql
+++ b/addon/gql/mutations/save-default-float-answer.graphql
@@ -1,0 +1,9 @@
+# import * from 'ember-caluma/gql/fragments/field-answer'
+
+mutation($input: SaveDefaultFloatAnswerInput!) {
+  saveDefaultFloatAnswer(input: $input) {
+    answer {
+      ...FieldAnswer
+    }
+  }
+}

--- a/addon/gql/mutations/save-default-integer-answer.graphql
+++ b/addon/gql/mutations/save-default-integer-answer.graphql
@@ -1,0 +1,9 @@
+# import * from 'ember-caluma/gql/fragments/field-answer'
+
+mutation($input: SaveDefaultIntegerAnswerInput!) {
+  saveDefaultIntegerAnswer(input: $input) {
+    answer {
+      ...FieldAnswer
+    }
+  }
+}

--- a/addon/gql/mutations/save-default-list-answer.graphql
+++ b/addon/gql/mutations/save-default-list-answer.graphql
@@ -1,0 +1,9 @@
+# import * from 'ember-caluma/gql/fragments/field-answer'
+
+mutation($input: SaveDefaultListAnswerInput!) {
+  saveDefaultListAnswer(input: $input) {
+    answer {
+      ...FieldAnswer
+    }
+  }
+}

--- a/addon/gql/mutations/save-default-string-answer.graphql
+++ b/addon/gql/mutations/save-default-string-answer.graphql
@@ -1,0 +1,9 @@
+# import * from 'ember-caluma/gql/fragments/field-answer'
+
+mutation($input: SaveDefaultStringAnswerInput!) {
+  saveDefaultStringAnswer(input: $input) {
+    answer {
+      ...FieldAnswer
+    }
+  }
+}

--- a/addon/gql/mutations/save-default-table-answer.graphql
+++ b/addon/gql/mutations/save-default-table-answer.graphql
@@ -1,0 +1,9 @@
+# import * from 'ember-caluma/gql/fragments/field-answer'
+
+mutation($input: SaveDefaultTableAnswerInput!) {
+  saveDefaultTableAnswer(input: $input) {
+    answer {
+      ...FieldAnswer
+    }
+  }
+}

--- a/addon/gql/queries/form-editor-question.graphql
+++ b/addon/gql/queries/form-editor-question.graphql
@@ -1,4 +1,6 @@
 # import * from 'ember-caluma/gql/fragments/question-info'
+# import * from 'ember-caluma/gql/fragments/field-question'
+# import SimpleAnswer from 'ember-caluma/gql/fragments/field-answer'
 
 query FormEditorQuestion($slug: String!) {
   allQuestions(slug: $slug) {
@@ -9,21 +11,43 @@ query FormEditorQuestion($slug: String!) {
           integerMaxValue: maxValue
           integerMinValue: minValue
           placeholder
+          defaultAnswer {
+            id
+            integerValue: value
+          }
         }
         ... on FloatQuestion {
           floatMaxValue: maxValue
           floatMinValue: minValue
           placeholder
+          defaultAnswer {
+            id
+            floatValue: value
+          }
         }
         ... on TextQuestion {
           minLength
           maxLength
           placeholder
+          defaultAnswer {
+            id
+            stringValue: value
+          }
         }
         ... on TextareaQuestion {
           minLength
           maxLength
           placeholder
+          defaultAnswer {
+            id
+            stringValue: value
+          }
+        }
+        ... on DateQuestion {
+          defaultAnswer {
+            id
+            dateValue: value
+          }
         }
         ... on MultipleChoiceQuestion {
           options {
@@ -35,6 +59,10 @@ query FormEditorQuestion($slug: String!) {
               }
             }
           }
+          defaultAnswer {
+            id
+            listValue: value
+          }
         }
         ... on ChoiceQuestion {
           options {
@@ -45,6 +73,10 @@ query FormEditorQuestion($slug: String!) {
                 isArchived
               }
             }
+          }
+          defaultAnswer {
+            id
+            stringValue: value
           }
         }
         ... on DynamicMultipleChoiceQuestion {
@@ -61,6 +93,29 @@ query FormEditorQuestion($slug: String!) {
                 node {
                   slug
                   label
+                }
+              }
+            }
+          }
+          defaultAnswer {
+            id
+            tableValue: value {
+              id
+              form {
+                slug
+                questions {
+                  edges {
+                    node {
+                      ...FieldQuestion
+                    }
+                  }
+                }
+              }
+              answers {
+                edges {
+                  node {
+                    ...SimpleAnswer
+                  }
                 }
               }
             }

--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -23,7 +23,7 @@ import { decodeId } from "ember-caluma/helpers/decode-id";
 import Base from "ember-caluma/lib/base";
 import { getAST, getTransforms } from "ember-caluma/utils/jexl";
 
-const TYPE_MAP = {
+export const TYPE_MAP = {
   TextQuestion: "StringAnswer",
   TextareaQuestion: "StringAnswer",
   IntegerQuestion: "IntegerAnswer",

--- a/addon/mirage-graphql/index.js
+++ b/addon/mirage-graphql/index.js
@@ -10,12 +10,18 @@ const importTypeOrBase = (path, type) => {
 };
 
 export const register = (tpl) => (target, name, descriptor) => {
+  if (descriptor.value.__isHandler) {
+    descriptor.value.__handlerFor.push(tpl);
+    return descriptor;
+  }
+
   descriptor.writable = false;
   descriptor.enumerable = true;
 
   descriptor.value = {
     __isHandler: true,
-    __handlerFor: tpl,
+    // Mocks can have multiple handlers per type.
+    __handlerFor: [tpl],
     fn: descriptor.value,
   };
 

--- a/addon/mirage-graphql/mocks/answer.js
+++ b/addon/mirage-graphql/mocks/answer.js
@@ -32,16 +32,20 @@ export default class extends BaseMock {
       },
     });
 
-    const doc = this.db.documents.findBy({ id: res.answer.documentId });
+    // Default answers don't have a document.
+    if (res.answer.documentId) {
+      const doc = this.db.documents.findBy({ id: res.answer.documentId });
 
-    this.db.documents.update(doc.id, {
-      answerIds: [...new Set([...(doc.answerIds || []), res.answer.id])],
-    });
+      this.db.documents.update(doc.id, {
+        answerIds: [...new Set([...(doc.answerIds || []), res.answer.id])],
+      });
+    }
 
     return res;
   }
 
   @register("SaveDocumentStringAnswerPayload")
+  @register("SaveDefaultStringAnswerPayload")
   handleSaveDocumentStringAnswer(_, { input }) {
     return this._handleSaveDocumentAnswer(_, {
       ...input,
@@ -51,6 +55,7 @@ export default class extends BaseMock {
   }
 
   @register("SaveDocumentIntegerAnswerPayload")
+  @register("SaveDefaultIntegerAnswerPayload")
   handleSaveIntegerAnswer(_, { input }) {
     return this._handleSaveDocumentAnswer(_, {
       ...input,
@@ -60,6 +65,7 @@ export default class extends BaseMock {
   }
 
   @register("SaveDocumentFloatAnswerPayload")
+  @register("SaveDefaultFloatAnswerPayload")
   handleSaveFloatAnswer(_, { input }) {
     return this._handleSaveDocumentAnswer(_, {
       ...input,
@@ -69,6 +75,7 @@ export default class extends BaseMock {
   }
 
   @register("SaveDocumentListAnswerPayload")
+  @register("SaveDefaultListAnswerPayload")
   handleSaveListAnswer(_, { input }) {
     return this._handleSaveDocumentAnswer(_, {
       ...input,
@@ -87,6 +94,7 @@ export default class extends BaseMock {
   }
 
   @register("SaveDocumentDateAnswerPayload")
+  @register("SaveDefaultDateAnswerPayload")
   handleSaveDateAnswer(_, { input }) {
     return this._handleSaveDocumentAnswer(_, {
       ...input,

--- a/addon/mirage-graphql/mocks/base.js
+++ b/addon/mirage-graphql/mocks/base.js
@@ -31,8 +31,14 @@ export default class {
       if (typeof handler === "object" && handler.__isHandler) {
         return {
           ...handlers,
-          [handler.__handlerFor.replace(/\{type\}/, this.type)]: (...args) =>
-            handler.fn.apply(this, args),
+          // Mocks can have multiple handlers per type.
+          ...handler.__handlerFor.reduce((targets, target) => {
+            return {
+              ...targets,
+              [target.replace(/\{type\}/, this.type)]: (...args) =>
+                handler.fn.apply(this, args),
+            };
+          }, {}),
         };
       }
 

--- a/addon/mirage-graphql/resolvers/index.js
+++ b/addon/mirage-graphql/resolvers/index.js
@@ -1,6 +1,7 @@
-import { GraphQLDateTime } from "graphql-iso-date";
+import { GraphQLDate, GraphQLDateTime } from "graphql-iso-date";
 
 export default {
+  Date: GraphQLDate,
   DateTime: GraphQLDateTime,
   // generic scalar serializes from a string to an object but deserializes as
   // object because of backend limitations.

--- a/addon/templates/components/cf-field/input/date.hbs
+++ b/addon/templates/components/cf-field/input/date.hbs
@@ -4,6 +4,6 @@
   id=field.pk
   format="L"
   onSelection=(action "onchange")
-  value=(get field.answer field.answer._valueKey)
+  value=field.answer.value
   disabled=disabled
 }}

--- a/addon/templates/components/cfb-form-editor/question.hbs
+++ b/addon/templates/components/cfb-form-editor/question.hbs
@@ -129,6 +129,14 @@
         }}
       {{/if}}
 
+      {{#if (and slug (has-question-type f.model "text" "textarea" "integer" "float" "choice" "multiple-choice" "date" "table"))}}
+        {{f.input
+          name="defaultAnswer"
+          label=(t "caluma.form-builder.question.defaultValue")
+          renderComponent=(component "cfb-form-editor/question/default")
+        }}
+      {{/if}}
+
       {{#if (has-question-type f.model "text" "textarea")}}
         {{f.input
           type="number"

--- a/addon/templates/components/cfb-form-editor/question/default.hbs
+++ b/addon/templates/components/cfb-form-editor/question/default.hbs
@@ -1,0 +1,10 @@
+{{component labelComponent}}
+
+{{component (get-widget this.field.question)
+  field=this.field
+  disabled=false
+  onSave=this.onUpdate
+}}
+
+{{component hintComponent}}
+{{component errorComponent}}

--- a/app/components/cfb-form-editor/question/default.js
+++ b/app/components/cfb-form-editor/question/default.js
@@ -1,0 +1,1 @@
+export { default } from "ember-caluma/components/cfb-form-editor/question/default";

--- a/tests/integration/components/cfb-form-editor/question/default-test.js
+++ b/tests/integration/components/cfb-form-editor/question/default-test.js
@@ -1,0 +1,28 @@
+import { render } from "@ember/test-helpers";
+import Changeset from "ember-changeset";
+import { hbs } from "ember-cli-htmlbars";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module(
+  "Integration | Component | cfb-form-editor/question/default",
+  function (hooks) {
+    setupRenderingTest(hooks);
+
+    test("it renders", async function (assert) {
+      this.changeset = new Changeset({ __typename: "TextQuestion" });
+      this.noop = () => {};
+
+      await render(hbs`
+        <CfbFormEditor::Question::Default
+          @name="test"
+          @model={{this.changeset}}
+          @update={{this.noop}}
+          @setDirty={{this.noop}}
+        />
+      `);
+
+      assert.ok(this.element);
+    });
+  }
+);

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -124,6 +124,7 @@ caluma:
       markdown: "Markdown"
       dataSource: "Datenquelle"
       formatValidators: "Validierung"
+      defaultValue: "Standardwert"
 
       general: "Allgemein"
       options: "Optionen"

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -124,6 +124,7 @@ caluma:
       markdown: "Markdown"
       dataSource: "Data source"
       formatValidators: "Validation"
+      defaultValue: "Default value"
 
       general: "General"
       options: "Options"

--- a/translations/fr.yaml
+++ b/translations/fr.yaml
@@ -77,6 +77,9 @@ caluma:
       month-next: "Mois suivant"
 
   form-builder:
+    question:
+      defaultValue: "Valeur par défaut"
+
     options:
       delete: "Supprimer l'option"
       archive: "Archiver (masquer) l'option"


### PR DESCRIPTION
This will create/update/delete default answers which will be used when rendering a form to fill out.

# Screenshots
## Text  
![Text](https://user-images.githubusercontent.com/65539425/101914698-e8c84580-3bc4-11eb-93c4-47c414f90a5d.png)

![Textarea](https://user-images.githubusercontent.com/65539425/101914711-ebc33600-3bc4-11eb-99f9-8f84da3c5489.png)

## Numbers
![Integer](https://user-images.githubusercontent.com/65539425/101914719-ed8cf980-3bc4-11eb-9239-0bf75c070a95.png)

![Float](https://user-images.githubusercontent.com/65539425/101914724-eebe2680-3bc4-11eb-90ca-4717dfcd3ec0.png)

## Date
![Date](https://user-images.githubusercontent.com/65539425/101915354-ce429c00-3bc5-11eb-82dc-ac034abab3c1.png)

## Choice
![Choice](https://user-images.githubusercontent.com/65539425/101918648-e4eaf200-3bc9-11eb-96b3-c55847b474d5.png)

![MultipleChoice](https://user-images.githubusercontent.com/65539425/101918655-e74d4c00-3bc9-11eb-8d84-fd62e9eb6402.png)

## Table
![Table](https://user-images.githubusercontent.com/65539425/102380623-6b3b7580-3fc8-11eb-947c-bc36dce9d4bd.png)
