### PR TITLE
feat(cf-field): add optional hints for form fields

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   db:
-    image: postgres:latest
+    image: postgres:14-alpine
     environment:
       - POSTGRES_USER=caluma
       - POSTGRES_PASSWORD=caluma
@@ -9,7 +9,7 @@ services:
       - dbdata:/var/lib/postgresql/data
 
   caluma:
-    image: ghcr.io/projectcaluma/caluma:dev
+    image: ghcr.io/projectcaluma/caluma:7.15.0
     ports:
       - "8000:8000"
     depends_on:

--- a/packages/-ember-caluma/mirage/scenarios/default.js
+++ b/packages/-ember-caluma/mirage/scenarios/default.js
@@ -18,6 +18,7 @@ export default function (server) {
     formIds: [form.id],
     type: "TEXT",
     maxLength: null,
+    hintText: null,
   });
   server.create("question", {
     slug: "description",
@@ -26,6 +27,7 @@ export default function (server) {
     type: "TEXTAREA",
     maxLength: 50,
     minLength: 5,
+    hintText: null,
   });
   server.create("question", {
     slug: "age",
@@ -35,6 +37,7 @@ export default function (server) {
     type: "INTEGER",
     minValue: 0,
     maxValue: null,
+    hintText: null,
   });
   server.create("question", {
     slug: "height",
@@ -44,11 +47,13 @@ export default function (server) {
     minValue: 0,
     maxValue: null,
     isHidden: "'age'|answer < 18",
+    hintText: null,
   });
   server.create("question", {
     slug: "like-caluma",
     label: "Do you like Caluma?",
     infoText: null,
+    hintText: "Please express your enthusiasm.",
     type: "CHOICE",
     formIds: [form.id],
     options: [
@@ -70,6 +75,7 @@ export default function (server) {
     formIds: [form.id],
     type: "MULTIPLE_CHOICE",
     isHidden: "'height'|answer > 1.6",
+    hintText: null,
     options: [
       server.create("option", {
         slug: "short-reason-moms-fault",
@@ -90,6 +96,7 @@ export default function (server) {
     label: "When?",
     formIds: [form.id],
     type: "DATE",
+    hintText: null,
   });
   server.create("question", {
     slug: "email",
@@ -115,6 +122,7 @@ export default function (server) {
     formIds: [form.id],
     type: "TEXT",
     meta: { widgetOverride: "dummy-one" },
+    hintText: null,
   });
   server.create("question", {
     slug: "submit",

--- a/packages/form-builder/addon/components/cfb-form-editor/question.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.hbs
@@ -164,6 +164,13 @@
         </div>
       {{/if}}
 
+      {{#if (not (has-question-type f.model "action-button" "static" "form"))}}
+        <f.input
+          @name="hintText"
+          @label={{t "caluma.form-builder.question.hintText"}}
+        />
+      {{/if}}
+
       {{#if (has-question-type f.model "text" "textarea" "integer" "float")}}
         <f.input
           @name="placeholder"

--- a/packages/form-builder/addon/components/cfb-form-editor/question.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.js
@@ -238,6 +238,7 @@ export default class CfbFormEditorQuestion extends Component {
       minValue: parseInt(changeset.get("integerMinValue")),
       maxValue: parseInt(changeset.get("integerMaxValue")),
       placeholder: changeset.get("placeholder"),
+      hintText: changeset.get("hintText"),
     };
   }
 
@@ -246,6 +247,7 @@ export default class CfbFormEditorQuestion extends Component {
       minValue: parseFloat(changeset.get("floatMinValue")),
       maxValue: parseFloat(changeset.get("floatMaxValue")),
       placeholder: changeset.get("placeholder"),
+      hintText: changeset.get("hintText"),
     };
   }
 
@@ -257,6 +259,7 @@ export default class CfbFormEditorQuestion extends Component {
       formatValidators: changeset
         .get("formatValidators")
         ?.edges.map((edge) => edge.node.slug),
+      hintText: changeset.get("hintText"),
     };
   }
 
@@ -268,36 +271,48 @@ export default class CfbFormEditorQuestion extends Component {
       formatValidators: changeset
         .get("formatValidators")
         ?.edges.map((edge) => edge.node.slug),
+      hintText: changeset.get("hintText"),
+    };
+  }
+
+  _getDateQuestionInput(changeset) {
+    return {
+      hintText: changeset.get("hintText"),
     };
   }
 
   _getMultipleChoiceQuestionInput(changeset) {
     return {
       options: changeset.get("options.edges").map(({ node: { slug } }) => slug),
+      hintText: changeset.get("hintText"),
     };
   }
 
   _getChoiceQuestionInput(changeset) {
     return {
       options: changeset.get("options.edges").map(({ node: { slug } }) => slug),
+      hintText: changeset.get("hintText"),
     };
   }
 
   _getDynamicMultipleChoiceQuestionInput(changeset) {
     return {
       dataSource: changeset.get("dataSource"),
+      hintText: changeset.get("hintText"),
     };
   }
 
   _getDynamicChoiceQuestionInput(changeset) {
     return {
       dataSource: changeset.get("dataSource"),
+      hintText: changeset.get("hintText"),
     };
   }
 
   _getTableQuestionInput(changeset) {
     return {
       rowForm: changeset.get("rowForm.slug"),
+      hintText: changeset.get("hintText"),
     };
   }
 
@@ -316,6 +331,13 @@ export default class CfbFormEditorQuestion extends Component {
   _getCalculatedFloatQuestionInput(changeset) {
     return {
       calcExpression: changeset.get("calcExpression"),
+      hintText: changeset.get("hintText"),
+    };
+  }
+
+  _getFileQuestionInput(changeset) {
+    return {
+      hintText: changeset.get("hintText"),
     };
   }
 

--- a/packages/form-builder/addon/gql/fragments/field.graphql
+++ b/packages/form-builder/addon/gql/fragments/field.graphql
@@ -19,6 +19,7 @@ fragment SimpleQuestion on Question {
       value
     }
     placeholder
+    hintText
   }
   ... on TextareaQuestion {
     textareaMinLength: minLength
@@ -28,6 +29,7 @@ fragment SimpleQuestion on Question {
       value
     }
     placeholder
+    hintText
   }
   ... on IntegerQuestion {
     integerMinValue: minValue
@@ -37,6 +39,7 @@ fragment SimpleQuestion on Question {
       value
     }
     placeholder
+    hintText
   }
   ... on FloatQuestion {
     floatMinValue: minValue
@@ -46,6 +49,7 @@ fragment SimpleQuestion on Question {
       value
     }
     placeholder
+    hintText
   }
   ... on ChoiceQuestion {
     choiceOptions: options {
@@ -62,6 +66,7 @@ fragment SimpleQuestion on Question {
       id
       value
     }
+    hintText
   }
   ... on MultipleChoiceQuestion {
     multipleChoiceOptions: options {
@@ -78,18 +83,24 @@ fragment SimpleQuestion on Question {
       id
       value
     }
+    hintText
   }
   ... on DateQuestion {
     dateDefaultAnswer: defaultAnswer {
       id
       value
     }
+    hintText
   }
   ... on StaticQuestion {
     staticContent
   }
   ... on CalculatedFloatQuestion {
     calcExpression
+    hintText
+  }
+  ... on FileQuestion {
+    hintText
   }
   ... on ActionButtonQuestion {
     action
@@ -112,6 +123,7 @@ fragment FieldTableQuestion on Question {
         }
       }
     }
+    hintText
     tableDefaultAnswer: defaultAnswer {
       id
       value {

--- a/packages/form-builder/addon/gql/mutations/save-calculated-float-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-calculated-float-question.graphql
@@ -9,6 +9,7 @@ mutation SaveCalculatedFloatQuestion(
       ...QuestionInfo
       ... on CalculatedFloatQuestion {
         calcExpression
+        hintText
       }
     }
     clientMutationId

--- a/packages/form-builder/addon/gql/mutations/save-choice-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-choice-question.graphql
@@ -15,6 +15,7 @@ mutation SaveChoiceQuestion($input: SaveChoiceQuestionInput!) {
             }
           }
         }
+        hintText
       }
     }
     clientMutationId

--- a/packages/form-builder/addon/gql/mutations/save-date-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-date-question.graphql
@@ -5,6 +5,9 @@ mutation SaveDateQuestion($input: SaveDateQuestionInput!) {
     question {
       id
       ...QuestionInfo
+      ... on DateQuestion {
+        hintText
+      }
     }
     clientMutationId
   }

--- a/packages/form-builder/addon/gql/mutations/save-dynamic-choice-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-dynamic-choice-question.graphql
@@ -7,6 +7,7 @@ mutation SaveDynamicChoiceQuestion($input: SaveDynamicChoiceQuestionInput!) {
       ...QuestionInfo
       ... on DynamicChoiceQuestion {
         dataSource
+        hintText
       }
     }
     clientMutationId

--- a/packages/form-builder/addon/gql/mutations/save-dynamic-multiple-choice-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-dynamic-multiple-choice-question.graphql
@@ -9,6 +9,7 @@ mutation SaveDynamicMultipleChoiceQuestion(
       ...QuestionInfo
       ... on DynamicMultipleChoiceQuestion {
         dataSource
+        hintText
       }
     }
     clientMutationId

--- a/packages/form-builder/addon/gql/mutations/save-file-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-file-question.graphql
@@ -5,6 +5,9 @@ mutation SaveFileQuestion($input: SaveFileQuestionInput!) {
     question {
       id
       ...QuestionInfo
+      ... on FileQuestion {
+        hintText
+      }
     }
     clientMutationId
   }

--- a/packages/form-builder/addon/gql/mutations/save-float-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-float-question.graphql
@@ -8,6 +8,7 @@ mutation SaveFloatQuestion($input: SaveFloatQuestionInput!) {
       ... on FloatQuestion {
         floatMinValue: minValue
         floatMaxValue: maxValue
+        hintText
       }
     }
     clientMutationId

--- a/packages/form-builder/addon/gql/mutations/save-integer-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-integer-question.graphql
@@ -8,6 +8,7 @@ mutation SaveIntegerQuestion($input: SaveIntegerQuestionInput!) {
       ... on IntegerQuestion {
         integerMinValue: minValue
         integerMaxValue: maxValue
+        hintText
       }
     }
     clientMutationId

--- a/packages/form-builder/addon/gql/mutations/save-multiple-choice-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-multiple-choice-question.graphql
@@ -15,6 +15,7 @@ mutation SaveMultipleChoiceQuestion($input: SaveMultipleChoiceQuestionInput!) {
             }
           }
         }
+        hintText
       }
     }
     clientMutationId

--- a/packages/form-builder/addon/gql/mutations/save-table-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-table-question.graphql
@@ -10,6 +10,7 @@ mutation SaveTableQuestion($input: SaveTableQuestionInput!) {
           id
           slug
         }
+        hintText
       }
     }
     clientMutationId

--- a/packages/form-builder/addon/gql/mutations/save-text-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-text-question.graphql
@@ -8,6 +8,7 @@ mutation SaveTextQuestion($input: SaveTextQuestionInput!) {
       ... on TextQuestion {
         minLength
         maxLength
+        hintText
       }
     }
     clientMutationId

--- a/packages/form-builder/addon/gql/mutations/save-textarea-question.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-textarea-question.graphql
@@ -8,6 +8,7 @@ mutation SaveTextareaQuestion($input: SaveTextareaQuestionInput!) {
       ... on TextareaQuestion {
         minLength
         maxLength
+        hintText
       }
     }
     clientMutationId

--- a/packages/form-builder/addon/gql/queries/form-editor-question.graphql
+++ b/packages/form-builder/addon/gql/queries/form-editor-question.graphql
@@ -11,6 +11,7 @@ query FormEditorQuestion($slug: String!) {
           integerMaxValue: maxValue
           integerMinValue: minValue
           placeholder
+          hintText
           defaultAnswer {
             id
             integerValue: value
@@ -20,6 +21,7 @@ query FormEditorQuestion($slug: String!) {
           floatMaxValue: maxValue
           floatMinValue: minValue
           placeholder
+          hintText
           defaultAnswer {
             id
             floatValue: value
@@ -29,6 +31,7 @@ query FormEditorQuestion($slug: String!) {
           minLength
           maxLength
           placeholder
+          hintText
           defaultAnswer {
             id
             stringValue: value
@@ -52,12 +55,14 @@ query FormEditorQuestion($slug: String!) {
               }
             }
           }
+          hintText
           defaultAnswer {
             id
             stringValue: value
           }
         }
         ... on DateQuestion {
+          hintText
           defaultAnswer {
             id
             dateValue: value
@@ -74,6 +79,7 @@ query FormEditorQuestion($slug: String!) {
               }
             }
           }
+          hintText
           defaultAnswer {
             id
             listValue: value
@@ -90,6 +96,7 @@ query FormEditorQuestion($slug: String!) {
               }
             }
           }
+          hintText
           defaultAnswer {
             id
             stringValue: value
@@ -97,9 +104,11 @@ query FormEditorQuestion($slug: String!) {
         }
         ... on DynamicMultipleChoiceQuestion {
           dataSource
+          hintText
         }
         ... on DynamicChoiceQuestion {
           dataSource
+          hintText
         }
         ... on TableQuestion {
           rowForm {
@@ -115,6 +124,7 @@ query FormEditorQuestion($slug: String!) {
               }
             }
           }
+          hintText
           defaultAnswer {
             id
             tableValue: value {
@@ -151,6 +161,10 @@ query FormEditorQuestion($slug: String!) {
         }
         ... on CalculatedFloatQuestion {
           calcExpression
+          hintText
+        }
+        ... on FileQuestion {
+          hintText
         }
         ... on ActionButtonQuestion {
           action

--- a/packages/form-builder/addon/validations/question.js
+++ b/packages/form-builder/addon/validations/question.js
@@ -16,6 +16,12 @@ export default {
   label: and(validatePresence(true), validateLength({ max: 1024 })),
   slug: validateSlug(),
 
+  hintText: or(
+    validateType("FormQuestion", true),
+    validateType("StaticQuestion", true),
+    validateType("FileQuestion", true),
+    validateLength({ max: 1024, allowBlank: true })
+  ),
   integerMinValue: or(
     validateType("IntegerQuestion", false),
     and(

--- a/packages/form-builder/translations/de.yaml
+++ b/packages/form-builder/translations/de.yaml
@@ -51,6 +51,7 @@ caluma:
       isRequired: "Pflichtfeld"
       staticContent: "Statischer Inhalt"
       infoText: "Infotext"
+      hintText: "Hinweistext"
       confirmationText: "Bestätigungstext"
       placeholder: "Platzhalter"
       isHidden: "Versteckt (JEXL)"

--- a/packages/form-builder/translations/en.yaml
+++ b/packages/form-builder/translations/en.yaml
@@ -51,6 +51,7 @@ caluma:
       isRequired: "Required"
       staticContent: "Static content"
       infoText: "Information text"
+      hintText: "Hint text"
       confirmationText: "Confirmation text"
       placeholder: "Placeholder"
       isHidden: "Hidden (JEXL)"

--- a/packages/form/addon/components/cf-field.hbs
+++ b/packages/form/addon/components/cf-field.hbs
@@ -46,6 +46,10 @@
       {{/if}}
     </div>
 
+    {{#if (and @field.question.raw.hintText this.hintTextVisible)}}
+      <CfField::hint @field={{@field}} />
+    {{/if}}
+
     {{#if @field.errors.length}}
       <CfField::errors @field={{@field}} />
     {{/if}}

--- a/packages/form/addon/components/cf-field.js
+++ b/packages/form/addon/components/cf-field.js
@@ -46,6 +46,15 @@ export default class CfFieldComponent extends Component {
     return !hasQuestionType(this.args.field?.question, "action-button");
   }
 
+  get hintTextVisible() {
+    return !hasQuestionType(
+      this.args.field?.question,
+      "action-button",
+      "static",
+      "form"
+    );
+  }
+
   get saveIndicatorVisible() {
     return !hasQuestionType(this.args.field?.question, "action-button");
   }

--- a/packages/form/addon/components/cf-field/hint.hbs
+++ b/packages/form/addon/components/cf-field/hint.hbs
@@ -1,0 +1,5 @@
+<div data-test-field-hint={{@field.pk}}>
+  <span class="uk-text-small uk-text-muted" ...attributes>
+    {{@field.question.raw.hintText}}
+  </span>
+</div>

--- a/packages/form/addon/gql/fragments/field.graphql
+++ b/packages/form/addon/gql/fragments/field.graphql
@@ -28,6 +28,7 @@ fragment SimpleQuestion on Question {
         }
       }
     }
+    hintText
   }
   ... on TextareaQuestion {
     textareaMinLength: minLength
@@ -46,6 +47,7 @@ fragment SimpleQuestion on Question {
         }
       }
     }
+    hintText
   }
   ... on IntegerQuestion {
     integerMinValue: minValue
@@ -55,6 +57,7 @@ fragment SimpleQuestion on Question {
       value
     }
     placeholder
+    hintText
   }
   ... on FloatQuestion {
     floatMinValue: minValue
@@ -64,6 +67,7 @@ fragment SimpleQuestion on Question {
       value
     }
     placeholder
+    hintText
   }
   ... on ChoiceQuestion {
     choiceOptions: options {
@@ -80,6 +84,7 @@ fragment SimpleQuestion on Question {
       id
       value
     }
+    hintText
   }
   ... on MultipleChoiceQuestion {
     multipleChoiceOptions: options {
@@ -96,18 +101,24 @@ fragment SimpleQuestion on Question {
       id
       value
     }
+    hintText
   }
   ... on DateQuestion {
     dateDefaultAnswer: defaultAnswer {
       id
       value
     }
+    hintText
   }
   ... on StaticQuestion {
     staticContent
   }
   ... on CalculatedFloatQuestion {
     calcExpression
+    hintText
+  }
+  ... on FileQuestion {
+    hintText
   }
   ... on ActionButtonQuestion {
     action
@@ -130,6 +141,7 @@ fragment FieldTableQuestion on Question {
         }
       }
     }
+    hintText
     tableDefaultAnswer: defaultAnswer {
       id
       value {

--- a/packages/form/app/components/cf-field/hint.js
+++ b/packages/form/app/components/cf-field/hint.js
@@ -1,0 +1,1 @@
+export { default } from "@projectcaluma/ember-form/components/cf-field/hint";

--- a/packages/form/tests/integration/components/cf-field/hint-test.js
+++ b/packages/form/tests/integration/components/cf-field/hint-test.js
@@ -1,0 +1,49 @@
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { setupIntl } from "ember-intl/test-support";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Integration | Component | cf-field/hint", function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  hooks.beforeEach(function () {
+    const form = {
+      slug: "some-form",
+      __typename: "Form",
+      questions: [
+        {
+          slug: "question-1",
+          label: "Test",
+          isRequired: "true",
+          isHidden: "true",
+          hintText: "Test",
+          __typename: "TextQuestion",
+        },
+      ],
+    };
+
+    const raw = {
+      id: 1,
+      __typename: "Document",
+      answers: [],
+      rootForm: form,
+      forms: [form],
+    };
+
+    const document = new (this.owner.factoryFor("caluma-model:document").class)(
+      { raw, owner: this.owner }
+    );
+    this.field = document.fields[0];
+  });
+
+  test("it renders", async function (assert) {
+    assert.expect(2);
+
+    await render(hbs`<CfField::hint @field={{field}} />`);
+
+    assert.dom(`div[data-test-field-hint='${this.field.pk}']`).exists();
+    assert.dom(`div[data-test-field-hint='${this.field.pk}']`).hasText("Test");
+  });
+});

--- a/packages/testing/addon/mirage-graphql/schema.graphql
+++ b/packages/testing/addon/mirage-graphql/schema.graphql
@@ -80,6 +80,7 @@ input AddWorkflowFlowInput {
   workflow: ID!
   tasks: [ID]!
   next: FlowJexl!
+  redoable: FlowJexl
   clientMutationId: String
 }
 
@@ -273,6 +274,7 @@ type CalculatedFloatQuestion implements Question & Node {
   isHidden: QuestionJexl!
   isArchived: Boolean!
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   forms(
@@ -670,6 +672,7 @@ type ChoiceQuestion implements Question & Node {
   isHidden: QuestionJexl!
   isArchived: Boolean!
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   defaultAnswer: StringAnswer
@@ -1009,6 +1012,7 @@ type DateQuestion implements Question & Node {
   isHidden: QuestionJexl!
   isArchived: Boolean!
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   defaultAnswer: DateAnswer
@@ -1380,6 +1384,7 @@ type DynamicChoiceQuestion implements Question & DynamicQuestion & Node {
   isHidden: QuestionJexl!
   isArchived: Boolean!
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   forms(
@@ -1448,6 +1453,7 @@ type DynamicMultipleChoiceQuestion implements Question & DynamicQuestion & Node 
   isHidden: QuestionJexl!
   isArchived: Boolean!
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   forms(
@@ -1559,6 +1565,7 @@ interface DynamicQuestion {
     last: Int
   ): DataSourceDataConnection
   dataSource: String!
+  hintText: String
 }
 
 type File implements Node {
@@ -1615,6 +1622,7 @@ type FileQuestion implements Question & Node {
   isHidden: QuestionJexl!
   isArchived: Boolean!
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   forms(
@@ -1694,6 +1702,7 @@ type FloatQuestion implements Question & Node {
   isArchived: Boolean!
   placeholder: String
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   defaultAnswer: FloatAnswer
@@ -2173,6 +2182,7 @@ type IntegerQuestion implements Question & Node {
   isArchived: Boolean!
   placeholder: String
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   defaultAnswer: IntegerAnswer
@@ -2286,6 +2296,7 @@ type MultipleChoiceQuestion implements Question & Node {
   isHidden: QuestionJexl!
   isArchived: Boolean!
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   defaultAnswer: ListAnswer
@@ -2385,6 +2396,7 @@ type Mutation {
   cancelWorkItem(input: CancelWorkItemInput!): CancelWorkItemPayload
   suspendWorkItem(input: SuspendWorkItemInput!): SuspendWorkItemPayload
   resumeWorkItem(input: ResumeWorkItemInput!): ResumeWorkItemPayload
+  redoWorkItem(input: RedoWorkItemInput!): RedoWorkItemPayload
   saveWorkItem(input: SaveWorkItemInput!): SaveWorkItemPayload
   createWorkItem(input: CreateWorkItemInput!): CreateWorkItemPayload
   saveForm(input: SaveFormInput!): SaveFormPayload
@@ -3183,6 +3195,21 @@ input QuestionOrderSetType {
   direction: AscDesc
 }
 
+input RedoWorkItemInput {
+  id: ID!
+
+  """
+  Provide extra context for dynamic jexl transforms and events
+  """
+  context: JSONString
+  clientMutationId: String
+}
+
+type RedoWorkItemPayload {
+  workItem: WorkItem
+  clientMutationId: String
+}
+
 input RemoveAnswerInput {
   answer: ID!
   clientMutationId: String
@@ -3302,6 +3329,7 @@ input SaveCalculatedFloatQuestionInput {
   meta: JSONString
   isArchived: Boolean
   calcExpression: QuestionJexl
+  hintText: String
   clientMutationId: String
 }
 
@@ -3338,6 +3366,7 @@ input SaveChoiceQuestionInput {
   meta: JSONString
   isArchived: Boolean
   options: [ID]!
+  hintText: String
   clientMutationId: String
 }
 
@@ -3427,6 +3456,7 @@ input SaveDateQuestionInput {
   isHidden: QuestionJexl
   meta: JSONString
   isArchived: Boolean
+  hintText: String
   clientMutationId: String
 }
 
@@ -3529,7 +3559,6 @@ input SaveDocumentFileAnswerInput {
   document: ID!
   meta: JSONString
   value: String
-  valueId: ID
   clientMutationId: String
 }
 
@@ -3628,6 +3657,7 @@ input SaveDynamicChoiceQuestionInput {
   meta: JSONString
   isArchived: Boolean
   dataSource: String!
+  hintText: String
   clientMutationId: String
 }
 
@@ -3645,6 +3675,7 @@ input SaveDynamicMultipleChoiceQuestionInput {
   meta: JSONString
   isArchived: Boolean
   dataSource: String!
+  hintText: String
   clientMutationId: String
 }
 
@@ -3661,6 +3692,7 @@ input SaveFileQuestionInput {
   isHidden: QuestionJexl
   meta: JSONString
   isArchived: Boolean
+  hintText: String
   clientMutationId: String
 }
 
@@ -3680,6 +3712,7 @@ input SaveFloatQuestionInput {
   minValue: Float
   maxValue: Float
   placeholder: String
+  hintText: String
   clientMutationId: String
 }
 
@@ -3731,6 +3764,7 @@ input SaveIntegerQuestionInput {
   minValue: Int
   maxValue: Int
   placeholder: String
+  hintText: String
   clientMutationId: String
 }
 
@@ -3748,6 +3782,7 @@ input SaveMultipleChoiceQuestionInput {
   meta: JSONString
   isArchived: Boolean
   options: [ID]!
+  hintText: String
   clientMutationId: String
 }
 
@@ -3834,6 +3869,7 @@ input SaveTableQuestionInput {
   Form that represents rows of a TableQuestion
   """
   rowForm: ID!
+  hintText: String
   clientMutationId: String
 }
 
@@ -3853,6 +3889,7 @@ input SaveTextareaQuestionInput {
   minLength: Int
   maxLength: Int
   placeholder: String
+  hintText: String
   formatValidators: [String]
   clientMutationId: String
 }
@@ -3873,6 +3910,7 @@ input SaveTextQuestionInput {
   minLength: Int
   maxLength: Int
   placeholder: String
+  hintText: String
   formatValidators: [String]
   clientMutationId: String
 }
@@ -4101,6 +4139,7 @@ enum SortableQuestionAttributes {
   IS_ARCHIVED
   PLACEHOLDER
   INFO_TEXT
+  HINT_TEXT
   CALC_EXPRESSION
 }
 
@@ -4254,6 +4293,11 @@ enum Status {
   Work item is suspended.
   """
   SUSPENDED
+
+  """
+  Work item has been marked for redo.
+  """
+  REDO
 }
 
 type StringAnswer implements Answer & Node {
@@ -4339,6 +4383,7 @@ type TableQuestion implements Question & Node {
   isHidden: QuestionJexl!
   isArchived: Boolean!
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   defaultAnswer: TableAnswer
@@ -4611,6 +4656,7 @@ type TextareaQuestion implements Question & Node {
   isArchived: Boolean!
   placeholder: String
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   formatValidators(
@@ -4682,6 +4728,7 @@ type TextQuestion implements Question & Node {
   isArchived: Boolean!
   placeholder: String
   infoText: String
+  hintText: String
   meta: GenericScalar!
   source: Question
   formatValidators(
@@ -5000,20 +5047,8 @@ type WorkItem implements Node {
   task: Task!
   status: WorkItemStatus!
   meta: GenericScalar
-
-  """
-  Offer work item to be processed by a group of users, such are not committed to process it though.
-  """
   addressedGroups: [String]!
-
-  """
-  List of groups this work item is assigned to for controlling.
-  """
   controllingGroups: [String]!
-
-  """
-  Users responsible to undertake given work item.
-  """
   assignedUsers: [String]!
   case: Case!
 
@@ -5213,6 +5248,11 @@ enum WorkItemStatus {
   Work item is suspended.
   """
   SUSPENDED
+
+  """
+  Work item has been marked for redo.
+  """
+  REDO
 }
 
 """
@@ -5243,4 +5283,9 @@ enum WorkItemStatusArgument {
   Work item is suspended.
   """
   SUSPENDED
+
+  """
+  Work item has been marked for redo.
+  """
+  REDO
 }


### PR DESCRIPTION
BREAKING CHANGE: Question hints requires Caluma >= v7.15.0

Add option to create hints for certain question types. These
are displayed below the input field and can be used to provide
short, informative messages. Hints are available for all question
types except for form, static and action button questions.