### PR TITLE
fix(form): use action button type "button"

### DIFF
--- a/packages/form/addon/components/cf-field/input/action-button.hbs
+++ b/packages/form/addon/components/cf-field/input/action-button.hbs
@@ -12,7 +12,6 @@
     @beforeMutate={{fn this.beforeMutate validate}}
     @onSuccess={{this.onSuccess}}
     @onError={{this.onError}}
-    @type={{this.type}}
     class={{if @disabled "uk-hidden"}}
   />
 </DocumentValidity>

--- a/packages/form/addon/components/cf-field/input/action-button.js
+++ b/packages/form/addon/components/cf-field/input/action-button.js
@@ -38,12 +38,6 @@ export default class CfFieldInputActionButtonComponent extends Component {
     return this.args.field.question.raw.color.toLowerCase();
   }
 
-  get type() {
-    return this.args.field.question.raw.action === "COMPLETE"
-      ? "submit"
-      : "button";
-  }
-
   get validateOnEnter() {
     return (
       this.args.field.question.raw.action === "COMPLETE" &&

--- a/packages/form/tests/integration/components/cf-field/input/action-button-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/action-button-test.js
@@ -55,9 +55,9 @@ module(
       assert.dom("button.uk-button-secondary").exists();
     });
 
-    test("renders a submit button for complete actions", async function (assert) {
+    test("renders a button for complete actions", async function (assert) {
       await render(hbs`<CfField::Input::ActionButton @field={{this.field}} />`);
-      assert.dom("button.uk-button-secondary").hasAttribute("type", "submit");
+      assert.dom("button.uk-button-secondary").hasAttribute("type", "button");
 
       this.field.question.raw.action = "SKIP";
       await render(hbs`<CfField::Input::ActionButton @field={{this.field}} />`);


### PR DESCRIPTION
Only use the default button type "button" for action
buttons. Using button type "submit" can lead to issues
on browsers such as firefox, where the default submit
action is triggered.