### PR TITLE
feat(form): support passing component override classes

### DIFF
--- a/packages/-ember-caluma/app/services/caluma-options.js
+++ b/packages/-ember-caluma/app/services/caluma-options.js
@@ -1,7 +1,8 @@
 import { inject as service } from "@ember/service";
 
 import CalumaOptionsService from "@projectcaluma/ember-core/services/caluma-options";
-import ENV from "ember-caluma/config/environment";
+import DummyOneComponent from "ember-caluma/components/dummy-one";
+import DummyTwoComponent from "ember-caluma/components/dummy-two";
 
 export default class CustomCalumaOptionsService extends CalumaOptionsService {
   @service intl;
@@ -10,17 +11,17 @@ export default class CustomCalumaOptionsService extends CalumaOptionsService {
   constructor(...args) {
     super(...args);
 
-    if (ENV.environment !== "production") {
-      this.registerComponentOverride({
-        label: "Dummy One",
-        component: "dummy-one",
-        types: ["TextQuestion", "TextareaQuestion"],
-      });
-      this.registerComponentOverride({
-        label: "Dummy Two",
-        component: "dummy-two",
-      });
-    }
+    this.registerComponentOverride({
+      label: "Dummy One",
+      component: "dummy-one",
+      componentClass: DummyOneComponent,
+      types: ["TextQuestion", "TextareaQuestion"],
+    });
+    this.registerComponentOverride({
+      label: "Dummy Two",
+      component: "dummy-two",
+      componentClass: DummyTwoComponent,
+    });
 
     this.currentGroupId = 1;
   }

--- a/packages/core/addon/services/caluma-options.js
+++ b/packages/core/addon/services/caluma-options.js
@@ -18,33 +18,6 @@ export default class CalumaOptionsService extends Service {
 
   @tracked currentGroupId;
 
-  constructor(...args) {
-    super(...args);
-
-    this.registerComponentOverride({
-      label: this.intl.t(
-        "caluma.form-builder.question.widgetOverrides.powerselect"
-      ),
-      component: "cf-field/input/powerselect",
-      types: [
-        "ChoiceQuestion",
-        "MultipleChoiceQuestion",
-        "DynamicChoiceQuestion",
-        "DynamicMultipleChoiceQuestion",
-      ],
-    });
-
-    this.registerComponentOverride({
-      label: this.intl.t("caluma.form-builder.question.widgetOverrides.hidden"),
-      component: "cf-field/input/hidden",
-    });
-
-    this.registerComponentOverride({
-      component: "cfb-form-editor/question/default/table",
-      types: [],
-    });
-  }
-
   _namespace = null;
   _overrides = {};
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -36,6 +36,7 @@
     "@ember/render-modifiers": "2.0.4",
     "@ember/test-helpers": "2.6.0",
     "@embroider/test-setup": "1.2.0",
+    "@embroider/util": "^1.2.0",
     "@faker-js/faker": "6.0.0-alpha.7",
     "@glimmer/component": "1.0.4",
     "@projectcaluma/ember-testing": "11.0.0-beta.3",

--- a/packages/form-builder/addon/instance-initializers/form-builder-widget-overrides.js
+++ b/packages/form-builder/addon/instance-initializers/form-builder-widget-overrides.js
@@ -1,0 +1,15 @@
+import DefaultTableComponent from "@projectcaluma/ember-form-builder/components/cfb-form-editor/question/default/table";
+
+export function initialize(appInstance) {
+  const options = appInstance.lookup("service:caluma-options");
+
+  options.registerComponentOverride({
+    component: "cfb-form-editor/question/default/table",
+    componentClass: DefaultTableComponent,
+    types: [],
+  });
+}
+
+export default {
+  initialize,
+};

--- a/packages/form-builder/app/instance-initializers/form-builder-widget-overrides.js
+++ b/packages/form-builder/app/instance-initializers/form-builder-widget-overrides.js
@@ -1,0 +1,4 @@
+export {
+  default,
+  initialize,
+} from "@projectcaluma/ember-form-builder/instance-initializers/form-builder-widget-overrides";

--- a/packages/form-builder/tests/unit/instance-initializers/form-builder-widget-overrides-test.js
+++ b/packages/form-builder/tests/unit/instance-initializers/form-builder-widget-overrides-test.js
@@ -1,0 +1,36 @@
+import Application from "@ember/application";
+import { run } from "@ember/runloop";
+import config from "dummy/config/environment";
+import { initialize } from "dummy/instance-initializers/form-builder-widget-overrides";
+import Resolver from "ember-resolver";
+import { module, test } from "qunit";
+
+module(
+  "Unit | Instance Initializer | form-builder-widget-overrides",
+  function (hooks) {
+    hooks.beforeEach(function () {
+      this.TestApplication = class TestApplication extends Application {
+        modulePrefix = config.modulePrefix;
+        podModulePrefix = config.podModulePrefix;
+        Resolver = Resolver;
+      };
+      this.TestApplication.instanceInitializer({
+        name: "initializer under test",
+        initialize,
+      });
+      this.application = this.TestApplication.create({ autoboot: false });
+      this.instance = this.application.buildInstance();
+    });
+    hooks.afterEach(function () {
+      run(this.instance, "destroy");
+      run(this.application, "destroy");
+    });
+
+    // TODO: Replace this with your real tests.
+    test("it works", async function (assert) {
+      await this.instance.boot();
+
+      assert.ok(true);
+    });
+  }
+);

--- a/packages/form/addon/components/cf-field.hbs
+++ b/packages/form/addon/components/cf-field.hbs
@@ -14,7 +14,10 @@
 
     <div class="uk-flex">
       <div class="uk-width-expand">
-        {{#let (component (get-widget @field.question)) as |FieldComponent|}}
+        {{#let
+          (component (ensure-safe-component (get-widget @field.question)))
+          as |FieldComponent|
+        }}
           <FieldComponent
             @field={{@field}}
             @disabled={{@disabled}}

--- a/packages/form/addon/components/cf-form-wrapper.hbs
+++ b/packages/form/addon/components/cf-form-wrapper.hbs
@@ -1,6 +1,8 @@
 {{#let
   (component
-    (get-widget @fieldset.field.question @fieldset.form default="cf-form")
+    (ensure-safe-component
+      (get-widget @fieldset.field.question @fieldset.form default="cf-form")
+    )
   )
   as |FormComponent|
 }}

--- a/packages/form/addon/helpers/get-widget.js
+++ b/packages/form/addon/helpers/get-widget.js
@@ -1,6 +1,15 @@
 import Helper from "@ember/component/helper";
 import { warn } from "@ember/debug";
 import { inject as service } from "@ember/service";
+import { ensureSafeComponent } from "@embroider/util";
+
+import InputComponent from "@projectcaluma/ember-form/components/cf-field/input";
+import FormComponent from "@projectcaluma/ember-form/components/cf-form";
+
+const DEFAULT_WIDGETS = {
+  "cf-field/input": InputComponent,
+  "cf-form": FormComponent,
+};
 
 /**
  * Helper for getting the right widget.
@@ -42,9 +51,14 @@ export default class GetWidgetHelper extends Helper {
         { id: "ember-caluma.unregistered-override" }
       );
 
-      if (override) return widget;
+      if (override) {
+        return ensureSafeComponent(
+          override.componentClass ?? override.component,
+          this
+        );
+      }
     }
 
-    return defaultWidget;
+    return ensureSafeComponent(DEFAULT_WIDGETS[defaultWidget], this);
   }
 }

--- a/packages/form/addon/instance-initializers/form-widget-overrides.js
+++ b/packages/form/addon/instance-initializers/form-widget-overrides.js
@@ -1,0 +1,52 @@
+import { setOwner } from "@ember/application";
+import { inject as service } from "@ember/service";
+
+import HiddenComponent from "@projectcaluma/ember-form/components/cf-field/input/hidden";
+import PowerSelectComponent from "@projectcaluma/ember-form/components/cf-field/input/powerselect";
+
+class HiddenOverride {
+  @service intl;
+
+  get label() {
+    return this.intl.t("caluma.form-builder.question.widgetOverrides.hidden");
+  }
+
+  component = "cf-field/input/hidden";
+  componentClass = HiddenComponent;
+}
+
+class PowerSelectOverride {
+  @service intl;
+
+  get label() {
+    return this.intl.t(
+      "caluma.form-builder.question.widgetOverrides.powerselect"
+    );
+  }
+
+  component = "cf-field/input/powerselect";
+  componentClass = PowerSelectComponent;
+  types = [
+    "ChoiceQuestion",
+    "MultipleChoiceQuestion",
+    "DynamicChoiceQuestion",
+    "DynamicMultipleChoiceQuestion",
+  ];
+}
+
+export function initialize(appInstance) {
+  const options = appInstance.lookup("service:caluma-options");
+
+  const hiddenOverride = new HiddenOverride();
+  const powerSelectOverride = new PowerSelectOverride();
+
+  setOwner(hiddenOverride, appInstance);
+  setOwner(powerSelectOverride, appInstance);
+
+  options.registerComponentOverride(hiddenOverride);
+  options.registerComponentOverride(powerSelectOverride);
+}
+
+export default {
+  initialize,
+};

--- a/packages/form/app/instance-initializers/form-widget-overrides.js
+++ b/packages/form/app/instance-initializers/form-widget-overrides.js
@@ -1,0 +1,4 @@
+export {
+  default,
+  initialize,
+} from "@projectcaluma/ember-form/instance-initializers/form-widget-overrides";

--- a/packages/form/tests/integration/helpers/get-widget-test.js
+++ b/packages/form/tests/integration/helpers/get-widget-test.js
@@ -1,4 +1,6 @@
+import { setComponentTemplate } from "@ember/component";
 import { render } from "@ember/test-helpers";
+import Component from "@glimmer/component";
 import { hbs } from "ember-cli-htmlbars";
 import { setupRenderingTest } from "ember-qunit";
 import { module, test } from "qunit";
@@ -6,60 +8,127 @@ import { module, test } from "qunit";
 module("Integration | Helper | get-widget", function (hooks) {
   setupRenderingTest(hooks);
 
-  test("it returns valid overrides", async function (assert) {
-    const calumaOptions = this.owner.lookup("service:calumaOptions");
+  hooks.beforeEach(function () {
+    // eslint-disable-next-line ember/no-empty-glimmer-component-classes
+    class SomeComponent extends Component {}
+    setComponentTemplate(hbs`some-component`, SomeComponent);
 
-    calumaOptions.registerComponentOverride({
+    this.SomeComponent = SomeComponent;
+
+    this.owner.register("component:some-component", SomeComponent);
+  });
+
+  test("it returns valid overrides", async function (assert) {
+    this.owner.lookup("service:calumaOptions").registerComponentOverride({
       label: "Some Component",
       component: "some-component",
     });
 
-    await render(
-      hbs`{{get-widget (hash raw=(hash meta=(hash widgetOverride="some-component")))}}`
-    );
+    await render(hbs`
+      {{component
+        (ensure-safe-component
+          (get-widget
+            (hash
+              raw=(hash
+                meta=(hash widgetOverride="some-component")
+              )
+            )
+          )
+        )
+      }}
+    `);
 
     assert.dom(this.element).hasText("some-component");
   });
 
   test("it doesn't return an invalid override", async function (assert) {
-    await render(
-      hbs`{{get-widget (hash meta=(hash widgetOverride="some-component"))}}`
-    );
+    await render(hbs`
+      {{component
+        (ensure-safe-component
+          (get-widget
+            (hash
+              raw=(hash
+                meta=(hash widgetOverride="some-component")
+              )
+            )
+          )
+        )
+        field=(hash question=(hash raw=(hash __typename="TextQuestion")))
+      }}
+    `);
 
-    assert.dom(this.element).hasText("cf-field/input");
+    assert.dom("input").exists();
   });
 
   test("it has a fallback", async function (assert) {
-    await render(hbs`{{get-widget null}}`);
+    await render(hbs`
+      {{component
+        (ensure-safe-component (get-widget null))
+        field=(hash question=(hash raw=(hash __typename="TextQuestion")))
+      }}
+    `);
 
-    assert.dom(this.element).hasText("cf-field/input");
+    assert.dom("input").exists();
 
-    await render(hbs`{{get-widget undefined}}`);
+    await render(hbs`
+      {{component
+        (ensure-safe-component (get-widget undefined))
+        field=(hash question=(hash raw=(hash __typename="TextQuestion")))
+      }}
+    `);
 
-    assert.dom(this.element).hasText("cf-field/input");
+    assert.dom("input").exists();
   });
 
   test("it can pass the default widget", async function (assert) {
-    await render(hbs`{{get-widget null default="cf-form"}}`);
+    await render(
+      hbs`{{component (ensure-safe-component (get-widget null default="cf-form"))}}`
+    );
 
-    assert.dom(this.element).hasText("cf-form");
+    assert.dom("form").exists();
   });
 
   test("it can handle multiple objects", async function (assert) {
-    const calumaOptions = this.owner.lookup("service:calumaOptions");
-
-    calumaOptions.registerComponentOverride({
+    this.owner.lookup("service:calumaOptions").registerComponentOverride({
       label: "Some Component",
       component: "some-component",
     });
 
-    await render(
-      hbs`{{get-widget
-        null
-        (hash raw=(hash meta=(hash widgetOverride="some-invalid-component")))
-        (hash raw=(hash meta=(hash widgetOverride="some-component")))
-      }}`
-    );
+    await render(hbs`
+      {{component
+        (ensure-safe-component
+          (get-widget
+            null
+            (hash raw=(hash meta=(hash widgetOverride="some-invalid-component")))
+            (hash raw=(hash meta=(hash widgetOverride="some-component")))
+          )
+        )
+      }}
+    `);
+
+    assert.dom(this.element).hasText("some-component");
+  });
+
+  test("it can handle component classes", async function (assert) {
+    this.owner.lookup("service:calumaOptions").registerComponentOverride({
+      label: "Some Component",
+      component: "some-component",
+      componentClass: this.SomeComponent,
+    });
+
+    await render(hbs`
+      {{component
+        (ensure-safe-component
+          (get-widget
+            (hash
+              raw=(hash
+                meta=(hash widgetOverride="some-component")
+              )
+            )
+          )
+        )
+      }}
+    `);
 
     assert.dom(this.element).hasText("some-component");
   });

--- a/packages/form/tests/unit/instance-initializers/form-widget-overrides-test.js
+++ b/packages/form/tests/unit/instance-initializers/form-widget-overrides-test.js
@@ -1,0 +1,33 @@
+import Application from "@ember/application";
+import { run } from "@ember/runloop";
+import config from "dummy/config/environment";
+import { initialize } from "dummy/instance-initializers/form-widget-overrides";
+import Resolver from "ember-resolver";
+import { module, test } from "qunit";
+
+module("Unit | Instance Initializer | form-widget-overrides", function (hooks) {
+  hooks.beforeEach(function () {
+    this.TestApplication = class TestApplication extends Application {
+      modulePrefix = config.modulePrefix;
+      podModulePrefix = config.podModulePrefix;
+      Resolver = Resolver;
+    };
+    this.TestApplication.instanceInitializer({
+      name: "initializer under test",
+      initialize,
+    });
+    this.application = this.TestApplication.create({ autoboot: false });
+    this.instance = this.application.buildInstance();
+  });
+  hooks.afterEach(function () {
+    run(this.instance, "destroy");
+    run(this.application, "destroy");
+  });
+
+  // TODO: Replace this with your real tests.
+  test("it works", async function (assert) {
+    await this.instance.boot();
+
+    assert.ok(true);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1509,7 +1509,7 @@
     lodash "^4.17.21"
     resolve "^1.20.0"
 
-"@embroider/util@^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0", "@embroider/util@^1.0.0", "@embroider/util@^1.1.0":
+"@embroider/util@^0.39.1 || ^0.40.0 || ^0.41.0 || ^1.0.0", "@embroider/util@^1.0.0", "@embroider/util@^1.1.0", "@embroider/util@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@embroider/util/-/util-1.2.0.tgz#8aa8413252ca4a566cb482b46be3b41997f36ea2"
   integrity sha512-uWgEAhMWghljnYxwsSKZkrB3tY9avJlkJoHvjN+ZazwP/5EfsB7Ck++2WEfIOBOOPEoQr1MYHVlvr+hIMwLrVw==
@@ -8199,7 +8199,6 @@ ember-engines-router-service@^0.3.0:
 
 ember-engines@0.8.20, "ember-engines@https://gitpkg.now.sh/anehx/ember-engines/packages/ember-engines?c08f7650ffc4b723e8ba1143d7498e58bc1e4b78":
   version "0.8.20"
-  uid "0defff12268ae3580b7d2ead8c8779827b267219"
   resolved "https://gitpkg.now.sh/anehx/ember-engines/packages/ember-engines?c08f7650ffc4b723e8ba1143d7498e58bc1e4b78#0defff12268ae3580b7d2ead8c8779827b267219"
   dependencies:
     "@embroider/macros" "^1.0.0"


### PR DESCRIPTION
This is needed so widget overrides can be used in an engine since the engine can't resolve the component by name.