### PR TITLE
feat(form): refactor table to glimmer and add invalid indicator

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -5,9 +5,5 @@ module.exports = {
   plugins: ["ember-template-lint-plugin-prettier"],
   rules: {
     "no-bare-strings": true,
-    // needs to be resolved before ember v4
-    "no-implicit-this": "warn",
-    "no-action": "warn",
-    "no-curly-component-invocation": "warn",
   },
 };

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question/default/table-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question/default/table-test.js
@@ -9,12 +9,15 @@ module(
     setupRenderingTest(hooks);
 
     test("it renders", async function (assert) {
-      // Set any properties with this.set('myProperty', 'value');
-      // Handle any actions with this.set('myAction', function(val) { ... });
+      this.field = {
+        question: { meta: {}, rowForm: { questions: { edges: [] } } },
+      };
 
-      await render(hbs`<CfbFormEditor::Question::Default::Table />`);
+      await render(
+        hbs`<CfbFormEditor::Question::Default::Table @field={{this.field}} />`
+      );
 
-      assert.dom(this.element).hasText("");
+      assert.dom(this.element).exists();
     });
   }
 );

--- a/packages/form/addon/components/cf-field/input/table.hbs
+++ b/packages/form/addon/components/cf-field/input/table.hbs
@@ -1,125 +1,124 @@
-{{#with field.question.rowForm.questions.edges as |questions|}}
-  <table class="uk-table">
-    <thead>
+<table class="uk-table uk-table-divider">
+  <thead>
+    <tr>
+      {{#each this.columns as |column|}}
+        <th>{{column.label}}</th>
+      {{/each}}
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {{#each @field.answer.value as |document|}}
       <tr>
-        {{#each columnHeaders as |edge|}}
-          <th>{{edge.node.label}}</th>
+        {{#each this.columns as |column|}}
+          <td>
+            <CfFieldValue
+              @field={{find-by "question.slug" column.slug document.fields}}
+            />
+          </td>
         {{/each}}
-        <th></th>
-      </tr>
-    </thead>
-    <tbody>
-      {{#each field.answer.value as |document|}}
-        <tr>
-          {{#if field.question.meta.columnsToDisplay.length}}
-            {{#each document.fields as |answerField|}}
-              {{#if
-                (includes
-                  answerField.answer.question.slug
-                  field.question.meta.columnsToDisplay
-                )
-              }}
-                <td>{{cf-field-value field=answerField}}</td>
-              {{/if}}
-            {{/each}}
-          {{else}}
-            {{#each (take 4 document.fields) as |field|}}
-              <td>{{cf-field-value field=field}}</td>
-            {{/each}}
-          {{/if}}
-          <td class="uk-text-right">
+        <td class="uk-table-middle">
+          <div class="uk-flex uk-flex-middle uk-flex-right">
+            {{#if (includes false (map-by "isValid" document.fields))}}
+              <UkIcon
+                @icon="warning"
+                class="uk-animation-fade uk-text-danger"
+              />
+            {{/if}}
             <button
               data-test-edit-row
               type="button"
-              class="uk-icon-button"
-              uk-icon="pencil"
+              class="uk-button-link uk-flex-inline uk-margin-small-left"
               title={{t "caluma.form.edit"}}
-              {{action "editRow" document}}
+              {{on "click" (fn this.edit document)}}
             >
+              <UkIcon @icon="pencil" />
               <span class="uk-hidden">{{t "caluma.form.edit"}}</span>
             </button>
-            {{#unless disabled}}
+            {{#unless @disabled}}
               <button
                 data-test-delete-row
                 type="button"
-                class="uk-icon-button"
-                uk-icon="trash"
+                class="uk-button-link uk-flex-inline uk-margin-small-left"
                 title={{t "caluma.form.delete"}}
-                {{action "deleteRow" document}}
+                {{on "click" (fn (perform this.delete) document)}}
               >
+                <UkIcon @icon="trash" />
                 <span class="uk-hidden">{{t "caluma.form.delete"}}</span>
               </button>
             {{/unless}}
-          </td>
-        </tr>
-      {{/each}}
-    </tbody>
+          </div>
+        </td>
+      </tr>
+    {{/each}}
+  </tbody>
+  {{#unless @disabled}}
     <tfoot>
-      {{#unless disabled}}
-        <tr>
-          <td colspan={{add (count-keys questions) 1}} class="uk-text-center">
-            <button
-              type="button"
-              class="uk-button uk-button-default uk-button-small"
-              title={{t "caluma.form.addRow"}}
-              {{on "click" (perform addRow)}}
-            >
-              <UkIcon @icon="plus" />
-              <span class="uk-hidden">{{t "caluma.form.addRow"}}</span>
-            </button>
-          </td>
-        </tr>
-      {{/unless}}
+      <tr>
+        <td colspan={{add this.columns.length 1}} class="uk-text-center">
+          <UkButton
+            @size="small"
+            @color="default"
+            @on-click={{perform this.add}}
+            data-test-add-row
+          >
+            <UkIcon @icon="plus" />
+            <span class="uk-hidden">{{t "caluma.form.addRow"}}</span>
+          </UkButton>
+        </td>
+      </tr>
     </tfoot>
-  </table>
+  {{/unless}}
+</table>
 
+{{#if this.documentToEdit}}
   <UkModal
-    @visible={{and showAddModal documentToEdit}}
-    @on-hide={{action "closeModal" "showAddModal"}}
-    @btnClose={{true}}
+    @visible={{this.showAddModal}}
+    @on-hide={{perform this.closeModal}}
     @bgClose={{false}}
     as |modal|
   >
     <modal.body>
-      {{#if documentToEdit}}
-        {{cf-form-wrapper
-          document=documentToEdit
-          fieldset=(object-at 0 documentToEdit.fieldsets)
-          disabled=disabled
-        }}
-      {{/if}}
-    </modal.body>
-
-    {{#unless disabled}}
-      <modal.footer @class="uk-text-right">
-        {{uk-button
-          label=(t "caluma.form.save")
-          disabled=save.isRunning
-          loading=save.isRunning
-          on-click=(perform save)
-        }}
-      </modal.footer>
-    {{/unless}}
-  </UkModal>
-
-  <UkModal
-    @visible={{and showDeleteModal documentToDelete}}
-    @on-hide={{action "closeModal" "showDeleteModal"}}
-    @btnClose={{true}}
-    @bgClose={{false}}
-    as |modal|
-  >
-    <modal.body>
-      {{t "caluma.form.deleteRow"}}
+      <CfFormWrapper
+        @document={{this.documentToEdit}}
+        @fieldset={{object-at 0 this.documentToEdit.fieldsets}}
+        @disabled={{@disabled}}
+      />
     </modal.body>
 
     <modal.footer @class="uk-text-right">
-      {{uk-button
-        label=(t "caluma.form.delete")
-        disabled=deleteRow.isRunning
-        loading=deleteRow.isRunning
-        on-click=(perform deleteRow documentToDelete)
-      }}
+      {{#if @disabled}}
+        <UkButton
+          @label={{t "caluma.form.close"}}
+          @color="primary"
+          @on-click={{perform this.close}}
+          @disabled={{this.close.isRunning}}
+          @loading={{this.close.isRunning}}
+          data-test-close
+        />
+      {{else}}
+        <UkButton
+          @label={{t "caluma.form.cancel"}}
+          @on-click={{perform this.close}}
+          @disabled={{this.close.isRunning}}
+          @loading={{this.close.isRunning}}
+          data-test-cancel
+        />
+        <DocumentValidity
+          @document={{this.documentToEdit}}
+          as |isValid validate|
+        >
+          <UkButton
+            @label={{t "caluma.form.save"}}
+            @color="primary"
+            @type="submit"
+            @disabled={{or this.save.isRunning (not isValid)}}
+            @loading={{this.save.isRunning}}
+            @on-click={{fn (perform this.save) validate}}
+            data-test-save
+          />
+        </DocumentValidity>
+      {{/if}}
     </modal.footer>
   </UkModal>
-{{/with}}
+{{/if}}

--- a/packages/form/tests/integration/components/cf-field/input/table-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/table-test.js
@@ -1,26 +1,30 @@
-import { render } from "@ember/test-helpers";
+import { waitFor, settled, click, fillIn, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
+import { setupMirage } from "ember-cli-mirage/test-support";
 import { setupIntl } from "ember-intl/test-support";
 import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
+import UIkit from "uikit";
+
+import { parseDocument } from "@projectcaluma/ember-form/lib/parsers";
 
 module("Integration | Component | cf-field/input/table", function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  test("it renders", async function (assert) {
-    this.set("field", {
+  hooks.beforeEach(function () {
+    this.field = {
       pk: "table-test",
       answer: {
         value: [
           {
             fields: [
               {
-                question: { __typename: "TextQuestion" },
+                question: { __typename: "TextQuestion", slug: "first-name" },
                 answer: { value: "Max" },
               },
               {
-                question: { __typename: "TextQuestion" },
+                question: { __typename: "TextQuestion", slug: "last-name" },
                 answer: { value: "Muster" },
               },
             ],
@@ -28,11 +32,11 @@ module("Integration | Component | cf-field/input/table", function (hooks) {
           {
             fields: [
               {
-                question: { __typename: "TextQuestion" },
+                question: { __typename: "TextQuestion", slug: "first-name" },
                 answer: { value: "Bea" },
               },
               {
-                question: { __typename: "TextQuestion" },
+                question: { __typename: "TextQuestion", slug: "last-name" },
                 answer: { value: "Beispiel" },
               },
             ],
@@ -40,22 +44,291 @@ module("Integration | Component | cf-field/input/table", function (hooks) {
         ],
       },
       question: {
+        meta: {},
         rowForm: {
           questions: {
             edges: [
-              { node: { label: "First name" } },
-              { node: { label: "Last name" } },
+              { node: { slug: "first-name", label: "First name" } },
+              { node: { slug: "last-name", label: "Last name" } },
             ],
           },
         },
       },
-    });
+    };
+  });
 
-    await render(hbs`{{cf-field/input/table field=field}}`);
+  test("it renders as table", async function (assert) {
+    await render(hbs`<CfField::Input::Table @field={{this.field}} />`);
+
     assert.dom("th:nth-of-type(1)").hasText("First name");
     assert.dom("th:nth-of-type(2)").hasText("Last name");
 
-    assert.dom("tbody > tr > td:nth-of-type(1)").hasText("Max");
-    assert.dom("tbody > tr > td:nth-of-type(2)").hasText("Muster");
+    assert.dom("tbody > tr:first-of-type > td:nth-of-type(1)").hasText("Max");
+    assert
+      .dom("tbody > tr:first-of-type > td:nth-of-type(2)")
+      .hasText("Muster");
+
+    assert.dom("tbody > tr").exists({ count: 2 });
+  });
+
+  test("it displays only configured columns", async function (assert) {
+    this.field.question.meta.columnsToDisplay = ["last-name"];
+
+    await render(hbs`<CfField::Input::Table @field={{this.field}} />`);
+
+    assert.dom("th:nth-of-type(1)").hasText("Last name");
+    assert
+      .dom("tbody > tr:first-of-type > td:nth-of-type(1)")
+      .hasText("Muster");
+
+    assert.dom("th").exists({ count: 2 });
+    assert.dom("tbody > tr:first-of-type > td").exists({ count: 2 });
+  });
+
+  test("it displays an error indicator for invalid rows", async function (assert) {
+    this.field.answer.value[0].fields[0].isValid = false;
+
+    await render(hbs`<CfField::Input::Table @field={{this.field}} />`);
+
+    assert
+      .dom(
+        "tbody > tr:nth-of-type(1) > td:last-of-type [icon=warning].uk-text-danger"
+      )
+      .exists();
+    assert
+      .dom(
+        "tbody > tr:nth-of-type(2) > td:last-of-type [icon=warning].uk-text-danger"
+      )
+      .doesNotExist();
+  });
+
+  test("it renders disabled", async function (assert) {
+    await render(
+      hbs`<CfField::Input::Table @field={{this.field}} @disabled={{true}} />`
+    );
+
+    assert.dom("[data-test-add-row]").doesNotExist();
+    assert.dom("[data-test-edit-row]").exists();
+    assert.dom("[data-test-delete-row]").doesNotExist();
+  });
+
+  module("actions", function (hooks) {
+    setupMirage(hooks);
+
+    hooks.beforeEach(function () {
+      this.rootForm = this.server.create("form");
+      this.tableForm = this.server.create("form");
+
+      this.tableQuestion = this.server.create("question", {
+        slug: "table",
+        type: "TABLE",
+        rowFormId: this.tableForm.id,
+        formIds: [this.rootForm.id],
+      });
+      this.rowQuestion = this.server.create("question", {
+        slug: "first-name",
+        type: "TEXT",
+        minLength: 1,
+        maxLength: 10,
+        formIds: [this.tableForm.id],
+      });
+
+      (this.rowAnswer = this.server.create("answer", {
+        value: "Foo",
+        questionId: this.rowQuestion.id,
+      }).id),
+        (this.rowDocument = this.server.create("document", {
+          formId: this.tableForm.id,
+          answerIds: [],
+        }));
+      this.document = this.server.create("document", {
+        formId: this.rootForm.id,
+      });
+
+      this.tableAnswer = this.server.create("answer", {
+        documentId: this.document.id,
+        questionId: this.tableQuestion.id,
+      });
+
+      const data = {
+        id: btoa(`Document:${this.document.id}`),
+        answers: {
+          edges: [
+            {
+              node: {
+                id: btoa(`Answer:${this.tableAnswer.id}`),
+                question: {
+                  slug: this.tableQuestion.slug,
+                },
+                tableValue: [
+                  {
+                    id: btoa(`Document:${this.rowDocument.id}`),
+                    form: {
+                      slug: this.tableForm.slug,
+                      meta: {},
+                      questions: {
+                        edges: [
+                          {
+                            node: {
+                              slug: this.rowQuestion.slug,
+                              label: this.rowQuestion.label,
+                              isRequired: "true",
+                              isHidden: "false",
+                              meta: {},
+                              __typename: "TextQuestion",
+                            },
+                          },
+                        ],
+                      },
+                      __typename: "Form",
+                    },
+                    answers: {
+                      edges: [
+                        {
+                          node: {
+                            id: btoa(`StringAnswer:${this.rowAnswer.id}`),
+                            question: {
+                              slug: this.rowQuestion.slug,
+                            },
+                            stringValue: this.rowAnswer.value,
+                            __typename: "StringAnswer",
+                          },
+                        },
+                      ],
+                    },
+                    __typename: "Document",
+                  },
+                ],
+                __typename: "TableAnswer",
+              },
+            },
+          ],
+        },
+        form: {
+          slug: "form",
+          meta: {
+            "is-top-form": true,
+            level: 0,
+          },
+          questions: {
+            edges: [
+              {
+                node: {
+                  slug: this.tableQuestion.slug,
+                  label: this.tableQuestion.label,
+                  isRequired: "true",
+                  isHidden: "false",
+                  meta: {},
+                  rowForm: {
+                    slug: this.tableForm.slug,
+                    questions: {
+                      edges: [
+                        {
+                          node: {
+                            slug: this.rowQuestion.slug,
+                            label: this.rowQuestion.label,
+                            isRequired: "true",
+                            isHidden: "false",
+                            meta: {},
+                            __typename: "TextQuestion",
+                          },
+                        },
+                      ],
+                    },
+                    __typename: "Form",
+                  },
+                  __typename: "TableQuestion",
+                },
+              },
+            ],
+          },
+          __typename: "Form",
+        },
+        __typename: "Document",
+      };
+
+      this.calumaDocument = this.owner
+        .factoryFor("caluma-model:document")
+        .create({ raw: parseDocument(data) });
+
+      this.field = this.calumaDocument.fields[0];
+
+      UIkit.container = this.owner.rootElement;
+    });
+
+    test("it can add a row", async function (assert) {
+      assert.expect(5);
+
+      this.save = (value) => {
+        assert.strictEqual(value.length, 2);
+        assert.step("save");
+      };
+
+      await render(hbs`
+        <CfField::Input::Table
+          @field={{this.field}}
+          @onSave={{this.save}}
+        />
+      `);
+
+      await click("[data-test-add-row]");
+
+      const input = `input[name="Document:4:Question:${this.rowQuestion.slug}"]`;
+      await waitFor(input);
+
+      await click("[data-test-save]");
+      assert.dom("[data-test-save]").isDisabled();
+      await fillIn(input, "Test");
+      await settled();
+      assert.dom("[data-test-save]").isEnabled();
+
+      await click("[data-test-save]");
+
+      assert.verifySteps(["save"]);
+    });
+
+    test("it can edit a row", async function (assert) {
+      assert.expect(1);
+
+      await render(hbs`
+        <CfField::Input::Table
+          @field={{this.field}}
+        />
+      `);
+
+      await click("[data-test-edit-row]");
+
+      const input = `input[name="Document:1:Question:${this.rowQuestion.slug}"]`;
+      await waitFor(input);
+
+      await fillIn(input, "Test");
+      await settled();
+      await click("[data-test-save]");
+
+      assert
+        .dom("tbody > tr:first-of-type > td:nth-of-type(1)")
+        .hasText("Test");
+    });
+
+    test("it can delete a row", async function (assert) {
+      assert.expect(3);
+
+      this.save = (value) => {
+        assert.strictEqual(value.length, 0);
+        assert.step("save");
+      };
+
+      await render(hbs`
+        <CfField::Input::Table
+          @field={{this.field}}
+          @onSave={{this.save}}
+        />
+      `);
+
+      await click("[data-test-delete-row]");
+      await click("button[autofocus]");
+
+      assert.verifySteps(["save"]);
+    });
   });
 });

--- a/packages/form/translations/de.yaml
+++ b/packages/form/translations/de.yaml
@@ -17,6 +17,8 @@ caluma:
     save: "Speichern"
     delete: "Löschen"
     edit: "Bearbeiten"
+    cancel: "Abbrechen"
+    close: "Schliessen"
     selectFile: "Klicken um Datei hochzuladen"
     changeFile: "Klicken um andere Datei hochzuladen"
     deleteRow: "Möchten Sie diese Zeile wirklich löschen?"

--- a/packages/form/translations/en.yaml
+++ b/packages/form/translations/en.yaml
@@ -17,6 +17,8 @@ caluma:
     save: "Save"
     delete: "Delete"
     edit: "Edit"
+    cancel: "Cancel"
+    close: "Close"
     selectFile: "Click to upload a file"
     changeFile: "Click to upload a different file"
     deleteRow: "Do you really want to delete this row?"

--- a/packages/form/translations/fr.yaml
+++ b/packages/form/translations/fr.yaml
@@ -18,6 +18,8 @@ caluma:
     save: "sauvegarder"
     delete: "supprimer"
     edit: "modifier"
+    cancel: "annuler"
+    close: "fermer"
     selectFile: "cliquez pour télécharger le ficher"
     changeFile: "cliquez pour télécharger un autre fichier"
     deleteRow: "Voulez-vous supprimer cette ligne?"


### PR DESCRIPTION
- Refactor to glimmer and simplify table input component
- Add indicator to invalid rows
- Add close button in edit mode
- Add cancel button in add mode
- Cleanup orphaned rows when cancelling in add mode
- Only enable save button if document is valid
- Add missing tests for table inputs, resolves #455