### PR TITLE
fix(form-builder): remove deprecated usage of transitionToRoute

### DIFF
--- a/packages/-ember-caluma/app/app.js
+++ b/packages/-ember-caluma/app/app.js
@@ -15,7 +15,6 @@ export default class App extends Application {
         services: [
           "apollo",
           "notification",
-          "router",
           "intl",
           "caluma-options",
           "validator",

--- a/packages/-ember-caluma/app/snippets/usage/app.js
+++ b/packages/-ember-caluma/app/snippets/usage/app.js
@@ -7,7 +7,6 @@ const App = Application.extend({
         services: [
           "apollo", // ember-apollo-client for graphql
           "notification", // ember-uikit for notifications
-          "router", // ember router for navigation
           "intl", // ember-intl for i18n
           "caluma-options", // service to configure ember-caluma
           "validator", // service for generic regex validation

--- a/packages/form-builder/addon/components/cfb-navigation.js
+++ b/packages/form-builder/addon/components/cfb-navigation.js
@@ -7,7 +7,7 @@ export default class CfbNavigationComponent extends Component {
   @service router;
 
   get _routes() {
-    const currentRoute = this.router.currentRouteName;
+    const currentRoute = `${this.router._mountPoint}.${this.router.currentRouteName}`;
     if (!currentRoute) return [];
 
     const routeParts = currentRoute.split(".");

--- a/packages/form-builder/addon/controllers/edit.js
+++ b/packages/form-builder/addon/controllers/edit.js
@@ -7,12 +7,12 @@ export default class EditController extends Controller {
 
   @action
   createQuestion() {
-    this.transitionToRoute("edit.questions.new");
+    this.router.transitionTo("edit.questions.new");
   }
 
   @action
   editQuestion({ slug }) {
-    this.transitionToRoute("edit.questions.edit", slug);
+    this.router.transitionTo("edit.questions.edit", slug);
   }
 
   @action
@@ -21,12 +21,12 @@ export default class EditController extends Controller {
       /edit\.questions\.edit$/.test(this.router.currentRouteName) &&
       new RegExp(`/${slug}$`).test(this.router.currentURL)
     ) {
-      this.transitionToRoute("edit.general");
+      this.router.transitionTo("edit.general");
     }
   }
 
   @action
   clickForm({ slug }) {
-    this.transitionToRoute("edit", slug);
+    this.router.transitionTo("edit", slug);
   }
 }

--- a/packages/form-builder/addon/controllers/edit/questions/edit.js
+++ b/packages/form-builder/addon/controllers/edit/questions/edit.js
@@ -1,9 +1,12 @@
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default class EditQuestionsEditController extends Controller {
+  @service router;
+
   @action
   afterSubmit() {
-    this.transitionToRoute("edit");
+    this.router.transitionTo("edit");
   }
 }

--- a/packages/form-builder/addon/controllers/edit/questions/new.js
+++ b/packages/form-builder/addon/controllers/edit/questions/new.js
@@ -1,9 +1,12 @@
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default class EditQuestionsNewController extends Controller {
+  @service router;
+
   @action
   afterSubmit({ slug }) {
-    this.transitionToRoute("edit.questions.edit", slug);
+    this.router.transitionTo("edit.questions.edit", slug);
   }
 }

--- a/packages/form-builder/addon/controllers/index.js
+++ b/packages/form-builder/addon/controllers/index.js
@@ -1,14 +1,17 @@
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default class IndexController extends Controller {
+  @service router;
+
   @action
   newForm() {
-    this.transitionToRoute("new");
+    this.router.transitionTo("new");
   }
 
   @action
   editForm({ slug }) {
-    this.transitionToRoute("edit", slug);
+    this.router.transitionTo("edit", slug);
   }
 }

--- a/packages/form-builder/addon/controllers/new.js
+++ b/packages/form-builder/addon/controllers/new.js
@@ -1,9 +1,12 @@
 import Controller from "@ember/controller";
 import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
 
 export default class NewController extends Controller {
+  @service router;
+
   @action
   afterSubmit({ slug }) {
-    this.transitionToRoute("edit", slug);
+    this.router.transitionTo("edit", slug);
   }
 }

--- a/packages/form-builder/addon/engine.js
+++ b/packages/form-builder/addon/engine.js
@@ -12,14 +12,7 @@ const Eng = Engine.extend({
   Resolver,
 
   dependencies: {
-    services: [
-      "apollo",
-      "notification",
-      "router",
-      "intl",
-      "caluma-options",
-      "validator",
-    ],
+    services: ["apollo", "notification", "intl", "caluma-options", "validator"],
   },
 });
 

--- a/packages/form-builder/package.json
+++ b/packages/form-builder/package.json
@@ -30,6 +30,7 @@
     "ember-composable-helpers": "^4.5.0",
     "ember-concurrency": "^2.1.2",
     "ember-concurrency-decorators": "^2.0.3",
+    "ember-engines-router-service": "^0.3.0",
     "ember-fetch": "^8.0.4",
     "ember-math-helpers": "^2.17.3",
     "ember-pikaday": "^3.0.0",

--- a/packages/form-builder/tests/dummy/app/app.js
+++ b/packages/form-builder/tests/dummy/app/app.js
@@ -14,7 +14,6 @@ export default class App extends Application {
         services: [
           "apollo",
           "notification",
-          "router",
           "intl",
           "caluma-options",
           "validator",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7610,7 +7610,7 @@ ember-cli-get-component-path-option@^1.0.0:
   resolved "https://registry.yarnpkg.com/ember-cli-get-component-path-option/-/ember-cli-get-component-path-option-1.0.0.tgz#0d7b595559e2f9050abed804f1d8eff1b08bc771"
   integrity sha1-DXtZVVni+QUKvtgE8djv8bCLx3E=
 
-ember-cli-htmlbars@5.7.1, ember-cli-htmlbars@^5.0.0, ember-cli-htmlbars@^5.1.0, ember-cli-htmlbars@^5.2.0, ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.3.2, ember-cli-htmlbars@^5.6.3, ember-cli-htmlbars@^5.7.0, ember-cli-htmlbars@^5.7.1:
+ember-cli-htmlbars@5.7.1, ember-cli-htmlbars@^5.0.0, ember-cli-htmlbars@^5.1.0, ember-cli-htmlbars@^5.1.1, ember-cli-htmlbars@^5.2.0, ember-cli-htmlbars@^5.3.1, ember-cli-htmlbars@^5.3.2, ember-cli-htmlbars@^5.6.3, ember-cli-htmlbars@^5.7.0, ember-cli-htmlbars@^5.7.1:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/ember-cli-htmlbars/-/ember-cli-htmlbars-5.7.1.tgz#eb5b88c7d9083bc27665fb5447a9b7503b32ce4f"
   integrity sha512-9laCgL4tSy48orNoQgQKEHp93MaqAs9ZOl7or5q+8iyGGJHW6sVXIYrVv5/5O9HfV6Ts8/pW1rSoaeKyLUE+oA==
@@ -8125,6 +8125,14 @@ ember-element-helper@^0.5.2:
     "@embroider/util" "^0.39.1 || ^0.40.0 || ^0.41.0"
     ember-cli-babel "^7.17.2"
     ember-cli-htmlbars "^5.1.0"
+
+ember-engines-router-service@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/ember-engines-router-service/-/ember-engines-router-service-0.3.0.tgz#d2584f4101f96b1e02e196a22f16eb949d5b3d87"
+  integrity sha512-BeNhrydHbjLhlC3nCrWDI0Z8aZbxCK0aKTldVY3kNvUr7/plHkp4Iv4W1zInl7mIMC56ouBzjWvxiD4w7QeNow==
+  dependencies:
+    ember-cli-babel "^7.18.0"
+    ember-cli-htmlbars "^5.1.1"
 
 ember-engines@0.8.19:
   version "0.8.19"


### PR DESCRIPTION
https://deprecations.emberjs.com/v3.x#toc_routing-transition-methods

We now use `ember-engines-router-service` to have an engine internal router service instead of using the host router service. The `router` in the engine configuration can now be removed.