### PR TITLE
fix: passing an empty object in a filter array does not cause a crash

### DIFF
--- a/packages/testing/addon/mirage-graphql/filters/base.js
+++ b/packages/testing/addon/mirage-graphql/filters/base.js
@@ -10,16 +10,18 @@ export default class {
   _getFilterFns(rawFilters) {
     const filters = Array.isArray(rawFilters)
       ? // new format
-        rawFilters.map((filter) => {
-          const entries = Object.entries(filter);
-          const key = entries[0][0];
-          const value = entries[0][1];
-          const options = entries
-            .slice(1)
-            .reduce((opts, [k, v]) => ({ ...opts, [k]: v }), {});
+        rawFilters
+          .filter((filter) => Object.keys(filter).length !== 0) // filter out empty filters
+          .map((filter) => {
+            const entries = Object.entries(filter);
+            const key = entries[0][0];
+            const value = entries[0][1];
+            const options = entries
+              .slice(1)
+              .reduce((opts, [k, v]) => ({ ...opts, [k]: v }), {});
 
-          return { key, value, options };
-        })
+            return { key, value, options };
+          })
       : // old format
         Object.entries(rawFilters).map(([key, value]) => ({
           key,

--- a/packages/testing/tests/unit/mirage/filters/base-test.js
+++ b/packages/testing/tests/unit/mirage/filters/base-test.js
@@ -42,4 +42,15 @@ module("Unit | Mirage GraphQL Filter | base", function (hooks) {
       this.collection
     );
   });
+
+  test("does not fail if an empty filter is passed in", async function (assert) {
+    assert.expect(1);
+
+    assert.deepEqual(
+      this.filter.filter(this.collection, {
+        filter: [{}],
+      }),
+      this.collection
+    );
+  });
 });


### PR DESCRIPTION
## Description
Given this GraphQL query:
```graphql
query Forms {
  allForms(filter: [{}]) {
    edges {
      node {
        id
      }
    }
  }
}
```

would cause the mirage filter to fail:
`Cannot read properties of undefined (reading '0')`

## This MR
This MR includes the fix as well as 1 extra test.

Please note: I only added 1 line. The rest is just indentation change.