### PR TITLE
chore(ci): allow ember-release scenario to fail

### DIFF
--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -29,6 +29,7 @@ module.exports = async function () {
       },
       {
         name: "ember-release",
+        allowedToFail: true,
         npm: {
           devDependencies: {
             "ember-source": await getChannelURL("release"),

--- a/packages/form/addon/components/document-validity.js
+++ b/packages/form/addon/components/document-validity.js
@@ -38,9 +38,9 @@ export default class DocumentValidity extends Component {
   @restartableTask
   *_validate() {
     yield Promise.all(
-      this.args.document.fields.map((field) =>
-        field.validate.linked().perform()
-      )
+      this.args.document.fields.map((field) => {
+        return field.validate.linked().perform();
+      })
     );
 
     if (this.isValid) {


### PR DESCRIPTION
Ember v4 is now officially released. However, we're not quite ready for this so we allow the `ember-release` to fail for now.