### PR TITLE
fix(form): change file download actions to query and network-only

### DIFF
--- a/packages/form/addon/components/cf-field-value.js
+++ b/packages/form/addon/components/cf-field-value.js
@@ -41,10 +41,16 @@ export default class CfFieldValueComponent extends Component {
   @action
   async download(id) {
     const { downloadUrl } = await this.apollo.query(
-      { query: getFileAnswerInfoQuery, variables: { id } },
+      {
+        query: getFileAnswerInfoQuery,
+        variables: { id },
+        fetchPolicy: "network-only",
+      },
       "node.fileValue"
     );
 
-    window.open(downloadUrl, "_blank");
+    if (downloadUrl) {
+      window.open(downloadUrl, "_blank");
+    }
   }
 }

--- a/packages/form/addon/components/cf-field/input/file.js
+++ b/packages/form/addon/components/cf-field/input/file.js
@@ -22,11 +22,11 @@ export default class CfFieldInputFileComponent extends Component {
 
   @action
   async download() {
-    const { downloadUrl } = await this.apollo.watchQuery(
+    const { downloadUrl } = await this.apollo.query(
       {
         query: getFileAnswerInfoQuery,
         variables: { id: this.args.field.answer.raw.id },
-        fetchPolicy: "cache-and-network",
+        fetchPolicy: "network-only",
       },
       "node.fileValue"
     );


### PR DESCRIPTION
This fixes the graphql "Invariant Violation: 10" error which occurs,
when trying to download a file answer through the table header