### PR TITLE
feat(cfb): implement reordering of question options

### DIFF
--- a/addon/components/cfb-form-editor/question-list.js
+++ b/addon/components/cfb-form-editor/question-list.js
@@ -115,11 +115,15 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
       });
 
       this.notification.success(
-        this.intl.t("caluma.form-builder.notification.form.reorder.success")
+        this.intl.t(
+          "caluma.form-builder.notification.form.reorder-questions.success"
+        )
       );
     } catch (e) {
       this.notification.danger(
-        this.intl.t("caluma.form-builder.notification.form.reorder.error")
+        this.intl.t(
+          "caluma.form-builder.notification.form.reorder-questions.error"
+        )
       );
     }
   }

--- a/addon/components/cfb-form-editor/question/options.js
+++ b/addon/components/cfb-form-editor/question/options.js
@@ -7,7 +7,6 @@ import lookupValidator from "ember-changeset-validations";
 import { task } from "ember-concurrency";
 import RenderComponent from "ember-validated-form/components/validated-input/-themes/uikit/render";
 import UIkit from "uikit";
-import { v4 } from "uuid";
 
 import layout from "../../../templates/components/cfb-form-editor/question/options";
 
@@ -109,6 +108,8 @@ export default RenderComponent.extend({
 
   _handleMoved({ detail: [sortable] }) {
     const options = [...sortable.$el.children];
+    // Remove last element as it is the add row button
+    options.pop();
 
     this.reorderQuestions.perform(
       options.map((option) =>
@@ -119,8 +120,6 @@ export default RenderComponent.extend({
 
   reorderQuestions: task(function* (slugs) {
     try {
-      slugs.pop();
-
       yield this.apollo.mutate({
         mutation: TYPES[this.model.__typename],
         variables: {
@@ -128,7 +127,6 @@ export default RenderComponent.extend({
             slug: this.questionSlug,
             label: this.model.label,
             options: slugs,
-            clientMutationId: v4(),
           },
         },
       });

--- a/addon/components/cfb-form-editor/question/options.js
+++ b/addon/components/cfb-form-editor/question/options.js
@@ -107,18 +107,17 @@ export default RenderComponent.extend({
   },
 
   _handleMoved({ detail: [sortable] }) {
-    const options = [...sortable.$el.children];
     // Remove last element as it is the add row button
-    options.pop();
+    const options = [...sortable.$el.children].slice(0, -1);
 
-    this.reorderQuestions.perform(
+    this.reorderOptions.perform(
       options.map((option) =>
         addQuestionPrefix(option.firstElementChild.id, this.questionSlug)
       )
     );
   },
 
-  reorderQuestions: task(function* (slugs) {
+  reorderOptions: task(function* (slugs) {
     try {
       yield this.apollo.mutate({
         mutation: TYPES[this.model.__typename],

--- a/addon/templates/components/cfb-form-editor/question/options.hbs
+++ b/addon/templates/components/cfb-form-editor/question/options.hbs
@@ -1,13 +1,21 @@
 {{component labelComponent}}
 
-<ul class="uk-list uk-list-divider uk-margin-remove-bottom uk-margin-small-top">
+<ul class="uk-list uk-list-divider uk-margin-remove-bottom uk-margin-small-top" id="option-list" uk-sortable="handle: .uk-sortable-handle;">
   {{#each optionRows as |row i|}}
     {{#validated-form
       data-test-row=(concat "option-" (add i 1))
       tagName="li"
       model=row
     as |f|}}
-      <div uk-grid class="uk-grid-small uk-flex">
+      <div uk-grid class="uk-grid-small uk-flex uk-flex-middle" id={{row.slug}}>
+        {{#if (not (and row.isNew (gt optionRows.length 1)))}}
+          <span
+            data-test-sort-handle
+            uk-icon="menu"
+            class="uk-sortable-handle"
+            role="button"
+          ></span>
+        {{/if}}
         <div class="uk-width-auto">
           {{#if (and row.isNew (gt optionRows.length 1))}}
             <button

--- a/addon/templates/components/cfb-form-editor/question/options.hbs
+++ b/addon/templates/components/cfb-form-editor/question/options.hbs
@@ -1,14 +1,14 @@
 {{component labelComponent}}
 
 <ul class="uk-list uk-list-divider uk-margin-remove-bottom uk-margin-small-top" id="option-list" uk-sortable="handle: .uk-sortable-handle;">
-  {{#each optionRows as |row i|}}
+  {{#each this.optionRows as |row i|}}
     {{#validated-form
       data-test-row=(concat "option-" (add i 1))
       tagName="li"
       model=row
     as |f|}}
       <div uk-grid class="uk-grid-small uk-flex uk-flex-middle" id={{row.slug}}>
-        {{#if (not (and row.isNew (gt optionRows.length 1)))}}
+        {{#if (not (and row.isNew (gt this.optionRows.length 1)))}}
           <span
             data-test-sort-handle
             uk-icon="menu"
@@ -17,7 +17,7 @@
           ></span>
         {{/if}}
         <div class="uk-width-auto">
-          {{#if (and row.isNew (gt optionRows.length 1))}}
+          {{#if (and row.isNew (gt this.optionRows.length 1))}}
             <button
               data-test-delete-row
               type="button"

--- a/addon/templates/components/cfb-form-editor/question/options.hbs
+++ b/addon/templates/components/cfb-form-editor/question/options.hbs
@@ -1,6 +1,11 @@
 {{component labelComponent}}
 
-<ul class="uk-list uk-list-divider uk-margin-remove-bottom uk-margin-small-top" id="option-list" uk-sortable="handle: .uk-sortable-handle;">
+<UkSortable
+  @handle=".uk-sortable-handle"
+  @on-moved={{action "_handleMoved"}}
+  @tagName="ul"
+  class="uk-list uk-list-divider uk-margin-remove-bottom uk-margin-small-top"
+>
   {{#each this.optionRows as |row i|}}
     {{#validated-form
       data-test-row=(concat "option-" (add i 1))
@@ -69,7 +74,7 @@
     >
     </button>
   </li>
-</ul>
+</UkSortable>
 
 {{component hintComponent}}
 {{component errorComponent}}

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -190,9 +190,13 @@ caluma:
           success: "Ihr Formular wurde erfolgreich erstellt!"
           error: "Hoppla, beim Erstellen des Formulars ist etwas schief gelaufen..."
 
-        reorder:
+        reorder-questions:
           success: "Ihre Fragen wurde erfolgreich sortiert!"
           error: "Hoppla, beim Sortieren der Fragen ist etwas schief gelaufen..."
+
+        reorder-options:
+          success: "Ihre Optionen wurde erfolgreich sortiert!"
+          error: "Hoppla, beim Sortieren der Optionen ist etwas schief gelaufen..."
 
         add-question:
           success: "Die Frage wurde erfolgreich zu Ihrem Formular hinzugefügt!"

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -190,9 +190,13 @@ caluma:
           success: "Your form was successfully created!"
           error: "Ooops, something went wrong while creating the form..."
 
-        reorder:
+        reorder-questions:
           success: "Your questions were successfully reordered!"
           error: "Ooops, something went wrong while reordering the questions..."
+
+        reorder-options:
+          success: "Your options were successfully reordered!"
+          error: "Ooops, something went wrong while reordering the options..."
 
         add-question:
           success: "The question was successfully added to your form!"


### PR DESCRIPTION
Allows reordering options of Choice or MultipleChoice questions, by dragging and dropping. Similar to reordering Questions.
New options aren't reorder able, as they have no slug before saving.

closes  #1086

![image](https://user-images.githubusercontent.com/30687616/102226539-cb5aea80-3ee8-11eb-938c-470768c2b55a.png)
