### PR TITLE
feat(jexl): allow optional answer transforms with default value

### DIFF
--- a/addon/lib/dependencies.js
+++ b/addon/lib/dependencies.js
@@ -1,4 +1,3 @@
-import { assert } from "@ember/debug";
 import { computed, get } from "@ember/object";
 
 import { getAST, getTransforms } from "ember-caluma/utils/jexl";
@@ -45,25 +44,6 @@ export function getDependenciesFromJexl(jexl, expression) {
       ),
     ]),
   ];
-}
-
-/**
- * Find a certain field in a document or throw an informative error.
- *
- * @param {Document} document The document containing the field
- * @param {String} slug The question slug of the searched field
- * @param {String} expression The expression to append to the error message
- * @return {Field} The searched field
- */
-export function findField(document, slug, expression) {
-  const field = document.findField(slug);
-
-  assert(
-    `Field for question \`${slug}\` could not be found in the document \`${document.uuid}\`. Please verify that the jexl expression is correct: \`${expression}\`.`,
-    field
-  );
-
-  return field;
 }
 
 /**
@@ -123,16 +103,14 @@ export function dependencies(
             return null;
           }
 
-          const field = findField(this.document, fieldSlug, expression);
+          const field = this.document.findField(fieldSlug);
 
-          if (!onlyNestedParents && nestedSlug && field.value) {
+          if (!onlyNestedParents && nestedSlug && field?.value) {
             // Get the nested fields from the parents value (rows)
             const childFields =
               nestedSlug === "__all__"
                 ? field.value.flatMap((row) => row.fields)
-                : field.value.map((row) =>
-                    findField(row, nestedSlug, expression)
-                  );
+                : field.value.map((row) => row.findField(nestedSlug));
 
             return [field, ...childFields];
           }

--- a/addon/lib/field.js
+++ b/addon/lib/field.js
@@ -525,13 +525,26 @@ export default Base.extend({
     "hiddenDependencies.@each.{hidden,value}",
     "jexlContext",
     "question.isHidden",
+    "pk",
     function () {
-      return (
-        this.get("fieldset.field.hidden") ||
+      if (
+        this.fieldset.field?.hidden ||
         (this.hiddenDependencies.length &&
-          this.hiddenDependencies.every(fieldIsHidden)) ||
-        this.document.jexl.evalSync(this.question.isHidden, this.jexlContext)
-      );
+          this.hiddenDependencies.every(fieldIsHidden))
+      ) {
+        return true;
+      }
+
+      try {
+        return this.document.jexl.evalSync(
+          this.question.isHidden,
+          this.jexlContext
+        );
+      } catch (error) {
+        throw new Error(
+          `Error while evaluating \`isHidden\` expression on field \`${this.pk}\`: ${error.message}`
+        );
+      }
     }
   ),
 
@@ -551,13 +564,26 @@ export default Base.extend({
     "jexlContext",
     "optionalDependencies.@each.{hidden,value}",
     "question.isRequired",
+    "pk",
     function () {
-      return (
-        this.get("fieldset.field.hidden") ||
+      if (
+        this.fieldset.field?.hidden ||
         (this.optionalDependencies.length &&
-          this.optionalDependencies.every(fieldIsHidden)) ||
-        !this.document.jexl.evalSync(this.question.isRequired, this.jexlContext)
-      );
+          this.optionalDependencies.every(fieldIsHidden))
+      ) {
+        return true;
+      }
+
+      try {
+        return !this.document.jexl.evalSync(
+          this.question.isRequired,
+          this.jexlContext
+        );
+      } catch (error) {
+        throw new Error(
+          `Error while evaluating \`isRequired\` expression on field \`${this.pk}\`: ${error.message}`
+        );
+      }
     }
   ),
 

--- a/tests/unit/lib/document-test.js
+++ b/tests/unit/lib/document-test.js
@@ -237,6 +237,7 @@ module("Unit | Library | document", function (hooks) {
     assert.expect(1);
 
     assert.deepEqual(this.document.jexlContext, {
+      null: null,
       form: "form",
       info: {
         root: { form: "form", formMeta: { "is-top-form": true, level: 0 } },

--- a/tests/unit/lib/field-test.js
+++ b/tests/unit/lib/field-test.js
@@ -121,7 +121,7 @@ module("Unit | Library | field", function (hooks) {
     assert.deepEqual(field.optionalDependencies, [dependentField]);
   });
 
-  test("computes the correct Jexl context", async function (assert) {
+  test("computes the correct jexl context", async function (assert) {
     assert.expect(1);
 
     const field = this.document
@@ -129,6 +129,7 @@ module("Unit | Library | field", function (hooks) {
       .value[0].findField("table-form-question");
 
     assert.deepEqual(field.jexlContext, {
+      null: null,
       form: "form",
       info: {
         form: "table-form",
@@ -433,6 +434,34 @@ module("Unit | Library | field", function (hooks) {
     assert.deepEqual(table.errors, [
       't:caluma.form.validation.table:("value":null)',
     ]);
+  });
+
+  test("it can handle optional 'answer' transforms", async function (assert) {
+    assert.expect(4);
+
+    const field = this.addField({
+      question: {
+        __typename: "TextQuestion",
+        isHidden: "'nonexistent'|answer('default') == 'default'",
+        isRequired: "false",
+      },
+      answer: null,
+    });
+
+    assert.ok(field.hidden);
+
+    field.question.set("isHidden", "'nonexistent'|answer(null) == null");
+    assert.ok(field.hidden);
+
+    assert.throws(() => {
+      field.question.set("isHidden", "'nonexistent'|answer == null");
+      field.hidden;
+    }, /(Error while evaluating `isHidden` expression).*(Field for question `nonexistent` could not be found)/);
+
+    assert.throws(() => {
+      field.question.set("isRequired", "'nonexistent'|answer == null");
+      field.optional;
+    }, /(Error while evaluating `isRequired` expression).*(Field for question `nonexistent` could not be found)/);
   });
 
   module("dependencies", function () {


### PR DESCRIPTION
This allows the user to write reusable JEXLs using answer transforms that don't necessarily resolve to a question in a certain form context.

https://github.com/projectcaluma/caluma/pull/1536