### PR TITLE
feat(form): show calculated fields in form and compute their value live

### DIFF
--- a/addon/components/cf-field/input.js
+++ b/addon/components/cf-field/input.js
@@ -8,6 +8,7 @@ const mapping = {
   ChoiceQuestion: "radio",
   DynamicMultipleChoiceQuestion: "checkbox",
   DynamicChoiceQuestion: "radio",
+  CalculatedFloatQuestion: "float",
 };
 
 /**

--- a/addon/components/cf-field/input/float.js
+++ b/addon/components/cf-field/input/float.js
@@ -1,37 +1,26 @@
-import Component from "@ember/component";
+import { action } from "@ember/object";
+import Component from "@glimmer/component";
 
-/**
- * Input component for the float question type
- *
- * @class CfFieldInputFloatComponent
- * @argument {Field} field The field for this input type
- */
-export default Component.extend({
-  tagName: "input",
-  classNames: ["uk-input"],
-  classNameBindings: ["field.isInvalid:uk-form-danger", "disabled:uk-disabled"],
-  attributeBindings: [
-    "type",
-    "step",
-    "disabled:readonly",
-    "field.pk:name",
-    "field.pk:id",
-    "field.answer.value:value",
-    "field.question.floatMinValue:min",
-    "field.question.floatMaxValue:max",
-  ],
-  type: "number",
-  step: 0.001,
+export default class CfFieldInputFloatComponent extends Component {
+  get isDisabled() {
+    return this.args.disabled || this.args.field.question.isCalculated;
+  }
 
   /**
    * Trigger save on input
    *
-   * @event input
+   * @method onInput
    * @param {Event} e The input event
    * @param {Object} e.target The target of the event
    * @param {String} e.target.value The current value of the field
    */
-  input({ target: { value } }) {
-    this.onSave(value === "" || isNaN(value) ? null : parseFloat(value));
-  },
-});
+  @action onInput({ target: { value } }) {
+    if (this.isDisabled) {
+      return;
+    }
+
+    const parsedValue = parseFloat(value);
+
+    this.args.onSave(!isNaN(parsedValue) ? parsedValue : null);
+  }
+}

--- a/addon/components/cf-field/label.js
+++ b/addon/components/cf-field/label.js
@@ -1,10 +1,11 @@
-import Component from "@ember/component";
+import Component from "@glimmer/component";
 
-import layout from "../../templates/components/cf-field/label";
+export default class CfFieldLabelComponent extends Component {
+  get optional() {
+    if (this.args.field.question.isCalculated) {
+      return false;
+    }
 
-export default Component.extend({
-  layout,
-  tagName: "label",
-  classNames: ["uk-form-label"],
-  attributeBindings: ["field.pk:for"],
-});
+    return this.args.field.optional;
+  }
+}

