### PR TITLE
fix: use concurrency decorators for compatibility

### DIFF
--- a/addon/components/cfb-form-editor/question-list.js
+++ b/addon/components/cfb-form-editor/question-list.js
@@ -5,12 +5,12 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { queryManager } from "ember-apollo-client";
 import { optional } from "ember-composable-helpers/helpers/optional";
+import { timeout } from "ember-concurrency";
 import {
   enqueueTask,
   lastValue,
   restartableTask,
-  timeout,
-} from "ember-concurrency";
+} from "ember-concurrency-decorators";
 import UIkit from "uikit";
 import { v4 } from "uuid";
 

--- a/addon/routes/edit.js
+++ b/addon/routes/edit.js
@@ -1,7 +1,7 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 import { queryManager } from "ember-apollo-client";
-import { lastValue, task } from "ember-concurrency";
+import { lastValue, dropTask } from "ember-concurrency-decorators";
 import gql from "graphql-tag";
 
 import { navigationTitle } from "ember-caluma/decorators";
@@ -14,7 +14,7 @@ export default class EditRoute extends Route {
   @lastValue("fetchName")
   title;
 
-  @task
+  @dropTask
   *fetchName(slug) {
     const [form] = yield this.apollo.watchQuery(
       {

--- a/addon/routes/edit/questions/edit.js
+++ b/addon/routes/edit/questions/edit.js
@@ -1,7 +1,7 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
 import { queryManager } from "ember-apollo-client";
-import { task, lastValue } from "ember-concurrency";
+import { lastValue, dropTask } from "ember-concurrency-decorators";
 import gql from "graphql-tag";
 
 import { navigationTitle } from "ember-caluma/decorators";
@@ -14,7 +14,7 @@ export default class EditQuestionsEditRoute extends Route {
   @lastValue("fetchLabel")
   title;
 
-  @task
+  @dropTask
   *fetchLabel(slug) {
     const [question] = yield this.apollo.query(
       {

--- a/addon/services/validator.js
+++ b/addon/services/validator.js
@@ -2,7 +2,7 @@ import { assert } from "@ember/debug";
 import Service from "@ember/service";
 import { isEmpty } from "@ember/utils";
 import { queryManager } from "ember-apollo-client";
-import { task } from "ember-concurrency";
+import { dropTask } from "ember-concurrency-decorators";
 
 import allFormatValidatorsQuery from "ember-caluma/gql/queries/all-format-validators.graphql";
 
@@ -47,7 +47,7 @@ export default class ValidatorService extends Service {
     });
   }
 
-  @task
+  @dropTask
   *validators() {
     const raw = yield this.apollo.query(
       { query: allFormatValidatorsQuery },

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ember-cli-showdown": "^4.5.0",
     "ember-cli-string-helpers": "^5.0.0",
     "ember-composable-helpers": "^4.4.0",
-    "ember-concurrency": "^2.0.2",
+    "ember-concurrency": "^1.3.0 || ^2.0.2",
     "ember-fetch": "^8.0.4",
     "ember-intl": "^5.6.2",
     "ember-math-helpers": "^2.15.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8030,7 +8030,7 @@ ember-concurrency-decorators@^2.0.0:
     ember-cli-htmlbars "^4.3.1"
     ember-cli-typescript "^3.1.4"
 
-"ember-concurrency@>=0.9.0 <3", "ember-concurrency@>=1.0.0 <3", ember-concurrency@^2.0.2:
+"ember-concurrency@>=0.9.0 <3", "ember-concurrency@>=1.0.0 <3", "ember-concurrency@^1.3.0 || ^2.0.2":
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ember-concurrency/-/ember-concurrency-2.0.2.tgz#0fdadb6afae417908970c04492f98f8f2e9d06ec"
   integrity sha512-dIlSg1NFZpNFJf7gEW0etrzfeivnBZKnjx6cSgbP1QUsaYgECoKXmNnuPK9YPZofqAnRZdCawQv4yMmW5zUNiw==


### PR DESCRIPTION
ember-concurrency v2+ uses tracked properties in the background. Sadly, we're not quite ready to enforce this so we readd the decorators addon to enable usage of ember-caluma with a prior version