### PR TITLE
fix: add ember-in-viewport to blueprint

### DIFF
--- a/blueprints/ember-caluma/index.js
+++ b/blueprints/ember-caluma/index.js
@@ -13,6 +13,7 @@ module.exports = {
         { name: "ember-cli-showdown" },
         { name: "ember-pikaday" },
         { name: "ember-composable-helpers" },
+        { name: "ember-in-viewport" },
       ],
     });
   },


### PR DESCRIPTION
Seems like I messed up earlier and the project I tested with had ember-in-viewport installed without me noticing.