### PR TITLE
fix(cfb): fix recalculation issue in default values

### DIFF
--- a/addon/components/cfb-form-editor/question/default.js
+++ b/addon/components/cfb-form-editor/question/default.js
@@ -42,6 +42,14 @@ export default class CfbFormEditorQuestionDefault extends RenderComponent {
     return raw;
   }
 
+  // This @computed decorator is important. Otherwise, Ember will - under some
+  // circumstances - enter the getter method multiple times and throw an error.
+  @computed(
+    "model.{__typename,slug}",
+    "question",
+    "router.currentRoute.attributes.formSlug",
+    "value.content"
+  )
   get field() {
     return getOwner(this)
       .factoryFor("caluma-model:field")


### PR DESCRIPTION
This adds a decorator to the field getter to stop Ember from recalculating the property too often.

`@computed("question", "value", "value.content", "model.slug")`
would technically be enough. The other properties are there to satisfy a linting rule.