### PR TITLE
fix(demo-app): added required "validation" route to router and added translations

### DIFF
--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -15,6 +15,7 @@ Router.map(function () {
     this.route("queries");
     this.route("migration");
     this.route("buttons");
+    this.route("validation");
   });
 
   this.route("demo", function () {

--- a/translations/dummy/de.yaml
+++ b/translations/dummy/de.yaml
@@ -4,6 +4,7 @@ dummy:
   usage: "Anwendung"
   testing: "Testen"
   migration: "Migration"
+  validation: "Validierung"
   queries:
     title: "Queries"
     load: "Laden"

--- a/translations/dummy/en.yaml
+++ b/translations/dummy/en.yaml
@@ -4,6 +4,7 @@ dummy:
   usage: "Usage"
   testing: "Testing"
   migration: "Migration"
+  validation: "Validation"
   queries:
     title: "Queries"
     load: "Load"

--- a/translations/dummy/fr.yaml
+++ b/translations/dummy/fr.yaml
@@ -4,6 +4,7 @@ dummy:
   usage: "Application"
   testing: "Tester"
   migration: "Migration"
+  validation: "Validation"
   queries:
     title: "Queries"
     load: "Télécharger"


### PR DESCRIPTION
Currently when making a fresh copy of the git repo the documentation in the dummy repo doesn't actually show anything because the "validation" route is missing from `router.js`.

I added the route and added the required translations in the dummy app.