### PR TITLE
fix: replace fragment symlink with a copy

### DIFF
--- a/packages/form-builder/addon/gql/fragments/field.graphql
+++ b/packages/form-builder/addon/gql/fragments/field.graphql
@@ -1,1 +1,225 @@
-../../../../form/addon/gql/fragments/field.graphql
+# We can not symlink this file so an exact copy exists in another package:
+# packages/form/addon/gql/fragments/field.graphql
+#
+# When changing this file the other must also receive the same changes.
+
+fragment SimpleQuestion on Question {
+  slug
+  label
+  isRequired
+  isHidden
+  meta
+  infoText
+  ... on TextQuestion {
+    textMinLength: minLength
+    textMaxLength: maxLength
+    textDefaultAnswer: defaultAnswer {
+      value
+    }
+    placeholder
+  }
+  ... on TextareaQuestion {
+    textareaMinLength: minLength
+    textareaMaxLength: maxLength
+    textareaDefaultAnswer: defaultAnswer {
+      value
+    }
+    placeholder
+  }
+  ... on IntegerQuestion {
+    integerMinValue: minValue
+    integerMaxValue: maxValue
+    integerDefaultAnswer: defaultAnswer {
+      value
+    }
+    placeholder
+  }
+  ... on FloatQuestion {
+    floatMinValue: minValue
+    floatMaxValue: maxValue
+    floatDefaultAnswer: defaultAnswer {
+      value
+    }
+    placeholder
+  }
+  ... on ChoiceQuestion {
+    choiceOptions: options {
+      edges {
+        node {
+          slug
+          label
+          isArchived
+        }
+      }
+    }
+    choiceDefaultAnswer: defaultAnswer {
+      value
+    }
+  }
+  ... on MultipleChoiceQuestion {
+    multipleChoiceOptions: options {
+      edges {
+        node {
+          slug
+          label
+          isArchived
+        }
+      }
+    }
+    multipleChoiceDefaultAnswer: defaultAnswer {
+      value
+    }
+  }
+  ... on DateQuestion {
+    dateDefaultAnswer: defaultAnswer {
+      value
+    }
+  }
+  ... on StaticQuestion {
+    staticContent
+  }
+  ... on CalculatedFloatQuestion {
+    calcExpression
+  }
+  ... on ActionButtonQuestion {
+    action
+    color
+    validateOnEnter
+  }
+}
+
+fragment FieldTableQuestion on Question {
+  ... on TableQuestion {
+    rowForm {
+      slug
+      questions {
+        edges {
+          node {
+            ...SimpleQuestion
+          }
+        }
+      }
+    }
+    tableDefaultAnswer: defaultAnswer {
+      value {
+        id
+        answers {
+          edges {
+            node {
+              id
+              question {
+                slug
+              }
+              ... on StringAnswer {
+                stringValue: value
+              }
+              ... on IntegerAnswer {
+                integerValue: value
+              }
+              ... on FloatAnswer {
+                floatValue: value
+              }
+              ... on ListAnswer {
+                listValue: value
+              }
+              ... on DateAnswer {
+                dateValue: value
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+fragment FieldQuestion on Question {
+  ...SimpleQuestion
+  ...FieldTableQuestion
+  ... on FormQuestion {
+    subForm {
+      slug
+      name
+      questions {
+        edges {
+          node {
+            # This part here limits our query to 2 level deep nested forms. This
+            # has to be solved in another way!
+            ...SimpleQuestion
+            ...FieldTableQuestion
+            ... on FormQuestion {
+              subForm {
+                slug
+                name
+                questions {
+                  edges {
+                    node {
+                      ...SimpleQuestion
+                      ...FieldTableQuestion
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+fragment SimpleAnswer on Answer {
+  id
+  question {
+    slug
+  }
+  ... on StringAnswer {
+    stringValue: value
+  }
+  ... on IntegerAnswer {
+    integerValue: value
+  }
+  ... on FloatAnswer {
+    floatValue: value
+  }
+  ... on ListAnswer {
+    listValue: value
+  }
+  ... on FileAnswer {
+    fileValue: value {
+      uploadUrl
+      downloadUrl
+      metadata
+      name
+    }
+  }
+  ... on DateAnswer {
+    dateValue: value
+  }
+}
+
+fragment FieldAnswer on Answer {
+  ...SimpleAnswer
+  ... on TableAnswer {
+    tableValue: value {
+      id
+      form {
+        slug
+        questions {
+          edges {
+            node {
+              ...FieldQuestion
+            }
+          }
+        }
+      }
+      answers {
+        edges {
+          node {
+            ...SimpleAnswer
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/form/addon/gql/fragments/field.graphql
+++ b/packages/form/addon/gql/fragments/field.graphql
@@ -1,3 +1,8 @@
+# We can not symlink this file so an exact copy exists in another package:
+# packages/form-builder/addon/gql/fragments/field.graphql
+#
+# When changing this file the other must also receive the same changes.
+
 fragment SimpleQuestion on Question {
   slug
   label


### PR DESCRIPTION
This change is needed as the symlink doesnt show up in the package,
which breaks queries in the form-builder package.