### PR TITLE
fix(file upload): don't use formdata for minio upload

### DIFF
--- a/addon/components/cf-field/input/file.js
+++ b/addon/components/cf-field/input/file.js
@@ -53,12 +53,9 @@ export default class CfFieldInputFileComponent extends Component {
     const { fileValue } = await this.args.onSave(file.name);
 
     try {
-      const data = new FormData();
-      data.append("file", file);
-
       const response = await fetch(fileValue.uploadUrl, {
         method: "PUT",
-        body: data,
+        body: file,
       });
 
       if (!response.ok) {


### PR DESCRIPTION
It seems that minio expects the request body to be the plain file
instead of a FormData object.

This fixes a regression introduced in #1287.