### PR TITLE
chore(action-button): exclude action button from build if workflow is not installed

### DIFF
--- a/bin/update-cross-dependencies.mjs
+++ b/bin/update-cross-dependencies.mjs
@@ -57,6 +57,7 @@ async function getUpdates(dependencies, dev = false) {
 const updates = {
   ...(await getUpdates(pkg.default.devDependencies, true)),
   ...(await getUpdates(pkg.default.dependencies)),
+  ...(await getUpdates(pkg.default.peerDependencies)),
 };
 
 if (!Object.keys(updates).length) {

--- a/packages/form/addon/components/cf-field/input/action-button.hbs
+++ b/packages/form/addon/components/cf-field/input/action-button.hbs
@@ -1,17 +1,23 @@
-<DocumentValidity
-  @document={{@field.document}}
-  @validateOnEnter={{this.validateOnEnter}}
-  as |isValid validate|
->
-  <WorkItemButton
-    @workItemId={{this.workItem}}
-    @mutation={{this.action}}
-    @label={{@field.question.raw.label}}
-    @disabled={{or (and (not-eq isValid null) (not isValid)) @disabled}}
-    @color={{this.color}}
-    @beforeMutate={{fn this.beforeMutate validate}}
-    @onSuccess={{this.onSuccess}}
-    @onError={{this.onError}}
-    class={{if @disabled "uk-hidden"}}
-  />
-</DocumentValidity>
+{{#if
+  (macroCondition
+    (macroDependencySatisfies "@projectcaluma/ember-workflow" "*")
+  )
+}}
+  <DocumentValidity
+    @document={{@field.document}}
+    @validateOnEnter={{this.validateOnEnter}}
+    as |isValid validate|
+  >
+    <WorkItemButton
+      @workItemId={{this.workItem}}
+      @mutation={{this.action}}
+      @label={{@field.question.raw.label}}
+      @disabled={{or (and (not-eq isValid null) (not isValid)) @disabled}}
+      @color={{this.color}}
+      @beforeMutate={{fn this.beforeMutate validate}}
+      @onSuccess={{this.onSuccess}}
+      @onError={{this.onError}}
+      class={{if @disabled "uk-hidden"}}
+    />
+  </DocumentValidity>
+{{/if}}

--- a/packages/form/addon/components/cf-field/input/action-button.js
+++ b/packages/form/addon/components/cf-field/input/action-button.js
@@ -1,61 +1,78 @@
 import { assert } from "@ember/debug";
 import { action } from "@ember/object";
+import { dependencySatisfies, macroCondition } from "@embroider/macros";
 import Component from "@glimmer/component";
 import { confirm } from "ember-uikit";
 
-export default class CfFieldInputActionButtonComponent extends Component {
-  constructor(...args) {
-    super(...args);
+let CfFieldInputActionButtonComponent;
 
-    assert(
-      "The document must have a `workItemUuid` for `<CfField::Input::ActionButton />` to work.",
-      this.args.field.document.workItemUuid
-    );
-  }
+if (macroCondition(dependencySatisfies("@projectcaluma/ember-workflow", ""))) {
+  CfFieldInputActionButtonComponent = class extends Component {
+    constructor(...args) {
+      super(...args);
 
-  get workItem() {
-    return (
-      this.args.context?.actionButtonWorkItemId ||
-      this.args.field.document.workItemUuid
-    );
-  }
-
-  get action() {
-    return this.args.field.question.raw.action.toLowerCase();
-  }
-
-  get color() {
-    return this.args.field.question.raw.color.toLowerCase();
-  }
-
-  get validateOnEnter() {
-    return (
-      this.args.field.question.raw.action === "COMPLETE" &&
-      this.args.field.question.raw.validateOnEnter
-    );
-  }
-
-  @action
-  async beforeMutate(validateFn) {
-    if (
-      this.args.field.question.raw.action === "COMPLETE" &&
-      !(await validateFn())
-    ) {
-      return false;
+      assert(
+        "The document must have a `workItemUuid` for `<CfField::Input::ActionButton />` to work.",
+        this.args.field.document.workItemUuid
+      );
     }
 
-    const confirmText = this.args.field.question.raw.infoText;
+    get workItem() {
+      return (
+        this.args.context?.actionButtonWorkItemId ||
+        this.args.field.document.workItemUuid
+      );
+    }
 
-    return !confirmText || confirm(confirmText);
-  }
+    get action() {
+      return this.args.field.question.raw.action.toLowerCase();
+    }
 
-  @action
-  onSuccess() {
-    return this.args.context?.actionButtonOnSuccess?.();
-  }
+    get color() {
+      return this.args.field.question.raw.color.toLowerCase();
+    }
 
-  @action
-  onError(error) {
-    return this.args.context?.actionButtonOnError?.(error);
-  }
+    get validateOnEnter() {
+      return (
+        this.args.field.question.raw.action === "COMPLETE" &&
+        this.args.field.question.raw.validateOnEnter
+      );
+    }
+
+    @action
+    async beforeMutate(validateFn) {
+      if (
+        this.args.field.question.raw.action === "COMPLETE" &&
+        !(await validateFn())
+      ) {
+        return false;
+      }
+
+      const confirmText = this.args.field.question.raw.infoText;
+
+      return !confirmText || confirm(confirmText);
+    }
+
+    @action
+    onSuccess() {
+      return this.args.context?.actionButtonOnSuccess?.();
+    }
+
+    @action
+    onError(error) {
+      return this.args.context?.actionButtonOnError?.(error);
+    }
+  };
+} else {
+  CfFieldInputActionButtonComponent = class extends Component {
+    constructor(...args) {
+      super(...args);
+
+      assert(
+        "@projectcaluma/ember-workflow must be installed to enable the usage of the action button questions"
+      );
+    }
+  };
 }
+
+export default CfFieldInputActionButtonComponent;

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -73,6 +73,14 @@
     "uuid": "8.3.2",
     "webpack": "5.70.0"
   },
+  "peerDependencies": {
+    "@projectcaluma/ember-workflow": "^11.0.0-beta.5"
+  },
+  "peerDependenciesMeta": {
+    "@projectcaluma/ember-workflow": {
+      "optional": true
+    }
+  },
   "engines": {
     "node": "12.* || 14.* || >= 16"
   },


### PR DESCRIPTION
This is mostly playing around with embroider, but can't hurt :man_shrugging:

To answer the question everyone will have from the beginning, here's the [RFC about optional peer dependencies](https://emberjs.github.io/rfcs/0507-embroider-v2-package-format.html#optional-peer-dependencies) and the [yarn docs](https://classic.yarnpkg.com/en/docs/package-json#peerdependenciesmeta-).