### PR TITLE
fix(jexl): fix division by 0 in avg transform

### DIFF
--- a/addon/lib/document.js
+++ b/addon/lib/document.js
@@ -152,7 +152,7 @@ export default Base.extend({
     documentJexl.addTransform("sum", (arr) => sum(onlyNumbers(arr)));
     documentJexl.addTransform("avg", (arr) => {
       const nums = onlyNumbers(arr);
-      return sum(nums) / nums.length;
+      return nums.length ? sum(nums) / nums.length : null;
     });
 
     return documentJexl;

--- a/tests/unit/lib/document-test.js
+++ b/tests/unit/lib/document-test.js
@@ -196,6 +196,10 @@ module("Unit | Library | document", function (hooks) {
     const expression = "values|avg";
 
     assert.equal(await this.document.jexl.eval(expression, { values }), 20);
+    assert.equal(
+      await this.document.jexl.eval(expression, { values: [] }),
+      null
+    );
   });
 
   test("computes the correct jexl context", async function (assert) {


### PR DESCRIPTION
Calculating the average of an empty array would result in a `0/0`
division. `null` has to be returned in that case instead of `NaN`.