### PR TITLE
fix(linting): separate husky commit-msg hook

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -4,5 +4,5 @@
 # skip in CI
 [ -n "$CI" ] && exit 0
 
-# lint staged files
-yarn lint-staged
+# lint commit message
+yarn commitlint --edit "$1"


### PR DESCRIPTION
The previously used `pre-commit` hook has no access to the current commit message. `yarn commitlint --edit $1` will fallback to `.git/COMMIT_EDITMSG` in case the argument passed (here `$1`) was undefined. BUT `.git/COMMIT_EDITMSG` references the commit message of the last (successful) commit, not the current one.

`$1` is always undefined for `pre-commit` hooks in husky.
`$1` contains the path to the file of the current commit message when used in `commit-msg` hook.

> Today I learned something. 🤓👍