--- a/addon/gql/fragments/field-question.graphql
+++ b/addon/gql/fragments/field-question.graphql
@@ -71,6 +71,9 @@ fragment SimpleQuestion on Question {
   ... on StaticQuestion {
     staticContent
   }
+  ... on CalculatedFloatQuestion {
+    calcExpression
+  }
 }
 
 fragment FieldTableQuestion on Question {

--- a/addon/lib/question.js
+++ b/addon/lib/question.js
@@ -97,6 +97,7 @@ export default Base.extend({
   }),
 
   isTable: equal("__typename", "TableQuestion"),
+  isCalculated: equal("__typename", "CalculatedFloatQuestion"),
 
   /**
    * All valid options for this question

--- a/addon/templates/components/cf-field/input/float.hbs
+++ b/addon/templates/components/cf-field/input/float.hbs
@@ -1,0 +1,12 @@
+<input
+  type="number"
+  step="0.001"
+  class="uk-input {{if @field.isInvalid "uk-form-danger"}} {{if this.isDisabled "uk-disabled"}}"
+  readonly={{this.isDisabled}}
+  name={{@field.pk}}
+  id={{@field.pk}}
+  value={{@field.value}}
+  min={{@field.question.floatMinValue}}
+  max={{@field.question.floatMaxValue}}
+  {{on "input" this.onInput}}
+>

--- a/addon/templates/components/cf-field/label.hbs
+++ b/addon/templates/components/cf-field/label.hbs
@@ -1,7 +1,9 @@
-<span class="uk-text-bold">
-  {{field.question.label}}
-</span>
+<label class="uk-form-label" for={{@field.pk}}>
+  <span class="uk-text-bold">
+    {{@field.question.label}}
+  </span>
 
-{{#if field.optional}}
-  <span class="uk-margin-small-left uk-text-muted uk-text-lowercase uk-text-normal">({{t "caluma.form.optional"}})</span>
-{{/if}}
+  {{#if this.optional}}
+    <span class="uk-margin-small-left uk-text-muted uk-text-lowercase uk-text-normal">({{t "caluma.form.optional"}})</span>
+  {{/if}}
+</label>

--- a/app/templates/components/cf-field/input/float.js
+++ b/app/templates/components/cf-field/input/float.js
@@ -1,0 +1,1 @@
+export { default } from "ember-caluma/templates/components/cf-field/input/float";

--- a/app/templates/components/cf-field/label.js
+++ b/app/templates/components/cf-field/label.js
@@ -1,0 +1,1 @@
+export { default } from "ember-caluma/templates/components/cf-field/label";

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "dependencies": {
     "@ember/render-modifiers": "^1.0.2",
+    "@glimmer/component": "1.0.3",
     "@glimmer/tracking": "^1.0.1",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-link-context": "^1.0.20",
@@ -73,7 +74,6 @@
     "@babel/plugin-proposal-object-rest-spread": "7.12.1",
     "@ember/jquery": "1.1.0",
     "@ember/optional-features": "2.0.0",
-    "@glimmer/component": "1.0.3",
     "babel-eslint": "10.1.0",
     "broccoli-asset-rev": "3.0.0",
     "ember-cli": "3.24.0",

--- a/tests/integration/components/cf-field/input-test.js
+++ b/tests/integration/components/cf-field/input-test.js
@@ -77,9 +77,7 @@ module("Integration | Component | cf-field/input", function (hooks) {
           question=(hash
             __typename="FloatQuestion"
           )
-          answer=(hash
-            value=0.55
-          )
+          value=0.55
         )
       }}
     `);

--- a/tests/integration/components/cf-field/input/float-test.js
+++ b/tests/integration/components/cf-field/input/float-test.js
@@ -8,8 +8,20 @@ module("Integration | Component | cf-field/input/float", function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
+  hooks.beforeEach(function () {
+    this.set("field", {
+      pk: "test-id",
+      value: 1.045,
+      question: {
+        isCalculated: false,
+        floatMinValue: 0.4,
+        floatMaxValue: 1.4,
+      },
+    });
+  });
+
   test("it computes the proper element id", async function (assert) {
-    await render(hbs`{{cf-field/input/float field=(hash pk="test-id")}}`);
+    await render(hbs`<CfField::input::float @field={{this.field}} />`);
 
     assert.dom("#test-id").exists();
   });
@@ -17,23 +29,10 @@ module("Integration | Component | cf-field/input/float", function (hooks) {
   test("it renders", async function (assert) {
     assert.expect(7);
 
-    await render(hbs`
-      {{cf-field/input/float
-        field=(hash
-          pk="test"
-          answer=(hash
-            value=1.045
-          )
-          question=(hash
-            floatMinValue=0.4
-            floatMaxValue=1.4
-          )
-        )
-      }}
-    `);
+    await render(hbs`<CfField::input::float @field={{this.field}} />`);
 
     assert.dom("input").hasClass("uk-input");
-    assert.dom("input").hasAttribute("name", "test");
+    assert.dom("input").hasAttribute("name", "test-id");
     assert.dom("input").hasAttribute("type", "number");
     assert.dom("input").hasAttribute("step", "0.001");
     assert.dom("input").hasAttribute("min", "0.4");
@@ -44,7 +43,12 @@ module("Integration | Component | cf-field/input/float", function (hooks) {
   test("it can be disabled", async function (assert) {
     assert.expect(2);
 
-    await render(hbs`{{cf-field/input/float disabled=true}}`);
+    await render(
+      hbs`<CfField::input::float
+        @field={{this.field}}
+        @disabled={{true}}
+      />`
+    );
 
     assert.dom("input").hasAttribute("readonly");
     assert.dom("input").hasClass("uk-disabled");
@@ -55,7 +59,12 @@ module("Integration | Component | cf-field/input/float", function (hooks) {
 
     this.set("save", (value) => assert.equal(value, 1.5));
 
-    await render(hbs`{{cf-field/input/float onSave=save}}`);
+    await render(
+      hbs`<CfField::input::float
+        @field={{this.field}}
+        @onSave={{this.save}}
+      />`
+    );
 
     await fillIn("input", 1.5);
   });
@@ -65,7 +74,12 @@ module("Integration | Component | cf-field/input/float", function (hooks) {
 
     this.set("save", (value) => assert.equal(value, null));
 
-    await render(hbs`{{cf-field/input/float onSave=save}}`);
+    await render(
+      hbs`<CfField::input::float
+        @field={{this.field}}
+        @onSave={{this.save}}
+      />`
+    );
 
     await fillIn("input", "Test");
   });

--- a/tests/unit/lib/data.js
+++ b/tests/unit/lib/data.js
@@ -40,6 +40,25 @@ const form = {
       },
       {
         node: {
+          slug: "float",
+          label: "Float question",
+          isRequired: "false",
+          isHidden: "false",
+          __typename: "FloatQuestion",
+        },
+      },
+      {
+        node: {
+          slug: "calculated",
+          label: "Calculated question",
+          isRequired: "false",
+          isHidden: "false",
+          calcExpression: "'float'|answer + 5 * 100",
+          __typename: "CalculatedFloatQuestion",
+        },
+      },
+      {
+        node: {
           slug: "table",
           label: "Table",
           isRequired: "false",
@@ -101,6 +120,14 @@ const answers = {
         },
         stringValue: "test answer 2",
         __typename: "StringAnswer",
+      },
+    },
+    {
+      node: {
+        id: id("FloatAnswer"),
+        question: { slug: "float" },
+        floatValue: 1.1,
+        __typename: "FloatAnswer",
       },
     },
     {

--- a/tests/unit/lib/document-test.js
+++ b/tests/unit/lib/document-test.js
@@ -46,6 +46,8 @@ module("Unit | Library | document", function (hooks) {
       ["question-1", false],
       ["question-2", true],
       ["question-3", true],
+      ["float", false],
+      ["calculated", false],
       ["table", false],
       ["multiple-choice", false],
     ]);
@@ -61,6 +63,8 @@ module("Unit | Library | document", function (hooks) {
       ["question-1", false],
       ["question-2", false],
       ["question-3", true],
+      ["float", false],
+      ["calculated", false],
       ["table", false],
       ["multiple-choice", false],
     ]);
@@ -74,6 +78,8 @@ module("Unit | Library | document", function (hooks) {
       ["question-1", false],
       ["question-2", false],
       ["question-3", false],
+      ["float", false],
+      ["calculated", false],
       ["table", false],
       ["multiple-choice", false],
     ]);
@@ -84,6 +90,8 @@ module("Unit | Library | document", function (hooks) {
       ["question-1", false],
       ["question-2", true],
       ["question-3", true],
+      ["float", false],
+      ["calculated", false],
       ["table", false],
       ["multiple-choice", false],
     ]);

--- a/tests/unit/lib/field-test.js
+++ b/tests/unit/lib/field-test.js
@@ -437,4 +437,32 @@ module("Unit | Library | field", function (hooks) {
       't:caluma.form.validation.table:("value":null)',
     ]);
   });
+
+  module("calculated", function (hooks) {
+    hooks.beforeEach(function () {
+      this.calculated = this.document.findField("calculated");
+      this.float = this.document.findField("float");
+    });
+
+    test("calculates the correct value", async function (assert) {
+      assert.expect(1);
+
+      // 1.1 + 5 * 100 = 501.1
+      assert.equal(this.calculated.value, 501.1);
+    });
+
+    test("recalculates when a dependent value changes", async function (assert) {
+      assert.expect(1);
+
+      this.set("float.value", 2);
+      assert.equal(this.calculated.value, 502);
+    });
+
+    test("recalculates when a dependent hidden state changes", async function (assert) {
+      assert.expect(1);
+
+      this.set("float.question.isHidden", "true");
+      assert.equal(this.calculated.value, null);
+    });
+  });
 });


### PR DESCRIPTION
This commit also refactors the float input and label components to glimmer components since I had to touch them.

Depends on #1173 