### PR TITLE
fix(field): some questions do not have an answer, handle this correctly

### DIFF
--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -264,7 +264,7 @@ export default Base.extend({
         return this.calculatedValue;
       }
 
-      return this.answer.value;
+      return this.answer?.value;
     }
   ),
 


### PR DESCRIPTION
For example `StaticQuestion` has no answer, therefore the field value should be handled accordingly.