### PR TITLE
feat(cfb): implement search and pagination of form list

### DIFF
--- a/addon/caluma-query/models/form.js
+++ b/addon/caluma-query/models/form.js
@@ -1,0 +1,11 @@
+import CalumaQueryModel from "./index";
+
+export default class FormModel extends CalumaQueryModel {
+  static fragment = `{
+    name
+    slug
+    description
+    isArchived
+    isPublished
+  }`;
+}

--- a/addon/caluma-query/queries/form.js
+++ b/addon/caluma-query/queries/form.js
@@ -1,0 +1,36 @@
+import BaseQuery from "./base";
+
+export default class FormQuery extends BaseQuery {
+  dataKey = "allForms";
+  modelName = "form";
+
+  get query() {
+    return `
+      query (
+        $filter: [FormFilterSetType], 
+        $order: [FormOrderSetType], 
+        $pageSize: Int, 
+        $cursor: String
+      ) {
+        allForms(
+          filter: $filter, 
+          order: $order, 
+          first: $pageSize,
+          after: $cursor,
+        ) {
+          ${this.pagination}
+          edges {
+            node {
+              id
+              __typename
+              ...FormFragment
+            }
+          }
+        }
+      }
+
+      fragment FormFragment on Form ${this.modelClass.fragment} 
+
+    `;
+  }
+}

--- a/addon/caluma-query/queries/index.js
+++ b/addon/caluma-query/queries/index.js
@@ -1,4 +1,5 @@
 import CaseQuery from "./case";
