### PR TITLE
fix(cfb): consider namespace during slug validation

### DIFF
--- a/addon/components/cfb-form-editor/general.js
+++ b/addon/components/cfb-form-editor/general.js
@@ -37,6 +37,7 @@ export default Component.extend({
         {
           node: {
             name: "",
+            namespace: "",
             slug: "",
             description: "",
             isPublished: true,
@@ -140,6 +141,7 @@ export default Component.extend({
     },
 
     updateSlug(value, changeset) {
+      changeset.set("namespace", this.prefix);
       changeset.set("slug", value);
 
       this.validateSlug.perform(this.prefix + value, changeset);

--- a/addon/components/cfb-form-editor/question.js
+++ b/addon/components/cfb-form-editor/question.js
@@ -102,6 +102,7 @@ export default Component.extend({
         {
           node: {
             label: "",
+            namespace: "",
             slug: "",
             description: "",
             isRequired: "false",
@@ -437,6 +438,7 @@ export default Component.extend({
     },
 
     updateSlug(value, changeset) {
+      changeset.set("namespace", this.prefix);
       changeset.set("slug", value);
       this.set("linkSlug", false);
 

--- a/addon/validations/form.js
+++ b/addon/validations/form.js
@@ -1,14 +1,11 @@
 import {
   validatePresence,
   validateLength,
-  validateFormat,
 } from "ember-changeset-validations/validators";
+
+import validateSlug from "../validators/slug";
 
 export default {
   name: [validatePresence(true), validateLength({ max: 255 })],
-  slug: [
-    validatePresence(true),
-    validateLength({ max: 50 }),
-    validateFormat({ regex: /^[a-z0-9-]+$/ }),
-  ],
+  slug: validateSlug(),
 };

--- a/addon/validators/slug.js
+++ b/addon/validators/slug.js
@@ -1,15 +1,35 @@
+import buildMessage from "ember-changeset-validations/utils/validation-errors";
 import {
   validatePresence,
-  validateLength,
   validateFormat,
 } from "ember-changeset-validations/validators";
 
 import and from "ember-caluma/utils/and";
 
+const validateNamespaceSlugLength = function ({ max, namespace }) {
+  return (key, newValue, oldValue, changes, content) => {
+    const prefix =
+      (changes?.[namespace] ||
+        (changes?.[namespace] === undefined && content?.[namespace])) ??
+      "";
+
+    const slug = prefix + newValue;
+
+    return (
+      slug.length <= max ||
+      buildMessage(key, {
+        type: "tooLong",
+        value: newValue,
+        context: { max: max - prefix.length },
+      })
+    );
+  };
+};
+
 const validateSlug = () =>
   and(
     validatePresence(true),
-    validateLength({ max: 127 }),
+    validateNamespaceSlugLength({ max: 127, namespace: "namespace" }),
     validateFormat({ regex: /^[a-z0-9-]+$/ })
   );
 

--- a/tests/integration/components/cfb-form-editor/general-test.js
+++ b/tests/integration/components/cfb-form-editor/general-test.js
@@ -212,4 +212,41 @@ module("Integration | Component | cfb-form-editor/general", function (hooks) {
       .dom("input[name=slug] + span")
       .hasText("t:caluma.form-builder.validations.form.slug:()");
   });
+
+  test("it validates the slug length with no namespace", async function (assert) {
+    assert.expect(2);
+
+    await render(hbs`{{cfb-form-editor/general slug=null}}`);
+
+    await fillIn("input[name=slug]", "x".repeat(127));
+    await blur("input[name=slug]");
+
+    assert.dom("input[name=slug] + span").doesNotExist();
+
+    await fillIn("input[name=slug]", "x".repeat(128));
+    await blur("input[name=slug]");
+
+    assert
+      .dom("input[name=slug] + span")
+      .hasText("Slug is too long (maximum is 127 characters)");
+  });
+
+  test("it validates the slug length with namespace", async function (assert) {
+    assert.expect(2);
+
+    this.owner.lookup("service:caluma-options").namespace = "Foo Bar";
+    await render(hbs`{{cfb-form-editor/general slug=null}}`);
+
+    await fillIn("input[name=slug]", "x".repeat(119));
+    await blur("input[name=slug]");
+
+    assert.dom(".cfb-prefixed + span").doesNotExist();
+
+    await fillIn("input[name=slug]", "x".repeat(120));
+    await blur("input[name=slug]");
+
+    assert
+      .dom(".cfb-prefixed + span")
+      .hasText("Slug is too long (maximum is 119 characters)");
+  });
 });

--- a/tests/integration/components/cfb-form-editor/question-test.js
+++ b/tests/integration/components/cfb-form-editor/question-test.js
@@ -503,6 +503,39 @@ module("Integration | Component | cfb-form-editor/question", function (hooks) {
       .hasText("t:caluma.form-builder.validations.question.slug:()");
   });
 
+  test("it validates the slug length with no namespace", async function (assert) {
+    await render(hbs`{{cfb-form-editor/question slug=null}}`);
+
+    await fillIn("input[name=slug]", "x".repeat(127));
+    await blur("input[name=slug]");
+
+    assert.dom("input[name=slug] + span").doesNotExist();
+
+    await fillIn("input[name=slug]", "x".repeat(128));
+    await blur("input[name=slug]");
+
+    assert
+      .dom("input[name=slug] + span")
+      .hasText("Slug is too long (maximum is 127 characters)");
+  });
+
+  test("it validates the slug length with namespace", async function (assert) {
+    this.owner.lookup("service:caluma-options").namespace = "Foo Bar";
+    await render(hbs`{{cfb-form-editor/question slug=null}}`);
+
+    await fillIn("input[name=slug]", "x".repeat(119));
+    await blur("input[name=slug]");
+
+    assert.dom(".cfb-prefixed + span").doesNotExist();
+
+    await fillIn("input[name=slug]", "x".repeat(120));
+    await blur("input[name=slug]");
+
+    assert
+      .dom(".cfb-prefixed + span")
+      .hasText("Slug is too long (maximum is 119 characters)");
+  });
+
   test("it auto-suggests the slug if it has not been manually changed", async function (assert) {
     assert.expect(3);
 


### PR DESCRIPTION
When building forms and questions, the namespace is taken into
account during slug validation. This ensures that the combined
length of the namespace (if existent) and slug never exceeds
the maximum length in a valid form or question.

Issue #1264