### PR TITLE
fix(lib/navigation): don't set state to empty if fields are required

### DIFF
--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -219,13 +219,19 @@ export default Base.extend({
    * @property {Boolean} isDirty
    * @accessor
    */
-  isDirty: computed("question.isCalculated", "isNew", "isDefault", function () {
-    if (this.question.isCalculated) {
-      return false;
-    }
+  isDirty: computed(
+    "isDefault",
+    "isNew",
+    "question.isCalculated",
+    "validate.lastSuccessful",
+    function () {
+      if (this.question.isCalculated || this.isDefault) {
+        return false;
+      }
 
-    return !this.isNew && !this.isDefault;
-  }),
+      return Boolean(this.validate.lastSuccessful) || !this.isNew;
+    }
+  ),
 
   /**
    * The type of the question

--- a/addon/lib/navigation.js
+++ b/addon/lib/navigation.js
@@ -244,12 +244,12 @@ export const NavigationItem = Base.extend({
         return null;
       }
 
-      if (this.visibleFields.every((f) => f.isNew)) {
-        return STATES.EMPTY;
+      if (this.visibleFields.some((f) => !f.isValid && f.isDirty)) {
+        return STATES.INVALID;
       }
 
-      if (this.visibleFields.some((f) => !f.isValid && !f.isNew)) {
-        return STATES.INVALID;
+      if (this.visibleFields.every((f) => f.isNew)) {
+        return STATES.EMPTY;
       }
 
       if (


### PR DESCRIPTION
Otherwise, there's no other way than do go though all (sub-)forms
to check where the missing question is located.