### PR TITLE
fix(jexl): fix validation of numbers in transforms

### DIFF
--- a/addon/lib/document.js
+++ b/addon/lib/document.js
@@ -8,7 +8,8 @@ import { decodeId } from "ember-caluma/helpers/decode-id";
 import Base from "ember-caluma/lib/base";
 import { intersects } from "ember-caluma/utils/jexl";
 
-const onlyNumbers = (nums) => nums.filter((num) => !isNaN(num));
+const onlyNumbers = (nums) =>
+  nums.filter((num) => !isNaN(num) && typeof num === "number");
 const sum = (nums) => nums.reduce((num, base) => base + num, 0);
 
 /**
@@ -139,15 +140,15 @@ export default Base.extend({
       return nums.length ? Math.max(...nums) : null;
     });
     documentJexl.addTransform("round", (num, places = 0) =>
-      isNaN(num)
+      !onlyNumbers([num]).length
         ? null
         : Math.round(num * Math.pow(10, places)) / Math.pow(10, places)
     );
     documentJexl.addTransform("ceil", (num) =>
-      isNaN(num) ? null : Math.ceil(num)
+      !onlyNumbers([num]).length ? null : Math.ceil(num)
     );
     documentJexl.addTransform("floor", (num) =>
-      isNaN(num) ? null : Math.floor(num)
+      !onlyNumbers([num]).length ? null : Math.floor(num)
     );
     documentJexl.addTransform("sum", (arr) => sum(onlyNumbers(arr)));
     documentJexl.addTransform("avg", (arr) => {

--- a/tests/unit/lib/document-test.js
+++ b/tests/unit/lib/document-test.js
@@ -140,14 +140,14 @@ module("Unit | Library | document", function (hooks) {
   });
 
   test("it transforms correcty with Math.min", async function (assert) {
-    const values = [10, 20, "notANumber", 30];
+    const values = [10, 20, "notANumber", 30, null, undefined, true, {}];
     const expression = "values|min";
 
     assert.equal(await this.document.jexl.eval(expression, { values }), 10);
   });
 
   test("it transforms correcty with Math.max", async function (assert) {
-    const values = [10, 20, "notANumber", 30];
+    const values = [10, 20, "notANumber", 30, null, undefined, true, {}];
     const expression = "values|max";
 
     assert.equal(await this.document.jexl.eval(expression, { values }), 30);
@@ -158,6 +158,10 @@ module("Unit | Library | document", function (hooks) {
     const expression = "value|ceil";
 
     assert.equal(await this.document.jexl.eval(expression, { value }), 2);
+    assert.equal(
+      await this.document.jexl.eval(expression, { value: null }),
+      null
+    );
   });
 
   test("it transforms correcty with Math.floor", async function (assert) {
@@ -165,6 +169,10 @@ module("Unit | Library | document", function (hooks) {
     const expression = "value|floor";
 
     assert.equal(await this.document.jexl.eval(expression, { value }), 1);
+    assert.equal(
+      await this.document.jexl.eval(expression, { value: null }),
+      null
+    );
   });
 
   test("it transforms correcty with Math.round", async function (assert) {
@@ -177,28 +185,35 @@ module("Unit | Library | document", function (hooks) {
       await this.document.jexl.eval(expression, { value, places }),
       1.877
     );
-
     assert.equal(
       await this.document.jexl.eval(expressionWithoutPlaces, { value, places }),
       2
     );
+    assert.equal(
+      await this.document.jexl.eval(expression, { value: null, places: null }),
+      null
+    );
   });
 
   test("it transforms correcty with sum transform", async function (assert) {
-    const values = [10, 20, "notANumber", 30];
+    const values = [10, 20, "notANumber", 30, null, undefined, true, {}];
     const expression = "values|sum";
 
     assert.equal(await this.document.jexl.eval(expression, { values }), 60);
   });
 
   test("it transforms correcty with avg transform", async function (assert) {
-    const values = [10, 20, "notANumber", 30];
+    const values = [10, 20, "notANumber", 30, null, undefined, true, {}];
     const expression = "values|avg";
 
     assert.equal(await this.document.jexl.eval(expression, { values }), 20);
     assert.equal(
       await this.document.jexl.eval(expression, { values: [] }),
       null
+    );
+    assert.equal(
+      await this.document.jexl.eval(expression, { values: [10] }),
+      10
     );
   });
 


### PR DESCRIPTION
We need to validate numbers differently since `null` `""` `true`
and `false` are not `NaN` and therefore a validation with `isNaN()`
is pretty much useless.