### PR TITLE
fix(core): override apollo service instead of serving a mixin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,11 +2,6 @@
 
 module.exports = {
   extends: "@adfinis-sygroup/eslint-config/ember-addon",
-  rules: {
-    // TODO: https://github.com/projectcaluma/ember-caluma/issues/529
-    "ember/no-mixins": "warn",
-    "ember/no-new-mixins": "warn",
-  },
   settings: {
     "import/internal-regex": "^(@projectcaluma|ember-caluma)/",
   },

--- a/packages/-ember-caluma/app/services/apollo.js
+++ b/packages/-ember-caluma/app/services/apollo.js
@@ -1,8 +1,0 @@
-import ApolloService from "ember-apollo-client/services/apollo";
-
-import CalumaApolloServiceMixin from "@projectcaluma/ember-core/mixins/caluma-apollo-service-mixin";
-
-export default class CustomApolloService extends ApolloService.extend(
-  CalumaApolloServiceMixin,
-  {}
-) {}

--- a/packages/-ember-caluma/app/snippets/apollo.js
+++ b/packages/-ember-caluma/app/snippets/apollo.js
@@ -1,8 +1,0 @@
-import ApolloService from "ember-apollo-client/services/apollo";
-
-import CalumaApolloServiceMixin from "@projectcaluma/ember-core/mixins/caluma-apollo-service-mixin";
-
-export default class CustomApolloService extends ApolloService.extend(
-  CalumaApolloServiceMixin,
-  {}
-) {}

--- a/packages/-ember-caluma/app/templates/docs/index.md
+++ b/packages/-ember-caluma/app/templates/docs/index.md
@@ -16,13 +16,6 @@ ember install @projectcaluma/ember-form
 
 # Usage
 
-To use any `@projectcaluma` package you need to customize the apollo service in
-order to support [fragments on unions and interfaces](https://www.apollographql.com/docs/react/advanced/fragments.html#fragment-matcher).
-Create a new service `app/services/apollo.js` and extend the apollo service with
-the provided mixin:
-
-{{docs-snippet name='apollo.js'}}
-
 To make `@projectcaluma/ember-form-builder` work a few steps must be followed.
 The form builder is a [routable engine](http://ember-engines.com) which must be
 mounted in `app/router.js`:

--- a/packages/core/addon/services/apollo.js
+++ b/packages/core/addon/services/apollo.js
@@ -1,12 +1,12 @@
 import { InMemoryCache, defaultDataIdFromObject } from "@apollo/client/cache";
 import { setContext } from "@apollo/client/link/context";
-import Mixin from "@ember/object/mixin";
 import { inject as service } from "@ember/service";
+import ApolloService from "ember-apollo-client/services/apollo";
 
 import possibleTypes from "@projectcaluma/ember-core/-private/possible-types";
 
-export default Mixin.create({
-  intl: service(),
+export default class CalumaApolloService extends ApolloService {
+  @service intl;
 
   cache() {
     return new InMemoryCache({
@@ -17,10 +17,10 @@ export default Mixin.create({
           _id: obj.slug || obj._id,
         }),
     });
-  },
+  }
 
-  link(...args) {
-    const httpLink = this._super(...args);
+  link() {
+    const httpLink = super.link();
 
     const localeLink = setContext((request, context) => ({
       ...context,
@@ -32,5 +32,5 @@ export default Mixin.create({
     }));
 
     return localeLink.concat(httpLink);
-  },
-});
+  }
+}

--- a/packages/core/app/services/apollo.js
+++ b/packages/core/app/services/apollo.js
@@ -1,0 +1,1 @@
+export { default } from "@projectcaluma/ember-core/services/apollo";

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -72,6 +72,7 @@
     "edition": "octane"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "after": "ember-apollo-client"
   }
 }

--- a/packages/core/tests/unit/services/apollo-test.js
+++ b/packages/core/tests/unit/services/apollo-test.js
@@ -1,24 +1,24 @@
 import { InMemoryCache } from "@apollo/client/cache";
-import EmberObject from "@ember/object";
 import { setupTest } from "ember-qunit";
 import { module, test } from "qunit";
 
 import possibleTypes from "@projectcaluma/ember-core/-private/possible-types";
-import CalumaApolloServiceMixinMixin from "@projectcaluma/ember-core/mixins/caluma-apollo-service-mixin";
+import CalumaApolloService from "@projectcaluma/ember-core/services/apollo";
 
-module("Unit | Mixin | caluma-apollo-service-mixin", function (hooks) {
+module("Unit | Service | apollo", function (hooks) {
   setupTest(hooks);
+
+  hooks.beforeEach(function () {
+    // this is needed since the tests don't read the addons `after` config which
+    // causes the owner to register the standard service of
+    // `ember-apollo-client` as `service:apollo`
+    this.owner.register("service:apollo", CalumaApolloService);
+  });
 
   test("it uses the correct possible types", function (assert) {
     assert.expect(2);
 
-    const CalumaApolloServiceMixinObject = EmberObject.extend(
-      CalumaApolloServiceMixinMixin
-    );
-
-    const subject = CalumaApolloServiceMixinObject.create();
-
-    const cache = subject.cache();
+    const cache = this.owner.lookup("service:apollo").cache();
 
     assert.ok(cache instanceof InMemoryCache);
     assert.deepEqual(cache.config.possibleTypes, possibleTypes);
@@ -27,13 +27,7 @@ module("Unit | Mixin | caluma-apollo-service-mixin", function (hooks) {
   test("it resolves the correct data id", function (assert) {
     assert.expect(2);
 
-    const CalumaApolloServiceMixinObject = EmberObject.extend(
-      CalumaApolloServiceMixinMixin
-    );
-
-    const subject = CalumaApolloServiceMixinObject.create();
-
-    const cache = subject.cache();
+    const cache = this.owner.lookup("service:apollo").cache();
 
     assert.strictEqual(
       cache.config.dataIdFromObject({

--- a/packages/distribution/tests/dummy/app/services/apollo.js
+++ b/packages/distribution/tests/dummy/app/services/apollo.js
@@ -1,8 +1,0 @@
-import ApolloService from "ember-apollo-client/services/apollo";
-
-import CalumaApolloServiceMixin from "@projectcaluma/ember-core/mixins/caluma-apollo-service-mixin";
-
-export default class CustomApolloService extends ApolloService.extend(
-  CalumaApolloServiceMixin,
-  {}
-) {}

--- a/packages/form-builder/tests/dummy/app/services/apollo.js
+++ b/packages/form-builder/tests/dummy/app/services/apollo.js
@@ -1,5 +1,0 @@
-import ApolloService from "ember-apollo-client/services/apollo";
-
-import CalumaApolloServiceMixin from "@projectcaluma/ember-core/mixins/caluma-apollo-service-mixin";
-
-export default ApolloService.extend(CalumaApolloServiceMixin, {});

--- a/packages/form/tests/dummy/app/services/apollo.js
+++ b/packages/form/tests/dummy/app/services/apollo.js
@@ -1,5 +1,0 @@
-import ApolloService from "ember-apollo-client/services/apollo";
-
-import CalumaApolloServiceMixin from "@projectcaluma/ember-core/mixins/caluma-apollo-service-mixin";
-
-export default ApolloService.extend(CalumaApolloServiceMixin, {});

--- a/packages/workflow/tests/dummy/app/services/apollo.js
+++ b/packages/workflow/tests/dummy/app/services/apollo.js
@@ -1,5 +1,0 @@
-import ApolloService from "ember-apollo-client/services/apollo";
-
-import CalumaApolloServiceMixin from "@projectcaluma/ember-core/mixins/caluma-apollo-service-mixin";
-
-export default ApolloService.extend(CalumaApolloServiceMixin, {});


### PR DESCRIPTION
BREAKING CHANGE: The apollo service mixin was removed in favor of
directly overriding the service. For more information on how to migrate,
please visit the v11 migration guide.

Resolves #529