### PR TITLE
fix(navigation): exclude static questions from visible fields

### DIFF
--- a/packages/form/addon/lib/navigation.js
+++ b/packages/form/addon/lib/navigation.js
@@ -232,7 +232,9 @@ export class NavigationItem extends Base {
   @cached
   get visibleFields() {
     return this.fieldset.fields.filter(
-      (f) => f.questionType !== "FormQuestion" && !f.hidden
+      (f) =>
+        !["FormQuestion", "StaticQuestion"].includes(f.questionType) &&
+        !f.hidden
     );
   }
 


### PR DESCRIPTION
Set the state of a parent form to valid if there is a subform with only
static questions.