### PR TITLE
feat(jexl): improve mapby and add stringify transform

### DIFF
--- a/addon/lib/dependencies.js
+++ b/addon/lib/dependencies.js
@@ -28,10 +28,12 @@ export function getDependenciesFromJexl(jexl, expression) {
   return [
     ...new Set([
       ...answerTransforms.map((transform) => transform.args[0].value),
-      ...mapbyTransforms.map(
-        (transform) =>
-          `${transform.args[0].args[0].value}.${transform.args[1].value}`
-      ),
+      ...mapbyTransforms.flatMap((transform) => {
+        const parentKey = transform.args[0].args[0].value;
+        const childKeys = transform.args.slice(1).map(({ value }) => value);
+
+        return childKeys.map((key) => `${parentKey}.${key}`);
+      }),
     ]),
   ];
 }

--- a/addon/lib/document.js
+++ b/addon/lib/document.js
@@ -6,7 +6,7 @@ import jexl from "jexl";
 
 import { decodeId } from "ember-caluma/helpers/decode-id";
 import Base from "ember-caluma/lib/base";
-import { intersects } from "ember-caluma/utils/jexl";
+import { intersects, mapby } from "ember-caluma/utils/jexl";
 
 const onlyNumbers = (nums) =>
   nums.filter((num) => !isNaN(num) && typeof num === "number");
@@ -122,9 +122,7 @@ export default Base.extend({
     const documentJexl = new jexl.Jexl();
 
     documentJexl.addTransform("answer", (slug) => this.findAnswer(slug));
-    documentJexl.addTransform("mapby", (arr, key) => {
-      return Array.isArray(arr) ? arr.map((obj) => obj[key]) : null;
-    });
+    documentJexl.addTransform("mapby", mapby);
     documentJexl.addBinaryOp("intersects", 20, intersects);
     documentJexl.addTransform("debug", (any, label = "JEXL Debug") => {
       // eslint-disable-next-line no-console
@@ -155,6 +153,7 @@ export default Base.extend({
       const nums = onlyNumbers(arr);
       return nums.length ? sum(nums) / nums.length : null;
     });
+    documentJexl.addTransform("stringify", (input) => JSON.stringify(input));
 
     return documentJexl;
   }),

--- a/addon/utils/jexl.js
+++ b/addon/utils/jexl.js
@@ -1,6 +1,16 @@
 export const intersects = (left, right) =>
   (left || []).some((val) => (right || []).includes(val));
 
+export const mapby = (arr, ...keys) => {
+  if (!Array.isArray(arr)) {
+    return null;
+  }
+
+  return arr.map((obj) =>
+    keys.length > 1 ? keys.map((key) => obj[key]) : obj[keys[0]]
+  );
+};
+
 /**
  * Transform a JEXL expression into it's AST
  *

--- a/tests/unit/lib/data.js
+++ b/tests/unit/lib/data.js
@@ -82,6 +82,15 @@ const form = {
                         __typename: "StringAnswer",
                       },
                     },
+                    {
+                      node: {
+                        question: {
+                          slug: "table-form-question-2",
+                        },
+                        stringValue: "test",
+                        __typename: "StringAnswer",
+                      },
+                    },
                   ],
                 },
               },
@@ -98,6 +107,16 @@ const form = {
           isHidden:
             "!('show-multiple-choice' in 'table'|answer|mapby('table-form-question'))",
           __typename: "MultipleChoiceQuestion",
+        },
+      },
+      {
+        node: {
+          slug: "json-dependency",
+          label: "Test JSON dependency",
+          isRequired: "false",
+          isHidden:
+            "!('[\"test1\",\"test2\"]' in 'table'|answer|mapby('table-form-question', 'table-form-question-2')|stringify)",
+          __typename: "TextQuestion",
         },
       },
     ],
@@ -161,6 +180,15 @@ const answers = {
                       __typename: "TextQuestion",
                     },
                   },
+                  {
+                    node: {
+                      slug: "table-form-question-2",
+                      label: "Question",
+                      isRequired: "false",
+                      isHidden: "false",
+                      __typename: "TextQuestion",
+                    },
+                  },
                 ],
               },
               __typename: "Form",
@@ -174,6 +202,16 @@ const answers = {
                       slug: "table-form-question",
                     },
                     stringValue: "show-multiple-choice",
+                    __typename: "StringAnswer",
+                  },
+                },
+                {
+                  node: {
+                    id: id("StringAnswer"),
+                    question: {
+                      slug: "table-form-question-2",
+                    },
+                    stringValue: "test",
                     __typename: "StringAnswer",
                   },
                 },

--- a/tests/unit/lib/document-test.js
+++ b/tests/unit/lib/document-test.js
@@ -50,6 +50,7 @@ module("Unit | Library | document", function (hooks) {
       ["calculated", false],
       ["table", false],
       ["multiple-choice", false],
+      ["json-dependency", true],
     ]);
   });
 
@@ -67,6 +68,7 @@ module("Unit | Library | document", function (hooks) {
       ["calculated", false],
       ["table", false],
       ["multiple-choice", false],
+      ["json-dependency", true],
     ]);
   });
 
@@ -82,6 +84,7 @@ module("Unit | Library | document", function (hooks) {
       ["calculated", false],
       ["table", false],
       ["multiple-choice", false],
+      ["json-dependency", true],
     ]);
     await this.setFieldValue("question-1", "foo");
 
@@ -94,6 +97,7 @@ module("Unit | Library | document", function (hooks) {
       ["calculated", false],
       ["table", false],
       ["multiple-choice", false],
+      ["json-dependency", true],
     ]);
   });
 
@@ -214,6 +218,18 @@ module("Unit | Library | document", function (hooks) {
     assert.equal(
       await this.document.jexl.eval(expression, { values: [10] }),
       10
+    );
+  });
+
+  test("it stringifies correctly", async function (assert) {
+    assert.equal(
+      await this.document.jexl.eval(
+        '\'["test1","test2"]\' == value|stringify',
+        {
+          value: ["test1", "test2"],
+        }
+      ),
+      true
     );
   });
 

--- a/tests/unit/lib/field-test.js
+++ b/tests/unit/lib/field-test.js
@@ -6,6 +6,7 @@ import { module, test } from "qunit";
 
 import data from "./data";
 
+import { getDependenciesFromJexl } from "ember-caluma/lib/dependencies";
 import { parseDocument } from "ember-caluma/lib/parsers";
 
 module("Unit | Library | field", function (hooks) {
@@ -431,6 +432,20 @@ module("Unit | Library | field", function (hooks) {
     assert.deepEqual(table.errors, [
       't:caluma.form.validation.table:("value":null)',
     ]);
+  });
+
+  module("dependencies", function () {
+    test("calculates mapby dependencies correctly", async function (assert) {
+      this.field = this.document.findField("json-dependency");
+
+      assert.deepEqual(
+        getDependenciesFromJexl(
+          this.field.document.jexl,
+          this.field.question.isHidden
+        ),
+        ["table", "table.table-form-question", "table.table-form-question-2"]
+      );
+    });
   });
 
   module("calculated", function (hooks) {


### PR DESCRIPTION
This extends the mapby transform to accept multiple keys as argument
which then returns an array instead of the single value. This will
result in nested arrays which is why we added a stringify transform that
converts such a collection into a string to be used in comparisons.