+import FormQuery from "./form";
 import WorkItemQuery from "./work-item";
 
 export function allWorkItems(options) {
@@ -9,4 +10,8 @@ export function allCases(options) {
   return new CaseQuery(options);
 }
 
-export default { allWorkItems, allCases };
+export function allForms(options) {
+  return new FormQuery(options);
+}
+
+export default { allWorkItems, allCases, allForms };

--- a/addon/initializers/caluma-query-models.js
+++ b/addon/initializers/caluma-query-models.js
@@ -1,9 +1,11 @@
 import CaseModel from "ember-caluma/caluma-query/models/case";
+import FormModel from "ember-caluma/caluma-query/models/form";
 import WorkItemModel from "ember-caluma/caluma-query/models/work-item";
 
 export function initialize(application) {
   application.register("caluma-query-model:work-item", WorkItemModel);
   application.register("caluma-query-model:case", CaseModel);
+  application.register("caluma-query-model:form", FormModel);
 }
 
 export default {

--- a/addon/mirage-graphql/filters/base.js
+++ b/addon/mirage-graphql/filters/base.js
@@ -16,6 +16,8 @@ export default class {
   }
 
   filter(records, filters) {
+    // flatten array of filters to find filter functions
+    filters = Array.isArray(filters) ? Object.assign(...filters) : filters;
     return this._getFilterFns(filters).reduce((recs, fn) => fn(recs), records);
   }
 

--- a/addon/mirage-graphql/filters/form.js
+++ b/addon/mirage-graphql/filters/form.js
@@ -4,4 +4,10 @@ export default class extends BaseFilter {
   isArchived(records, value) {
     return records.filter(({ isArchived }) => isArchived === value);
   }
+
+  search(records, value) {
+    const re = new RegExp(`.*${value}.*`, "i");
+
+    return records.filter(({ slug, label }) => re.test(`${slug}${label}`));
+  }
 }

--- a/addon/mirage-graphql/serializers/form.js
+++ b/addon/mirage-graphql/serializers/form.js
@@ -1,0 +1,11 @@
+import BaseSerializer from "./base";
+export default class extends BaseSerializer {
+  serialize(deserialized) {
+    const serialized = super.serialize(deserialized);
+
+    return {
+      ...serialized,
+      id: btoa(`Form:${deserialized.id}`),
+    };
+  }
+}

--- a/addon/templates/components/cfb-form-list.hbs
+++ b/addon/templates/components/cfb-form-list.hbs
@@ -1,4 +1,8 @@
-<div {{did-insert (perform this.forms)}} {{did-update (perform this.forms)}} ...attributes>
+<div
+  ...attributes
+  {{did-insert (perform this.fetchForms)}}
+  {{did-update (perform this.fetchForms)}}
+>
   <div class="uk-flex uk-flex-between">
     <div class="uk-button-group">
       <UkButton
@@ -26,30 +30,51 @@
       />
     </div>
   </div>
-
-  {{#if this.forms.isRunning}}
+  <form class="uk-search uk-search-default uk-width-1-1 uk-margin-small-top">
+    <span class="uk-search-icon-flip" uk-search-icon></span>
+    <input
+      data-test-form-search-input
+      class="uk-search-input"
+      type="search"
+      placeholder="{{t "caluma.form-builder.global.search"}}..."
+      value={{this.search}}
+      {{on "input" this.searchForms}}
+    />
+  </form>
+  {{#if this.formsQuery.isLoading}}
     <div class="uk-height-small uk-flex uk-flex-center uk-flex-middle">
       {{uk-spinner ratio=2}}
     </div>
+  {{else if this.formsQuery.value.length}}
+    <ul data-test-form-list class="uk-list uk-list-divider uk-list-large">
+      {{#each this.formsQuery.value key="id" as |item|}}
+        <CfbFormList::Item
+          data-test-form-list-item={{item.slug}}
+          @item={{item}}
+          @on-edit-form={{@on-edit-form}}
+        />
+      {{/each}}
+      {{#if this.formsQuery.hasNextPage}}
+        <li class="uk-text-center cfb-pointer">
+          <a
+            data-test-form-loader-button
+            href="#"
+            {{on "click" this.loadMoreForms}}
+          >
+            {{t "caluma.form-builder.form.loadMore"}}
+          </a>
+        </li>
+      {{/if}}
+    </ul>
   {{else}}
-    {{#if this.forms.lastSuccessful.value.length}}
-      <ul data-test-form-list class="uk-list uk-list-divider uk-list-large">
-        {{#each this.forms.lastSuccessful.value key="node.id" as |item|}}
-          <CfbFormList::Item
-            data-test-form-list-item={{item.node.slug}}
-            @item={{item.node}}
-            @on-edit-form={{@on-edit-form}}
-          />
-        {{/each}}
-      </ul>
-    {{else}}
-      <div
-        data-test-form-list-empty
-        class="uk-padding-large uk-padding-remove-horizontal uk-text-center"
-      >
-        {{uk-icon "search" ratio=10}}
-        <p class="uk-text-muted">{{t "caluma.form-builder.form.empty"}}</p>
-      </div>
-    {{/if}}
+    <div
+      data-test-form-list-empty
+      class="uk-padding-large uk-padding-remove-horizontal uk-text-center"
+    >
+      <UkIcon @icon="search" @ratio={{10}} />
+      <p class="uk-text-muted">
+        {{t "caluma.form-builder.form.empty"}}
+      </p>
+    </div>
   {{/if}}
 </div>

--- a/tests/acceptance/form-list-test.js
+++ b/tests/acceptance/form-list-test.js
@@ -1,8 +1,8 @@
-import { visit } from "@ember/test-helpers";
+import { visit, typeIn, click, fillIn } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { setupIntl } from "ember-intl/test-support";
 import { setupApplicationTest } from "ember-qunit";
-import { module, test } from "qunit";
+import { module, test, skip } from "qunit";
 
 module("Acceptance | form list", function (hooks) {
   setupApplicationTest(hooks);
@@ -19,5 +19,124 @@ module("Acceptance | form list", function (hooks) {
     assert
       .dom("[data-test-demo-content] [data-test-form-list-item]")
       .exists({ count: 5 });
+  });
+
+  test("can search forms", async function (assert) {
+    assert.expect(3);
+
+    this.server.createList("form", 5);
+    this.server.create("form", { name: "Test", slug: "test" });
+
+    await visit("/demo/form-builder");
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-list-item]")
+      .exists({ count: 6 });
+
+    await typeIn(
+      "[data-test-demo-content] [data-test-form-search-input]",
+      "test"
+    );
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-list-item]")
+      .exists({ count: 1 });
+
+    await fillIn("[data-test-demo-content] [data-test-form-search-input]", "");
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-list-item]")
+      .exists({ count: 6 });
+  });
+
+  test("can paginate forms", async function (assert) {
+    assert.expect(3);
+
+    this.server.createList("form", 25);
+
+    await visit("/demo/form-builder");
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-list-item]")
+      .exists({ count: 20 });
+
+    await click("[data-test-demo-content] [data-test-form-loader-button]");
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-list-item]")
+      .exists({ count: 25 });
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-loader-button]")
+      .doesNotExist();
+  });
+
+  test("can combine search and pagination", async function (assert) {
+    assert.expect(4);
+
+    this.server.createList("form", 25);
+    this.server.create("form", { name: "Test 1", slug: "test-1" });
+    this.server.create("form", { name: "Test 2", slug: "test-2" });
+    this.server.create("form", { name: "Test 3", slug: "test-3" });
+    this.server.create("form", { name: "Test 4", slug: "test-4" });
+    this.server.create("form", { name: "Test 5", slug: "test-5" });
+
+    await visit("/demo/form-builder");
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-list-item]")
+      .exists({ count: 20 });
+
+    await typeIn(
+      "[data-test-demo-content] [data-test-form-search-input]",
+      "form"
+    );
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-list-item]")
+      .exists({ count: 20 });
+
+    await click("[data-test-demo-content] [data-test-form-loader-button]");
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-list-item]")
+      .exists({ count: 25 });
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-loader-button]")
+      .doesNotExist();
+  });
+
+  skip("can search substrings", async function (assert) {
+    assert.expect(3);
+
+    this.server.createList("form", 3);
+    this.server.create("form", { name: "Fo 1", slug: "fo-1" });
+    this.server.create("form", { name: "Fo 2", slug: "fo-2" });
+    this.server.create("form", { name: "Test", slug: "test" });
+
+    await visit("/demo/form-builder");
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-list-item]")
+      .exists({ count: 6 });
+
+    await typeIn(
+      "[data-test-demo-content] [data-test-form-search-input]",
+      "fo"
+    );
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-list-item]")
+      .exists({ count: 5 });
+
+    await typeIn(
+      "[data-test-demo-content] [data-test-form-search-input]",
+      "rm"
+    );
+
+    assert
+      .dom("[data-test-demo-content] [data-test-form-list-item]")
+      .exists({ count: 3 });
   });
 });

--- a/tests/integration/components/cfb-form-list-test.js
+++ b/tests/integration/components/cfb-form-list-test.js
@@ -1,33 +1,21 @@
-import { defineProperty } from "@ember/object";
 import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { task } from "ember-concurrency";
+import { setupMirage } from "ember-cli-mirage/test-support";
 import { setupIntl } from "ember-intl/test-support";
 import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
 
 module("Integration | Component | cfb-form-list", function (hooks) {
   setupRenderingTest(hooks);
+  setupMirage(hooks);
   setupIntl(hooks);
 
   test("it renders blockless", async function (assert) {
     assert.expect(2);
 
-    defineProperty(
-      this,
-      "forms",
-      task(function* () {
-        return yield [
-          { node: { id: 1, slug: "form-1", title: "Form 1" } },
-          { node: { id: 2, slug: "form-2", title: "Form 2" } },
-          { node: { id: 3, slug: "form-3", title: "Form 3" } },
-          { node: { id: 4, slug: "form-4", title: "Form 4" } },
-          { node: { id: 5, slug: "form-5", title: "Form 5" } },
-        ];
-      })
-    );
+    this.server.createList("form", 5);
 
-    await render(hbs`<CfbFormList @forms={{this.forms}}/>`);
+    await render(hbs`<CfbFormList/>`);
 
     assert.dom("[data-test-form-list]").exists();
     assert.dom("[data-test-form-list-item]").exists({ count: 5 });
@@ -36,15 +24,7 @@ module("Integration | Component | cfb-form-list", function (hooks) {
   test("it displays an empty state", async function (assert) {
     assert.expect(1);
 
-    defineProperty(
-      this,
-      "forms",
-      task(function* () {
-        return yield [];
-      })
-    );
-
-    await render(hbs`<CfbFormList @forms={{this.forms}}/>`);
+    await render(hbs`<CfbFormList/>`);
 
     assert.dom("[data-test-form-list-empty]").exists();
   });
@@ -52,19 +32,11 @@ module("Integration | Component | cfb-form-list", function (hooks) {
   test("it can trigger editing of a row", async function (assert) {
     assert.expect(2);
 
-    defineProperty(
-      this,
-      "forms",
-      task(function* () {
-        return yield [{ node: { id: 1, slug: "form-1" } }];
-      })
-    );
+    this.server.create("form", { id: 1, slug: "form-1" });
 
     this.set("on-edit-form", () => assert.step("edit-form"));
 
-    await render(
-      hbs`<CfbFormList @forms={{this.forms}} @on-edit-form={{this.on-edit-form}}/>`
-    );
+    await render(hbs`<CfbFormList @on-edit-form={{this.on-edit-form}}/>`);
 
     await click(`[data-test-form-list-item=form-1] [data-test-edit-form]`);
 
@@ -74,19 +46,11 @@ module("Integration | Component | cfb-form-list", function (hooks) {
   test("it can trigger adding a new form", async function (assert) {
     assert.expect(2);
 
-    defineProperty(
-      this,
-      "forms",
-      task(function* () {
-        return yield [{ node: { slug: "" } }];
-      })
-    );
+    this.server.create("form", { slug: "" });
 
     this.set("on-new-form", () => assert.step("new-form"));
 
-    await render(
-      hbs`<CfbFormList @forms={{this.forms}} @on-new-form={{this.on-new-form}}/>`
-    );
+    await render(hbs`<CfbFormList @on-new-form={{this.on-new-form}}/>`);
 
     await click("[data-test-new-form]");
 
@@ -94,20 +58,18 @@ module("Integration | Component | cfb-form-list", function (hooks) {
   });
 
   test("it displays archived forms", async function (assert) {
-    assert.expect(4);
+    assert.expect(3);
 
-    defineProperty(
-      this,
-      "forms",
-      task(function* () {
-        return yield [{ node: { id: 1, slug: "form-1", title: "Form 1" } }];
-      })
-    );
+    this.server.create("form", {
+      id: 1,
+      slug: "form-1",
+      title: "Form 1",
+      isArchived: true,
+    });
 
-    await render(hbs`<CfbFormList @forms={{this.forms}}/>`);
+    await render(hbs`<CfbFormList/>`);
 
-    assert.dom("[data-test-form-list]").exists();
-    assert.dom("[data-test-form-list-item]").exists({ count: 1 });
+    assert.dom("[data-test-form-list-empty]").exists();
 
     await click("[data-test-filter-archived]");
 

--- a/translations/de.yaml
+++ b/translations/de.yaml
@@ -94,6 +94,7 @@ caluma:
       allForms: "Alle Formulare"
       new: "Neues Formular"
       empty: "Wir haben keine Formulare gefunden. Klicken Sie den Knopf im der rechten oberen Ecke um ein Formular zu Erstellen!"
+      loadMore: "Mehr Formulare laden"
 
       not-found: "Kein Formular mit dem Slug '{slug}' gefunden"
 

--- a/translations/en.yaml
+++ b/translations/en.yaml
@@ -94,6 +94,7 @@ caluma:
       allForms: "All forms"
       new: "New form"
       empty: "We did not find any forms. Click the button in the top right corner to create a new form right now!"
+      loadMore: "Load more forms"
 
       not-found: "No form with slug '{slug}' found"
 


### PR DESCRIPTION
Add the capability of searching for specific form names among the
listed forms. Paginate the retrieved forms and allow to load more
forms on demand.