### PR TITLE
feat(cfb): link sub- & rowforms in question list

### DIFF
--- a/addon-mirage-support/factories/question.js
+++ b/addon-mirage-support/factories/question.js
@@ -45,8 +45,22 @@ export default Factory.extend({
       }
     } else if (question.type === "TABLE") {
       if (question.rowForm === undefined) {
+        const form = server.create("form");
         question.update({
-          rowForm: (i) => `subform-${i + 1}`,
+          rowForm: {
+            slug: form.slug,
+            name: form.name,
+          },
+        });
+      }
+    } else if (question.type === "FORM") {
+      if (question.subForm === undefined) {
+        const form = server.create("form");
+        question.update({
+          subForm: {
+            slug: form.slug,
+            name: form.name,
+          },
         });
       }
     } else if (question.type === "STATIC") {

--- a/addon/components/cfb-form-editor.hbs
+++ b/addon/components/cfb-form-editor.hbs
@@ -16,6 +16,7 @@
           @on-create-question={{@on-create-question}}
           @on-after-add-question={{@on-after-add-question}}
           @on-after-remove-question={{@on-after-remove-question}}
+          @on-click-form={{@on-click-form}}
         />
       {{/if}}
     </div>

--- a/addon/components/cfb-form-editor/question-list.hbs
+++ b/addon/components/cfb-form-editor/question-list.hbs
@@ -1,4 +1,8 @@
-<div ...attributes {{did-insert (queue (fn this.setupUIkit) (perform this.questionTask))}}>
+<div 
+  ...attributes
+  {{did-insert (queue (fn this.setupUIkit) (perform this.questionTask))}}
+  {{did-update (perform this.questionTask) @form}}
+>
   <div class="uk-text-center uk-margin">
     {{#if (includes this.mode (array "remove" "add"))}}
       <button
@@ -74,6 +78,7 @@
           @on-edit-question={{@on-edit-question}}
           @on-remove-question={{perform this.removeQuestion}}
           @on-add-question={{perform this.addQuestion}}
+          @on-click-form={{@on-click-form}}
           @on-register={{this.registerChild}}
           @on-unregister={{this.unregisterChild}}
         />

--- a/addon/components/cfb-form-editor/question-list/item.hbs
+++ b/addon/components/cfb-form-editor/question-list/item.hbs
@@ -51,10 +51,21 @@
     {{/if}}
 
     <span
-      class="uk-width-expand uk-margin-small-right uk-text-small uk-text-muted uk-text-truncate"
+      class="{{if this.showFormLink "uk-width-auto" "uk-width-expand"}}
+        uk-margin-small-right uk-text-small uk-text-muted uk-text-truncate"
     >
       {{@question.label}}
     </span>
+    {{#if this.showFormLink}}
+      <span uk-icon="link" class="uk-flex-none"></span>
+      <a data-test-link-subform
+        href="#"
+        class="uk-width-expand uk-margin-small-right uk-text-small uk-text-truncate"
+        {{on "click" (fn (optional @on-click-form) (or @question.subForm @question.rowForm))}}
+      >
+        {{or @question.subForm.name @question.rowForm.name}}
+      </a>
+    {{/if}}
 
     <span class="uk-position-relative uk-width-auto">
       <UkBadge

--- a/addon/components/cfb-form-editor/question-list/item.js
+++ b/addon/components/cfb-form-editor/question-list/item.js
@@ -2,6 +2,8 @@ import Component from "@glimmer/component";
 import jexl from "jexl";
 import { v4 } from "uuid";
 
+import { hasQuestionType } from "ember-caluma/helpers/has-question-type";
+
 export default class CfbFormEditorQuestionListItem extends Component {
   constructor(...args) {
     super(...args);
@@ -15,5 +17,13 @@ export default class CfbFormEditorQuestionListItem extends Component {
     } catch (error) {
       return false;
     }
+  }
+
+  get showFormLink() {
+    const question = this.args.question;
+    return (
+      this.args.mode === "reorder" &&
+      (hasQuestionType(question, "form") || hasQuestionType(question, "table"))
+    );
   }
 }

--- a/addon/controllers/edit.js
+++ b/addon/controllers/edit.js
@@ -24,4 +24,9 @@ export default class EditController extends Controller {
       this.transitionToRoute("edit.general");
     }
   }
+
+  @action
+  clickForm({ slug }) {
+    this.transitionToRoute("edit", slug);
+  }
 }

--- a/addon/gql/queries/search-form-question.graphql
+++ b/addon/gql/queries/search-form-question.graphql
@@ -9,6 +9,18 @@ query SearchFormQuestion($slug: String!, $search: String, $archived: Boolean) {
           edges {
             node {
               ...QuestionInfo
+              ... on FormQuestion {
+                subForm {
+                  slug
+                  name
+                }
+              }
+              ... on TableQuestion {
+                rowForm {
+                  slug
+                  name
+                }
+              }
             }
           }
         }

--- a/addon/gql/queries/search-question.graphql
+++ b/addon/gql/queries/search-question.graphql
@@ -21,6 +21,18 @@ query SearchQuestion(
     edges {
       node {
         ...QuestionInfo
+        ... on FormQuestion {
+          subForm {
+            slug
+            name
+          }
+        }
+        ... on TableQuestion {
+          rowForm {
+            slug
+            name
+          }
+        }
       }
     }
   }

--- a/addon/routes/edit.js
+++ b/addon/routes/edit.js
@@ -16,7 +16,7 @@ export default class EditRoute extends Route {
 
   @dropTask
   *fetchName(slug) {
-    const [form] = yield this.apollo.watchQuery(
+    const [form] = yield this.apollo.query(
       {
         query: gql`
           query FormName($slug: String!) {

--- a/addon/templates/edit.hbs
+++ b/addon/templates/edit.hbs
@@ -4,6 +4,7 @@
   @on-create-question={{this.createQuestion}}
   @on-after-add-question={{this.editQuestion}}
   @on-after-remove-question={{this.afterRemoveQuestion}}
+  @on-click-form={{this.clickForm}}
 >
   {{outlet}}
 </CfbFormEditor>

--- a/tests/acceptance/question-link-form-test.js
+++ b/tests/acceptance/question-link-form-test.js
@@ -1,0 +1,121 @@
+import { visit, click, currentURL } from "@ember/test-helpers";
+import { setupMirage } from "ember-cli-mirage/test-support";
+import { setupIntl } from "ember-intl/test-support";
+import { setupApplicationTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Acceptance | question link form", function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  test("can link to subforms", async function (assert) {
+    assert.expect(10);
+
+    const questions = this.server.createList("question", 3);
+    const subForm = this.server.create("form", { questions });
+    const question = this.server.create("question", {
+      type: "FORM",
+      subForm: {
+        slug: subForm.slug,
+        name: subForm.name,
+      },
+    });
+    const form = this.server.create("form", { questions: [] });
+
+    await visit(`/demo/form-builder/${form.slug}`);
+    await click("[data-test-demo-content] [data-test-add-question]");
+    assert
+      .dom(
+        `[data-test-demo-content] [data-test-question-list-item=${question.slug}] [data-test-link-subform]`
+      )
+      .doesNotExist();
+    await click(
+      `[data-test-demo-content] [data-test-question-list-item=${question.slug}] [data-test-add-item]`
+    );
+
+    await click("[data-test-demo-content] [data-test-cancel]");
+
+    await click(
+      `[data-test-demo-content] [data-test-question-list-item=${question.slug}] [data-test-link-subform]`
+    );
+    assert.equal(currentURL(), `/demo/form-builder/${subForm.slug}`);
+
+    assert
+      .dom("[data-test-question-list-item]")
+      .exists({ count: questions.length });
+    const questionList = [
+      ...document.querySelectorAll("[data-test-question-list-item]"),
+    ];
+    questions.forEach((question, index) => {
+      assert.dom(questionList[index]).containsText(question.slug);
+    });
+
+    assert.equal(
+      document.querySelector("[data-test-demo-content] input[name='name']")
+        .value,
+      subForm.name
+    );
+    assert
+      .dom(".uk-breadcrumb .cfb-navigation__item__link")
+      .exists({ count: 2 });
+    assert
+      .dom(".uk-breadcrumb :nth-child(2) .cfb-navigation__item__link")
+      .hasAttribute("href", `/demo/form-builder/${subForm.slug}`);
+    assert
+      .dom(".uk-breadcrumb :nth-child(2) .cfb-navigation__item__link")
+      .hasText(subForm.name);
+  });
+
+  test("can link to rowforms", async function (assert) {
+    assert.expect(8);
+
+    this.server.create("document");
+    const rowformQuestion = this.server.create("question", { type: "TABLE" });
+    const rowform = this.server.create("form", {
+      questions: [rowformQuestion],
+    });
+    const question = this.server.create("question", {
+      type: "TABLE",
+      rowForm: {
+        slug: rowform.slug,
+        name: rowform.name,
+      },
+    });
+    const form = this.server.create("form", { questions: [question] });
+
+    await visit(`/demo/form-builder/${form.slug}`);
+    await click("[data-test-demo-content] [data-test-add-question]");
+    assert
+      .dom(
+        `[data-test-demo-content] [data-test-question-list-item=${rowformQuestion.slug}] [data-test-link-subform]`
+      )
+      .doesNotExist();
+
+    await click("[data-test-demo-content] [data-test-cancel]");
+    await click(
+      `[data-test-demo-content] [data-test-question-list-item=${question.slug}] [data-test-link-subform]`
+    );
+    assert.equal(currentURL(), `/demo/form-builder/${rowform.slug}`);
+
+    assert.dom("[data-test-question-list-item]").exists({ count: 1 });
+    assert
+      .dom("[data-test-question-list-item]")
+      .containsText(rowformQuestion.slug);
+    assert.equal(
+      document.querySelector("[data-test-demo-content] input[name='name']")
+        .value,
+      rowform.name
+    );
+
+    assert
+      .dom(".uk-breadcrumb .cfb-navigation__item__link")
+      .exists({ count: 2 });
+    assert
+      .dom(".uk-breadcrumb :nth-child(2) .cfb-navigation__item__link")
+      .hasAttribute("href", `/demo/form-builder/${rowform.slug}`);
+    assert
+      .dom(".uk-breadcrumb :nth-child(2) .cfb-navigation__item__link")
+      .hasText(rowform.name);
+  });
+});

--- a/tests/integration/components/cfb-form-editor/question-list-test.js
+++ b/tests/integration/components/cfb-form-editor/question-list-test.js
@@ -58,6 +58,38 @@ module(
         .hasText("t:caluma.form-builder.global.empty-search:()");
     });
 
+    test("it links subforms in form questions", async function (assert) {
+      assert.expect(2);
+
+      const formQuestion = this.server.create("question", { type: "FORM" });
+      this.server.create("form", {
+        slug: "new-form",
+        questions: [formQuestion],
+      });
+
+      await render(hbs`<CfbFormEditor::QuestionList @form='new-form'/>`);
+
+      assert.dom("[data-test-link-subform]").exists();
+      assert.dom("[data-test-link-subform]").hasText(formQuestion.subForm.name);
+    });
+
+    test("it links rowforms in table questions", async function (assert) {
+      assert.expect(2);
+
+      const tableQuestion = this.server.create("question", { type: "TABLE" });
+      this.server.create("form", {
+        slug: "new-form",
+        questions: [tableQuestion],
+      });
+
+      await render(hbs`<CfbFormEditor::QuestionList @form='new-form'/>`);
+
+      assert.dom("[data-test-link-subform]").exists();
+      assert
+        .dom("[data-test-link-subform]")
+        .hasText(tableQuestion.rowForm.name);
+    });
+
     // for some reason, the triggerEvent action does not do what it did before and
     // causes this test to fail - therefore we skip it and hope for the best.
     test.todo("it can reorder questions", async function (assert) {


### PR DESCRIPTION
For table and form questions add direct link to subform
or rowform in question list. Show correct path and
question list corresponding to sub- / rowform.

Resolves: #1416

![image](https://user-images.githubusercontent.com/32454507/125099489-5a735e00-e0d8-11eb-9a8c-713f12a61ee1.png)
