### PR TITLE
fix(file upload): don't use formdata for minio upload

### DIFF
--- a/addon/components/cf-field/input/file.js
+++ b/addon/components/cf-field/input/file.js
@@ -36,12 +36,9 @@ export default Component.extend({
    */
   _uploadFile(file, url) {
     return new Promise((resolve, reject) => {
-      const data = new FormData();
-      data.append("file", file);
-
       fetch(url, {
         method: "PUT",
-        body: data,
+        body: file,
       })
         .then((response) =>
           response.ok ? resolve(response) : reject(response)


### PR DESCRIPTION
It seems that minio expects the request body to be the plain file instead of a `FormData` object. 

This fixes a regression introduced in https://github.com/projectcaluma/ember-caluma/pull/1287