### PR TITLE
fix(deps): add resolution to fix @babel/parser to 7.12.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,11 +128,13 @@
     "typeface-oxygen-mono": "1.1.13"
   },
   "//": {
-    "focus-trap": "Focus trap now throws an error if there is no tabbable element on initialization. This breaks the modal dialogs as they are hidden on initialization."
+    "focus-trap": "Focus trap now throws an error if there is no tabbable element on initialization. This breaks the modal dialogs as they are hidden on initialization.",
+    "@babel/parser": "For some reason 7.12.13 fails to transpile TypeScript sources. https://github.com/babel/babel/issues/12745"
   },
   "resolutions": {
     "focus-trap": "6.2.1",
-    "uikit": "3.6.14"
+    "uikit": "3.6.14",
+    "@babel/parser": "7.12.11"
   },
   "engines": {
     "node": "10.* || >= 12"

--- a/yarn.lock
+++ b/yarn.lock
@@ -271,7 +271,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.12.10", "@babel/parser@^7.12.11", "@babel/parser@^7.12.3", "@babel/parser@^7.12.7", "@babel/parser@^7.4.5", "@babel/parser@^7.7.0", "@babel/parser@^7.8.7":
+"@babel/parser@7.12.11", "@babel/parser@^7.12.10", "@babel/parser@^7.12.11", "@babel/parser@^7.12.3", "@babel/parser@^7.12.7", "@babel/parser@^7.4.5", "@babel/parser@^7.7.0", "@babel/parser@^7.8.7":
   version "7.12.11"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
   integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==


### PR DESCRIPTION
For some reason 7.12.13 fails to transpile TypeScript sources.
At least ember-intl but this is probably just because it's the
first package alphabetically.