### PR TITLE
fix(jexl): fix jexl dependency gathering for empty tables

### DIFF
--- a/addon/lib/dependencies.js
+++ b/addon/lib/dependencies.js
@@ -114,7 +114,7 @@ export function dependencies(
 
           const field = findField(this.document, fieldSlug, expression);
 
-          if (!onlyNestedParents && nestedSlug) {
+          if (!onlyNestedParents && nestedSlug && field.value) {
             // Get the nested fields from the parents value (rows)
             return [
               field,


### PR DESCRIPTION
The `field.value` is empty when no document exists for a table question. Only try to gather the fields if a document/value exists, otherwise this field is of no interest.

Fixes #1235 