### PR TITLE
feat(buttons): add willMutate hook for work item and task buttons

### DIFF
--- a/addon/components/task-button.hbs
+++ b/addon/components/task-button.hbs
@@ -14,6 +14,7 @@
       @title={{@title}}
       @onSuccess={{@onSuccess}}
       @onError={{@onError}}
+      @willMutate={{@willMutate}}
     >
       {{#if (has-block)}}
         {{yield}}

--- a/addon/components/work-item-button.js
+++ b/addon/components/work-item-button.js
@@ -39,21 +39,27 @@ export default class WorkItemButtonComponent extends Component {
   @dropTask
   *mutate() {
     try {
+      if (typeof this.args.willMutate === "function") {
+        const proceed = yield this.args.willMutate();
+
+        if (proceed === false) return;
+      }
+
       yield this.apollo.mutate({
         mutation: this[`${this.args.mutation}WorkItemMutation`],
         variables: { id: this.args.workItemId },
       });
 
-      if (this.args.onSuccess) {
-        this.args.onSuccess();
+      if (typeof this.args.onSuccess === "function") {
+        yield this.args.onSuccess();
       } else {
         this.notification.success(
           this.intl.t("caluma.mutate-work-item.success")
         );
       }
     } catch (e) {
-      if (this.args.onError) {
-        this.args.onError(e);
+      if (typeof this.args.onError === "function") {
+        yield this.args.onError(e);
       } else {
         // eslint-disable-next-line no-console
         console.error(e);

--- a/tests/dummy/app/templates/docs/buttons.md
+++ b/tests/dummy/app/templates/docs/buttons.md
@@ -35,6 +35,7 @@ The WorkItemButton component has 5 parameters:
 - `label` (Optional) Overwrites the button text.
 - `onSuccess`(Optional) Function to be called when the mutation succeeds.
 - `onError`(Optional) Function to be called when the mutation fails.
+- `willMutate`(Optional) Function to be called before the mutation is executed, if this function returns `false` the mutation is aborted.
 
 Additionally there are many optional parameters for the underlying [UkButton](https://adfinis-sygroup.github.io/ember-uikit/#/docs/components/button) component, refer to the UkButton component documentation to see what exactly they do:
 
@@ -80,5 +81,6 @@ The TaskButton component has 6 parameters:
 - `label` (Optional) Overwrites the button text.
 - `onSuccess`(Optional) Will be passed to WorkItemButton onSuccess.
 - `onError`(Optional) Will be passed to WorkItemButton onError.
+- `willMutate`(Optional) Will be passed to WorkItemButton willMutate.
 
 Additionally the [UkButton](https://adfinis-sygroup.github.io/ember-uikit/#/docs/components/button) parameters from the WorkItemButton still apply.

--- a/tests/integration/components/work-item-button-test.js
+++ b/tests/integration/components/work-item-button-test.js
@@ -68,4 +68,21 @@ module("Integration | Component | work-item-button", function (hooks) {
     this.set("mutation", mutation);
     await click("button");
   });
+
+  test("it triggers willMutate hook", async function (assert) {
+    assert.expect(2);
+
+    this.willMutate = () => {
+      assert.step("willMutate");
+      return false;
+    };
+
+    await render(
+      hbs`<WorkItemButton @mutation="complete" @workItemId="test" @willMutate={{this.willMutate}} />`
+    );
+
+    await click("button");
+
+    assert.verifySteps(["willMutate"]);
+  });
 });


### PR DESCRIPTION
This will allow the user to pass an action that is executed before the mutation starts. E.g displaying a confirmation dialog.