### PR TITLE
feat(validation): switch default for validateOnEnter

### DIFF
--- a/addon/components/document-validity.hbs
+++ b/addon/components/document-validity.hbs
@@ -1,4 +1,4 @@
-{{#if this.validateOnEnter}}
+{{#if @validateOnEnter}}
   <div {{in-viewport onEnter=this.validate}}>
     {{yield this.isValid this.validate}}
   </div>

--- a/addon/components/document-validity.js
+++ b/addon/components/document-validity.js
@@ -25,19 +25,13 @@ export default class DocumentValidity extends Component {
    */
 
   /**
-   * Whether to validate the document on entering the viewport. Default is `true`.
+   * Whether to validate the document on entering the viewport. Default is `false`.
    *
    * @argument {Boolean} validateOnEnter
    */
 
   get isValid() {
     return this.args.document.fields.every((f) => f.isValid);
-  }
-
-  get validateOnEnter() {
-    return this.args.validateOnEnter !== undefined
-      ? this.args.validateOnEnter
-      : true;
   }
 
   @action

--- a/tests/dummy/app/templates/docs/validation.md
+++ b/tests/dummy/app/templates/docs/validation.md
@@ -1,35 +1,35 @@
 # Validation
 
-Built in components to validate Caluma data.
+Built in components to validate Caluma documents.
 
 ## Usage
 
 ### DocumentValidity
 
-This component validates the passed document for its validity as soon as it
-enters the viewport and will yield the validity status of the document and an
-action for manual validation.
+This component yields a boolean `isValid` and a function `validate` which
+validates the passed Caluma document when triggered.
 
 ```hbs
-<DocumentValidity @document={{this.calumaDocument}} as |isValid|>
-  {{#if isValid}}
-    <p>The document is valid</p>
-  {{/if}}
-</DocumentValidity>
-```
-
-Or when triggered manually:
-
-```hbs
-<DocumentValidity
-  @document={{this.calumaDocument}}
-  @validateOnEnter={{false}}
-  as |isValid validate|
->
+<DocumentValidity @document={{this.calumaDocument}} as |isValid validate|>
   {{#if isValid}}
     <p>The document is valid</p>
   {{/if}}
   <button {{on "click" validate}}>Validate!</button>
+</DocumentValidity>
+```
+
+It can also be triggered automatically when the component enters the viewport
+using the parameter `validateOnEnter`:
+
+```hbs
+<DocumentValidity
+  @document={{this.calumaDocument}}
+  @validateOnEnter={{true}}
+  as |isValid|
+>
+  {{#if isValid}}
+    <p>The document is valid</p>
+  {{/if}}
 </DocumentValidity>
 ```
 

--- a/tests/integration/components/document-validity-test.js
+++ b/tests/integration/components/document-validity-test.js
@@ -34,7 +34,7 @@ module("Integration | Component | document-validity", function (hooks) {
     assert.expect(1);
 
     await render(hbs`
-      <DocumentValidity @document={{this.document}} as |isValid|>
+      <DocumentValidity @document={{this.document}} @validateOnEnter={{true}} as |isValid|>
         <p>
           {{#if isValid}}
             Valid
@@ -56,7 +56,7 @@ module("Integration | Component | document-validity", function (hooks) {
     this.makeInvalid();
 
     await render(hbs`
-      <DocumentValidity @document={{this.document}} @validateOnEnter={{false}} as |isValid validate|>
+      <DocumentValidity @document={{this.document}} as |isValid validate|>
         <p>
           {{#if isValid}}
             Valid


### PR DESCRIPTION
BREAKING CHANGE: The `validateOnEnter` parameter for the `DocumentValidity` component is now `false` instead of `true` since this is the default use case.