### PR TITLE
fix(form): delete existing file input without error

### DIFF
--- a/packages/form/addon/components/cf-field.hbs
+++ b/packages/form/addon/components/cf-field.hbs
@@ -12,6 +12,7 @@
             @disabled={{@disabled}}
             @context={{@context}}
             @onSave={{perform this.save}}
+            @onDelete={{perform this.delete}}
           />
         {{/let}}
       </div>

--- a/packages/form/addon/components/cf-field.js
+++ b/packages/form/addon/components/cf-field.js
@@ -68,4 +68,17 @@ export default class CfFieldComponent extends Component {
       // that's ok
     }
   }
+
+  /**
+   * Delete the value of the input. This will call validation but no endpoints for
+   * deleting any resources. This has to be done by the calling function.
+   *
+   * @method delete
+   */
+  @restartableTask
+  *delete() {
+    set(this.args.field.answer, "value", null);
+
+    yield this.args.field.validate.perform();
+  }
 }

--- a/packages/form/addon/components/cf-field/input.hbs
+++ b/packages/form/addon/components/cf-field/input.hbs
@@ -5,6 +5,7 @@
         @field={{@field}}
         @disabled={{@disabled}}
         @onSave={{@onSave}}
+        @onDelete={{@onDelete}}
         @context={{@context}}
       />
     </div>

--- a/packages/form/addon/components/cf-field/input/file.js
+++ b/packages/form/addon/components/cf-field/input/file.js
@@ -82,7 +82,7 @@ export default class CfFieldInputFileComponent extends Component {
         },
       });
 
-      await this.args.onSave(null);
+      await this.args.onDelete();
     } catch (error) {
       set(this.args.field, "_errors", [{ type: "deleteFailed" }]);
     }


### PR DESCRIPTION
Uploading and deleting a file in a file input yielded an error. What happend was a deletion + another query which tried to set the current *value* to `null`.

We circumvent this bug now by a separate `delete` method on the `input::file` component, which does not perform another *save* action with `null` as *value* argument. The actual deletion of the file is triggered beforehand via `removeAnswerMutation`.

Follow up/regression from #1625