### PR TITLE
chore(deps): upgrade momentjs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,10 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('yarn.lock') }}
+          key: node-modules-v2-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            node-modules-${{ hashFiles('yarn.lock') }}
-            node-modules-
+            node-modules-v2-${{ hashFiles('yarn.lock') }}
+            node-modules-v2-
 
       - name: Install dependencies
         run: yarn install
@@ -157,10 +157,10 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: node_modules
-          key: node-modules-${{ hashFiles('yarn.lock') }}
+          key: node-modules-v2-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            node-modules-${{ hashFiles('yarn.lock') }}
-            node-modules-
+            node-modules-v2-${{ hashFiles('yarn.lock') }}
+            node-modules-v2-
 
       - name: Install dependencies
         run: yarn install

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jexl": "^2.3.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isequal": "^4.5.0",
-    "moment": "2.24.0",
+    "moment": "^2.29.1",
     "proxy-polyfill": "^0.3.2",
     "sass": "^1.32.8",
     "slugify": "^1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13721,12 +13721,7 @@ moment-timezone@^0.5.13:
   dependencies:
     moment ">= 2.9.0"
 
-moment@2.24.0:
-  version "2.24.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
-  integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
-"moment@>= 2.9.0", moment@^2.19.3:
+"moment@>= 2.9.0", moment@^2.19.3, moment@^2.29.1:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==


### PR DESCRIPTION
The issue that made us downgrade moment has been fixed in
ember-moment-shim 3.8.0.
https://github.com/adopted-ember-addons/ember-pikaday/issues/343