### PR TITLE
feat(form): add new question type action button

### DIFF
--- a/packages/-ember-caluma/app/controllers/demo/form-rendering.js
+++ b/packages/-ember-caluma/app/controllers/demo/form-rendering.js
@@ -1,0 +1,11 @@
+import Controller from "@ember/controller";
+import { action } from "@ember/object";
+import { inject as service } from "@ember/service";
+
+export default class DemoFormRenderingController extends Controller {
+  @service notification;
+
+  @action actionButtonOnSuccess() {
+    this.notification.success("Successfully submitted the form!");
+  }
+}

--- a/packages/-ember-caluma/app/services/caluma-options.js
+++ b/packages/-ember-caluma/app/services/caluma-options.js
@@ -12,17 +12,12 @@ export default class CustomCalumaOptionsService extends CalumaOptionsService {
 
     if (ENV.environment !== "production") {
       this.registerComponentOverride({
-        label: this.intl.t(
-          "caluma.form-builder.question.widgetOverrides.dummy-one"
-        ),
+        label: "Dummy One",
         component: "dummy-one",
         types: ["TextQuestion", "TextareaQuestion"],
       });
-
       this.registerComponentOverride({
-        label: this.intl.t(
-          "caluma.form-builder.question.widgetOverrides.dummy-two"
-        ),
+        label: "Dummy Two",
         component: "dummy-two",
       });
     }

--- a/packages/-ember-caluma/app/templates/demo/form-rendering.hbs
+++ b/packages/-ember-caluma/app/templates/demo/form-rendering.hbs
@@ -1,3 +1,6 @@
 {{#if @model}}
-  <CfContent @documentId={{@model}} />
+  <CfContent
+    @documentId={{@model}}
+    @context={{hash actionButtonOnSuccess=this.actionButtonOnSuccess}}
+  />
 {{/if}}

--- a/packages/-ember-caluma/mirage/scenarios/default.js
+++ b/packages/-ember-caluma/mirage/scenarios/default.js
@@ -13,14 +13,16 @@ export default function (server) {
   });
   server.create("question", {
     slug: "description",
-    label: "Describe yourself.",
+    label: "Describe yourself:",
     formIds: [form.id],
     type: "TEXTAREA",
-    maxLength: 255,
+    maxLength: 50,
+    minLength: 5,
   });
   server.create("question", {
     slug: "age",
     label: "What is your age?",
+    infoText: null,
     formIds: [form.id],
     type: "INTEGER",
     minValue: 0,
@@ -38,6 +40,7 @@ export default function (server) {
   server.create("question", {
     slug: "like-caluma",
     label: "Do you like Caluma?",
+    infoText: null,
     type: "CHOICE",
     formIds: [form.id],
     options: [
@@ -67,12 +70,26 @@ export default function (server) {
   server.create("question", {
     slug: "dummy",
     label: "Dummy widget",
+    isRequired: "false",
+    infoText: null,
     formIds: [form.id],
     type: "TEXT",
     meta: { widgetOverride: "dummy-one" },
   });
+  server.create("question", {
+    slug: "submit",
+    label: "Submit",
+    isRequired: "false",
+    infoText: "Do you really want to submit this form?",
+    formIds: [form.id],
+    type: "ACTION_BUTTON",
+    color: "SECONDARY",
+  });
 
-  server.create("document", { formId: form.id });
+  server.create("document", {
+    workItemId: server.create("work-item").id,
+    formId: form.id,
+  });
 
   server.createList("work-item", 20);
   server.createList("format-validator", 3);

--- a/packages/core/addon/-private/possible-types.js
+++ b/packages/core/addon/-private/possible-types.js
@@ -7,7 +7,6 @@ export default {
     "WorkItem",
     "Flow",
     "DynamicOption",
-    "CalculatedFloatQuestion",
     "Option",
     "TextQuestion",
     "StringAnswer",
@@ -30,13 +29,14 @@ export default {
     "StaticQuestion",
     "FileAnswer",
     "File",
+    "CalculatedFloatQuestion",
+    "ActionButtonQuestion",
     "SimpleTask",
     "CompleteWorkflowFormTask",
     "CompleteTaskFormTask",
   ],
   Task: ["SimpleTask", "CompleteWorkflowFormTask", "CompleteTaskFormTask"],
   Question: [
-    "CalculatedFloatQuestion",
     "TextQuestion",
     "ChoiceQuestion",
     "MultipleChoiceQuestion",
@@ -50,6 +50,8 @@ export default {
     "FormQuestion",
     "FileQuestion",
     "StaticQuestion",
+    "CalculatedFloatQuestion",
+    "ActionButtonQuestion",
   ],
   Answer: [
     "StringAnswer",
@@ -60,4 +62,5 @@ export default {
     "TableAnswer",
     "FileAnswer",
   ],
+  DynamicQuestion: ["DynamicChoiceQuestion", "DynamicMultipleChoiceQuestion"],
 };

--- a/packages/form-builder/addon/components/cfb-form-editor/question.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.hbs
@@ -86,7 +86,9 @@
         {{#if
           (not
             (or
-              (has-question-type f.model "static" "calculated-float")
+              (has-question-type
+                f.model "static" "calculated-float" "action-button"
+              )
               (not (includes f.model.isRequired (array "true" "false")))
             )
           )
@@ -205,6 +207,27 @@
           @renderComponent={{component "cfb-form-editor/question/validation"}}
           @on-update={{changeset-set f.model "meta.formatValidators"}}
           @value={{changeset-get f.model "meta.formatValidators"}}
+        />
+      {{/if}}
+
+      {{#if (has-question-type f.model "action-button")}}
+        <f.input
+          @type="select"
+          @options={{this.possibleActions}}
+          @optionLabelPath="label"
+          @optionTargetPath="value"
+          @label={{t "caluma.form-builder.question.action"}}
+          @name="action"
+          @required={{true}}
+        />
+        <f.input
+          @type="select"
+          @options={{this.possibleColors}}
+          @optionLabelPath="label"
+          @optionTargetPath="value"
+          @label={{t "caluma.form-builder.question.color"}}
+          @name="color"
+          @required={{true}}
         />
       {{/if}}
 
@@ -428,6 +451,16 @@
       </UkButton>
 
       {{#if this.showAdvanced}}
+        {{#if (has-question-type f.model "action-button")}}
+          <f.input
+            @name="validateOnEnter"
+            @required={{true}}
+            @label={{t "caluma.form-builder.question.validateOnEnter"}}
+            @renderComponent={{component "cfb-toggle-switch" size="small"}}
+            class="uk-flex uk-flex-between uk-flex-column"
+          />
+        {{/if}}
+
         <div class="uk-margin">
           <f.input
             @label={{t "caluma.form-builder.question.isHidden"}}
@@ -436,7 +469,13 @@
           />
         </div>
 
-        {{#if (not (has-question-type f.model "static" "calculated-float"))}}
+        {{#if
+          (not
+            (has-question-type
+              f.model "static" "calculated-float" "action-button"
+            )
+          )
+        }}
           <div class="uk-margin">
             <f.input
               @label={{t "caluma.form-builder.question.isRequired"}}

--- a/packages/form-builder/addon/components/cfb-form-editor/question.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.js
@@ -16,6 +16,7 @@ import { hasQuestionType } from "@projectcaluma/ember-core/helpers/has-question-
 import slugify from "@projectcaluma/ember-core/utils/slugify";
 import addFormQuestionMutation from "@projectcaluma/ember-form-builder/gql/mutations/add-form-question.graphql";
 import removeDefaultAnswerMutation from "@projectcaluma/ember-form-builder/gql/mutations/remove-default-answer.graphql";
+import saveActionButtonQuestionMutation from "@projectcaluma/ember-form-builder/gql/mutations/save-action-button-question.graphql";
 import saveCalculatedFloatQuestionMutation from "@projectcaluma/ember-form-builder/gql/mutations/save-calculated-float-question.graphql";
 import saveChoiceQuestionMutation from "@projectcaluma/ember-form-builder/gql/mutations/save-choice-question.graphql";
 import saveDateQuestionMutation from "@projectcaluma/ember-form-builder/gql/mutations/save-date-question.graphql";
@@ -58,7 +59,12 @@ export const TYPES = {
   StaticQuestion: saveStaticQuestionMutation,
   DateQuestion: saveDateQuestionMutation,
   CalculatedFloatQuestion: saveCalculatedFloatQuestionMutation,
+  ActionButtonQuestion: saveActionButtonQuestionMutation,
 };
+
+const ACTIONS = ["COMPLETE", "SKIP"];
+
+const COLORS = ["PRIMARY", "SECONDARY", "DEFAULT"];
 
 const TYPES_ANSWER = {
   StringAnswer: saveDefaultStringAnswerMutation,
@@ -101,6 +107,10 @@ export default class CfbFormEditorQuestion extends Component {
             subForm: {},
             meta: {},
             dataSource: "",
+            // action button
+            action: ACTIONS[0],
+            color: COLORS[0],
+            validateOnEnter: false,
             __typename: Object.keys(TYPES)[0],
           },
         },
@@ -154,6 +164,20 @@ export default class CfbFormEditorQuestion extends Component {
     return Object.keys(TYPES).map((value) => ({
       value,
       label: this.intl.t(`caluma.form-builder.question.types.${value}`),
+    }));
+  }
+
+  get possibleActions() {
+    return ACTIONS.map((value) => ({
+      value,
+      label: this.intl.t(`caluma.form-builder.question.actions.${value}`),
+    }));
+  }
+
+  get possibleColors() {
+    return COLORS.map((value) => ({
+      value,
+      label: this.intl.t(`caluma.form-builder.question.colors.${value}`),
     }));
   }
 
@@ -289,6 +313,14 @@ export default class CfbFormEditorQuestion extends Component {
   _getCalculatedFloatQuestionInput(changeset) {
     return {
       calcExpression: changeset.get("calcExpression"),
+    };
+  }
+
+  _getActionButtonQuestionInput(changeset) {
+    return {
+      action: changeset.get("action"),
+      color: changeset.get("color"),
+      validateOnEnter: Boolean(changeset.get("validateOnEnter")),
     };
   }
 

--- a/packages/form-builder/addon/gql/fragments/field-question.graphql
+++ b/packages/form-builder/addon/gql/fragments/field-question.graphql
@@ -76,6 +76,11 @@ fragment SimpleQuestion on Question {
   ... on CalculatedFloatQuestion {
     calcExpression
   }
+  ... on ActionButtonQuestion {
+    action
+    color
+    validateOnEnter
+  }
 }
 
 fragment FieldTableQuestion on Question {

--- a/packages/form-builder/addon/gql/mutations/save-action-button-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-action-button-question.graphql
@@ -1,0 +1,15 @@
+# import * from '@projectcaluma/ember-form-builder/gql/fragments/question-info.graphql'
+
+mutation SaveActionButtonQuestion($input: SaveActionButtonQuestionInput!) {
+  saveActionButtonQuestion(input: $input) {
+    question {
+      ...QuestionInfo
+      ... on ActionButtonQuestion {
+        action
+        color
+        validateOnEnter
+      }
+    }
+    clientMutationId
+  }
+}

--- a/packages/form-builder/addon/gql/queries/form-editor-question.graphql
+++ b/packages/form-builder/addon/gql/queries/form-editor-question.graphql
@@ -132,6 +132,11 @@ query FormEditorQuestion($slug: String!) {
         ... on CalculatedFloatQuestion {
           calcExpression
         }
+        ... on ActionButtonQuestion {
+          action
+          color
+          validateOnEnter
+        }
       }
     }
   }

--- a/packages/form-builder/translations/de.yaml
+++ b/packages/form-builder/translations/de.yaml
@@ -107,12 +107,25 @@ caluma:
         DynamicMultipleChoiceQuestion: "Dynamische Mehrfachauswahl"
         DynamicChoiceQuestion: "Dynamische Einzelauswahl"
         CalculatedFloatQuestion: "Berechnung (Gleitkommazahl)"
+        ActionButtonQuestion: "Aktionsbutton"
+
+      confirmText: "Bestätigungstext"
+      action: "Aktion"
+      color: "Farbe"
+      validateOnEnter: "Validierung beim Betreten des Fensters"
+
+      actions:
+        COMPLETE: "Abschliessen"
+        SKIP: "Überspringen"
+
+      colors:
+        PRIMARY: "Primär"
+        SECONDARY: "Sekundär"
+        DEFAULT: "Standard"
 
       widgetOverrides:
         powerselect: "Power Select"
         hidden: "Versteckt"
-        dummy-one: "Dummy One"
-        dummy-two: "Dummy Two"
 
       not-found: "Keine Frage mit dem Slug '{slug}' gefunden"
 

--- a/packages/form-builder/translations/en.yaml
+++ b/packages/form-builder/translations/en.yaml
@@ -107,12 +107,25 @@ caluma:
         DynamicMultipleChoiceQuestion: "Dynamic choices"
         DynamicChoiceQuestion: "Dynamic choice"
         CalculatedFloatQuestion: "Calculation (float)"
+        ActionButtonQuestion: "Action button"
+
+      confirmText: "Confirm text"
+      action: "Action"
+      color: "Color"
+      validateOnEnter: "Validate on entering the viewport"
+
+      actions:
+        COMPLETE: "Complete"
+        SKIP: "Skip"
+
+      colors:
+        PRIMARY: "Primary"
+        SECONDARY: "Secondary"
+        DEFAULT: "Default"
 
       widgetOverrides:
         powerselect: "Power Select"
         hidden: "Hidden"
-        dummy-one: "Dummy One"
-        dummy-two: "Dummy Two"
 
       not-found: "No question with slug '{slug}' found"
 

--- a/packages/form/addon/components/cf-field.hbs
+++ b/packages/form/addon/components/cf-field.hbs
@@ -16,21 +16,23 @@
         {{/let}}
       </div>
 
-      {{#if @field.question.infoText}}
+      {{#if (and @field.question.infoText this.infoTextVisible)}}
         <CfField::info @text={{@field.question.infoText}} />
       {{/if}}
 
-      <div
-        class="cf-field__icon uk-padding-remove-vertical uk-flex uk-flex-middle uk-flex-center"
-      >
-        {{#if @field.save.isRunning}}
-          <UkSpinner class="uk-animation-fade" />
-        {{else if (or @field.save.last.isError @field.isInvalid)}}
-          <UkIcon @icon="warning" class="uk-animation-fade uk-text-danger" />
-        {{else if @field.save.last.isSuccessful}}
-          <UkIcon @icon="check" class="uk-animation-fade uk-text-success" />
-        {{/if}}
-      </div>
+      {{#if this.saveIndicatorVisible}}
+        <div
+          class="cf-field__icon uk-padding-remove-vertical uk-flex uk-flex-middle uk-flex-center"
+        >
+          {{#if @field.save.isRunning}}
+            <UkSpinner class="uk-animation-fade" />
+          {{else if (or @field.save.last.isError @field.isInvalid)}}
+            <UkIcon @icon="warning" class="uk-animation-fade uk-text-danger" />
+          {{else if @field.save.last.isSuccessful}}
+            <UkIcon @icon="check" class="uk-animation-fade uk-text-success" />
+          {{/if}}
+        </div>
+      {{/if}}
     </div>
 
     {{#if @field.errors.length}}

--- a/packages/form/addon/components/cf-field.js
+++ b/packages/form/addon/components/cf-field.js
@@ -29,8 +29,16 @@ export default class CfFieldComponent extends Component {
   get labelVisible() {
     return (
       !this.args.field?.question.meta.hideLabel &&
-      !hasQuestionType(this.args.field?.question, "static")
+      !hasQuestionType(this.args.field?.question, "static", "action-button")
     );
+  }
+
+  get infoTextVisible() {
+    return !hasQuestionType(this.args.field?.question, "action-button");
+  }
+
+  get saveIndicatorVisible() {
+    return !hasQuestionType(this.args.field?.question, "action-button");
   }
 
   /**

--- a/packages/form/addon/components/cf-field/input.hbs
+++ b/packages/form/addon/components/cf-field/input.hbs
@@ -5,6 +5,7 @@
         @field={{@field}}
         @disabled={{@disabled}}
         @onSave={{@onSave}}
+        @context={{@context}}
       />
     </div>
   {{/let}}

--- a/packages/form/addon/components/cf-field/input.js
+++ b/packages/form/addon/components/cf-field/input.js
@@ -1,3 +1,4 @@
+import { dasherize } from "@ember/string";
 import Component from "@glimmer/component";
 
 const mapping = {
@@ -25,7 +26,7 @@ export default class CfFieldInputComponent extends Component {
 
     return (
       typename &&
-      (mapping[typename] || typename.replace(/Question$/, "").toLowerCase())
+      (mapping[typename] || dasherize(typename.replace(/Question$/, "")))
     );
   }
 }

--- a/packages/form/addon/components/cf-field/input/action-button.hbs
+++ b/packages/form/addon/components/cf-field/input/action-button.hbs
@@ -1,0 +1,19 @@
+{{#unless @disabled}}
+  <DocumentValidity
+    @document={{@field.document}}
+    @validateOnEnter={{this.validateOnEnter}}
+    as |isValid validate|
+  >
+    <WorkItemButton
+      @workItemId={{@field.document.workItemUuid}}
+      @mutation={{this.action}}
+      @label={{@field.question.label}}
+      @disabled={{and (not-eq isValid null) (not isValid)}}
+      @color={{this.color}}
+      @beforeMutate={{fn this.beforeMutate validate}}
+      @onSuccess={{this.onSuccess}}
+      @onError={{this.onError}}
+      @type={{this.type}}
+    />
+  </DocumentValidity>
+{{/unless}}

--- a/packages/form/addon/components/cf-field/input/action-button.js
+++ b/packages/form/addon/components/cf-field/input/action-button.js
@@ -1,0 +1,68 @@
+import { assert } from "@ember/debug";
+import { action } from "@ember/object";
+import Component from "@glimmer/component";
+import UIkit from "uikit";
+
+async function confirm(text) {
+  try {
+    await UIkit.modal.confirm(text);
+
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+export default class CfFieldInputActionButtonComponent extends Component {
+  constructor(...args) {
+    super(...args);
+
+    assert(
+      "The document must have a `workItemUuid` for `<CfField::Input::ActionButton />` to work.",
+      this.args.field.document.workItemUuid
+    );
+  }
+
+  get action() {
+    return this.args.field.question.action.toLowerCase();
+  }
+
+  get color() {
+    return this.args.field.question.color.toLowerCase();
+  }
+
+  get type() {
+    return this.args.field.question.action === "COMPLETE" ? "submit" : "button";
+  }
+
+  get validateOnEnter() {
+    return (
+      this.args.field.question.action === "COMPLETE" &&
+      this.args.field.question.validateOnEnter
+    );
+  }
+
+  @action
+  async beforeMutate(validateFn) {
+    if (
+      this.args.field.question.action === "COMPLETE" &&
+      !(await validateFn())
+    ) {
+      return false;
+    }
+
+    const confirmText = this.args.field.question.infoText;
+
+    return !confirmText || confirm(confirmText);
+  }
+
+  @action
+  onSuccess() {
+    return this.args.context?.actionButtonOnSuccess?.();
+  }
+
+  @action
+  onError(error) {
+    return this.args.context?.actionButtonOnError?.(error);
+  }
+}

--- a/packages/form/addon/gql/fragments/field-question.graphql
+++ b/packages/form/addon/gql/fragments/field-question.graphql
@@ -76,6 +76,11 @@ fragment SimpleQuestion on Question {
   ... on CalculatedFloatQuestion {
     calcExpression
   }
+  ... on ActionButtonQuestion {
+    action
+    color
+    validateOnEnter
+  }
 }
 
 fragment FieldTableQuestion on Question {

--- a/packages/form/addon/gql/queries/get-document-answers.graphql
+++ b/packages/form/addon/gql/queries/get-document-answers.graphql
@@ -8,6 +8,9 @@ query ($id: ID!) {
         form {
           slug
         }
+        workItem {
+          id
+        }
         answers {
           edges {
             node {

--- a/packages/form/addon/lib/document.js
+++ b/packages/form/addon/lib/document.js
@@ -83,6 +83,10 @@ export default Base.extend({
     return decodeId(this.raw.id);
   }),
 
+  workItemUuid: computed("raw.workItem.id", function () {
+    return this.raw.workItem ? decodeId(this.raw.workItem.id) : null;
+  }),
+
   /**
    * The root form of this document
    *

--- a/packages/form/addon/lib/field.js
+++ b/packages/form/addon/lib/field.js
@@ -936,4 +936,15 @@ export default Base.extend({
   _validateCalculatedFloatQuestion() {
     return resolve(true);
   },
+
+  /**
+   * Dummy method for the validation of work item button fields
+   *
+   * @method _validateActionButtonQuestion
+   * @return {RSVP.Promise}
+   * @private
+   */
+  _validateActionButtonQuestion() {
+    return resolve(true);
+  },
 });

--- a/packages/form/app/components/cf-field/input/action-button.js
+++ b/packages/form/app/components/cf-field/input/action-button.js
@@ -1,0 +1,1 @@
+export { default } from "@projectcaluma/ember-form/components/cf-field/input/action-button";

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -41,6 +41,7 @@
     "@ember/test-helpers": "2.5.0",
     "@embroider/test-setup": "0.47.1",
     "@projectcaluma/ember-testing": "9.0.0",
+    "@projectcaluma/ember-workflow": "9.0.2",
     "broccoli-asset-rev": "3.0.0",
     "ember-cli": "3.28.3",
     "ember-cli-code-coverage": "1.0.3",

--- a/packages/form/tests/integration/components/cf-field/input/action-button-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/action-button-test.js
@@ -1,0 +1,124 @@
+import { click, settled, render, waitFor } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { setupMirage } from "ember-cli-mirage/test-support";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+import UIkit from "uikit";
+
+module(
+  "Integration | Component | cf-field/input/action-button",
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+
+    hooks.beforeEach(function (assert) {
+      UIkit.container = this.owner.rootElement;
+
+      this.field = {
+        document: {
+          workItemUuid: this.server.create("work-item").id,
+          fields: [
+            {
+              isValid: true,
+              validate: {
+                perform: () => Promise.resolve(assert.step("validate")),
+              },
+            },
+          ],
+        },
+        question: {
+          label: "Submit",
+          infoText: "Really?",
+          action: "COMPLETE",
+          color: "SECONDARY",
+          validateOnEnter: false,
+        },
+      };
+
+      this.success = function () {
+        assert.step("success");
+      };
+      this.error = function () {
+        assert.step("error");
+      };
+    });
+
+    test("renders a button", async function (assert) {
+      await render(hbs`<CfField::Input::ActionButton @field={{this.field}} />`);
+
+      assert.dom("button.uk-button-secondary").exists();
+    });
+
+    test("renders a submit button for complete actions", async function (assert) {
+      await render(hbs`<CfField::Input::ActionButton @field={{this.field}} />`);
+      assert.dom("button.uk-button-secondary").hasAttribute("type", "submit");
+
+      this.field.question.action = "SKIP";
+      await render(hbs`<CfField::Input::ActionButton @field={{this.field}} />`);
+      assert.dom("button.uk-button-secondary").hasAttribute("type", "button");
+    });
+
+    test("validates as configured", async function (assert) {
+      await render(hbs`<CfField::Input::ActionButton @field={{this.field}} />`);
+
+      assert.verifySteps([]);
+      await click("button.uk-button-secondary");
+      assert.verifySteps(["validate"]);
+
+      this.field.question.validateOnEnter = true;
+
+      await render(hbs`<CfField::Input::ActionButton @field={{this.field}} />`);
+
+      // wait for the button to enter the viewport which triggers the validation
+      await settled();
+
+      assert.verifySteps(["validate"]);
+    });
+
+    test("does not validate if action is skip", async function (assert) {
+      this.field.question.action = "skip";
+
+      await render(hbs`<CfField::Input::ActionButton @field={{this.field}} />`);
+
+      assert.verifySteps([]);
+      await click("button.uk-button-secondary");
+      assert.verifySteps([]);
+
+      this.field.question.validateOnEnter = true;
+
+      await render(hbs`<CfField::Input::ActionButton @field={{this.field}} />`);
+
+      // wait for the button to enter the viewport which triggers the validation
+      await settled();
+
+      assert.verifySteps([]);
+    });
+
+    test("triggers the callback functions", async function (assert) {
+      assert.expect(6);
+
+      await render(hbs`
+      <CfField::Input::ActionButton
+        @field={{this.field}}
+        @context={{hash
+          actionButtonOnSuccess=this.success
+          actionButtonOnError=this.error
+        }}
+      />
+    `);
+
+      await click("button.uk-button-secondary");
+      await waitFor(".uk-modal.uk-open");
+      await click(".uk-modal-footer button.uk-button-primary");
+      assert.verifySteps(["validate", "success"]);
+
+      this.server.post("/graphql/", {}, 500);
+
+      await click("button.uk-button-secondary");
+      await waitFor(".uk-modal.uk-open");
+      await click(".uk-modal-footer button.uk-button-primary");
+
+      assert.verifySteps(["validate", "error"]);
+    });
+  }
+);

--- a/packages/testing/addon-mirage-support/factories/question.js
+++ b/packages/testing/addon-mirage-support/factories/question.js
@@ -74,6 +74,16 @@ export default Factory.extend({
           staticContent: (i) => `static-${i + 1}`,
         });
       }
+    } else if (question.type === "ACTION_BUTTON") {
+      if (question.action === undefined) {
+        question.update({ action: "COMPLETE" });
+      }
+      if (question.color === undefined) {
+        question.update({ color: "PRIMARY" });
+      }
+      if (question.validateOnEnter === undefined) {
+        question.update({ validateOnEnter: false });
+      }
     }
   },
 });

--- a/packages/testing/addon-mirage-support/models/document.js
+++ b/packages/testing/addon-mirage-support/models/document.js
@@ -4,4 +4,5 @@ export default Model.extend({
   form: belongsTo(),
   answers: hasMany(),
   case: belongsTo(),
+  workItem: belongsTo(),
 });

--- a/packages/testing/addon/mirage-graphql/mocks/base.js
+++ b/packages/testing/addon/mirage-graphql/mocks/base.js
@@ -119,15 +119,7 @@ export default class {
       this.serializer.deserialize(vars)
     );
 
-    /* istanbul ignore next */
-    if (!record) {
-      // eslint-disable-next-line no-console
-      return Error(
-        `Did not find a record of type "${this.type}" in the store. Did you forget to create one?`
-      );
-    }
-
-    return this.serializer.serialize(record);
+    return record && this.serializer.serialize(record);
   }
 
   @register("Save{type}Payload")

--- a/packages/testing/addon/mirage-graphql/schema.graphql
+++ b/packages/testing/addon/mirage-graphql/schema.graphql
@@ -1,3 +1,67 @@
+type ActionButtonQuestion implements Question & Node {
+  createdAt: DateTime!
+  modifiedAt: DateTime!
+  createdByUser: String
+  createdByGroup: String
+  modifiedByUser: String
+  modifiedByGroup: String
+  slug: String!
+  label: String!
+
+  """
+  Required expression is only evaluated when question is not hidden.
+  """
+  isRequired: QuestionJexl!
+  isHidden: QuestionJexl!
+  isArchived: Boolean!
+  infoText: String
+  meta: GenericScalar!
+  source: Question
+  forms(
+    before: String
+    after: String
+    first: Int
+    last: Int
+    metaValue: [JSONValueFilterType]
+
+    """
+    FormOrdering
+    """
+    orderBy: [FormOrdering]
+    slug: String
+    name: String
+    description: String
+    isPublished: Boolean
+    isArchived: Boolean
+    questions: [String]
+    createdByUser: String
+    createdByGroup: String
+    modifiedByUser: String
+    modifiedByGroup: String
+
+    """
+    Only return entries created after the given DateTime (Exclusive)
+    """
+    createdBefore: DateTime
+
+    """
+    Only return entries created at or before the given DateTime (Inclusive)
+    """
+    createdAfter: DateTime
+    metaHasKey: String
+    search: String
+    slugs: [String]
+  ): FormConnection
+
+  """
+  The ID of the object.
+  """
+  id: ID!
+  action: ButtonAction!
+  color: ButtonColor!
+  validateOnEnter: Boolean!
+}
+
 input AddFormQuestionInput {
   form: ID!
   question: ID!
@@ -175,6 +239,23 @@ enum AscDesc {
   DESC
 }
 
+"""
+An enumeration.
+"""
+enum ButtonAction {
+  COMPLETE
+  SKIP
+}
+
+"""
+An enumeration.
+"""
+enum ButtonColor {
+  PRIMARY
+  SECONDARY
+  DEFAULT
+}
+
 type CalculatedFloatQuestion implements Question & Node {
   createdAt: DateTime!
   modifiedAt: DateTime!
@@ -279,6 +360,11 @@ type Case implements Node {
   The ID of the object.
   """
   id: ID!
+
+  """
+  Stores a path to the given object
+  """
+  path: [String]!
 
   """
   Time when case has either been canceled or completed
@@ -1077,6 +1163,11 @@ type Document implements Node {
   The ID of the object.
   """
   id: ID!
+
+  """
+  Stores a path to the given object
+  """
+  path: [String]!
   form: Form!
 
   """
@@ -1282,7 +1373,7 @@ type DocumentValidityEdge {
   cursor: String!
 }
 
-type DynamicChoiceQuestion implements Question & Node {
+type DynamicChoiceQuestion implements Question & DynamicQuestion & Node {
   createdAt: DateTime!
   modifiedAt: DateTime!
   createdByUser: String
@@ -1350,7 +1441,7 @@ type DynamicChoiceQuestion implements Question & Node {
   id: ID!
 }
 
-type DynamicMultipleChoiceQuestion implements Question & Node {
+type DynamicMultipleChoiceQuestion implements Question & DynamicQuestion & Node {
   createdAt: DateTime!
   modifiedAt: DateTime!
   createdByUser: String
@@ -1433,7 +1524,7 @@ type DynamicOption implements Node {
   slug: String!
   label: String!
   document: Document!
-  question: CalculatedFloatQuestion!
+  question: DynamicQuestion!
 }
 
 type DynamicOptionConnection {
@@ -1468,6 +1559,16 @@ input DynamicOptionFilterSetType {
   question: ID
   document: ID
   invert: Boolean
+}
+
+interface DynamicQuestion {
+  options(
+    before: String
+    after: String
+    first: Int
+    last: Int
+  ): DataSourceDataConnection
+  dataSource: String!
 }
 
 type File implements Node {
@@ -2336,6 +2437,9 @@ type Mutation {
   saveCalculatedFloatQuestion(
     input: SaveCalculatedFloatQuestionInput!
   ): SaveCalculatedFloatQuestionPayload
+  saveActionButtonQuestion(
+    input: SaveActionButtonQuestionInput!
+  ): SaveActionButtonQuestionPayload
   copyDocument(input: CopyDocumentInput!): CopyDocumentPayload
   saveDocument(input: SaveDocumentInput!): SaveDocumentPayload
   saveDocumentStringAnswer(
@@ -2872,11 +2976,12 @@ type Query {
     first: Int
     last: Int
   ): DocumentValidityConnection
-
-  """
-  The ID of the object
-  """
-  node(id: ID!): Node
+  node(
+    """
+    The ID of the object
+    """
+    id: ID!
+  ): Node
   _debug: DjangoDebug
 }
 
@@ -3177,6 +3282,24 @@ input ResumeWorkItemInput {
 
 type ResumeWorkItemPayload {
   workItem: WorkItem
+  clientMutationId: String
+}
+
+input SaveActionButtonQuestionInput {
+  label: String!
+  slug: String!
+  infoText: String
+  isHidden: QuestionJexl
+  meta: JSONString
+  isArchived: Boolean
+  action: ButtonAction!
+  color: ButtonColor!
+  validateOnEnter: Boolean!
+  clientMutationId: String
+}
+
+type SaveActionButtonQuestionPayload {
+  question: Question
   clientMutationId: String
 }
 
@@ -3955,6 +4078,7 @@ enum SortableDocumentAttributes {
   CREATED_BY_GROUP
   MODIFIED_BY_USER
   MODIFIED_BY_GROUP
+  PATH
   FORM
   SOURCE
 }
@@ -4866,6 +4990,11 @@ type WorkItem implements Node {
   The ID of the object.
   """
   id: ID!
+
+  """
+  Stores a path to the given object
+  """
+  path: [String]!
 
   """
   Will be set from Task, if not provided.


### PR DESCRIPTION
Add a new question type for action buttons that render a button for completing or skipping the work item related to the current document.

Backend implementation: https://github.com/projectcaluma/caluma/pull/1607