### PR TITLE
fix(form-builder): replace prismjs with highlight.js

### DIFF
--- a/packages/form-builder/addon/components/cfb-code-editor.js
+++ b/packages/form-builder/addon/components/cfb-code-editor.js
@@ -2,11 +2,14 @@ import { action } from "@ember/object";
 import { addObserver } from "@ember/object/observers";
 import Component from "@glimmer/component";
 import { CodeJar } from "codejar";
-import Prism from "prismjs";
+import hljs from "highlight.js/lib/core";
+import json from "highlight.js/lib/languages/json";
+import markdown from "highlight.js/lib/languages/markdown";
+import jexl from "highlightjs-jexl/src/languages/jexl";
 
-import "prismjs/components/prism-json.js";
-import "prismjs/components/prism-jexl.js";
-import "prismjs/components/prism-markdown.js";
+hljs.registerLanguage("json", json);
+hljs.registerLanguage("markdown", markdown);
+hljs.registerLanguage("jexl", jexl);
 
 export default class CfbCodeEditorComponent extends Component {
   _editor = null;
@@ -54,7 +57,7 @@ export default class CfbCodeEditorComponent extends Component {
 
   @action
   didInsertNode(element) {
-    this._editor = CodeJar(element, (editor) => Prism.highlightElement(editor));
+    this._editor = CodeJar(element, (editor) => hljs.highlightElement(editor));
     this._editor.onUpdate(this.onUpdate);
 
     this.updateCode();

--- a/packages/form-builder/index.js
+++ b/packages/form-builder/index.js
@@ -9,10 +9,4 @@ module.exports = buildEngine({
   lazyLoading: {
     enabled: false,
   },
-
-  included(...args) {
-    this._super.included.apply(this, args);
-
-    this.import("node_modules/prismjs/themes/prism.css");
-  },
 });

--- a/packages/form-builder/package.json
+++ b/packages/form-builder/package.json
@@ -46,8 +46,9 @@
     "ember-validated-form": "^5.3.0",
     "graphql": "^15.8.0",
     "graphql-tag": "^2.12.6",
-    "jexl": "^2.3.0",
-    "prismjs": "^1.27.0"
+    "highlight.js": "^11.5.0",
+    "highlightjs-jexl": "^0.0.5",
+    "jexl": "^2.3.0"
   },
   "//": "TODO: remove ember-data when https://github.com/ember-engines/ember-engines/pull/794 is released",
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8181,9 +8181,8 @@ ember-engines-router-service@^0.3.0:
     ember-cli-babel "^7.18.0"
     ember-cli-htmlbars "^5.1.1"
 
-ember-engines@0.8.20, "ember-engines@https://gitpkg.now.sh/ember-engines/ember-engines/packages/ember-engines?4d8a7607ed690053f6e8ab4f35f9dfa543a3697f":
+ember-engines@0.8.20:
   version "0.8.20"
-  uid dba02df86d214d12a4123f6967aebbd23d0b145b
   resolved "https://gitpkg.now.sh/ember-engines/ember-engines/packages/ember-engines?4d8a7607ed690053f6e8ab4f35f9dfa543a3697f#dba02df86d214d12a4123f6967aebbd23d0b145b"
   dependencies:
     "@embroider/macros" "^1.3.0"
@@ -10752,6 +10751,16 @@ highlight.js@^11.4.0:
   version "11.4.0"
   resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.4.0.tgz#34ceadd49e1596ee5aba3d99346cdfd4845ee05a"
   integrity sha512-nawlpCBCSASs7EdvZOYOYVkJpGmAOKMYZgZtUqSRqodZE0GRVcFKwo1RcpeOemqh9hyttTdd5wDBwHkuSyUfnA==
+
+highlight.js@^11.5.0:
+  version "11.5.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.5.0.tgz#00abb7ed926491adbdabc93a4f3fd2b88b451b4a"
+  integrity sha512-SM6WDj5/C+VfIY8pZ6yW6Xa0Fm1tniYVYWYW1Q/DcMnISZFrC3aQAZZZFAAZtybKNrGId3p/DNbFTtcTXXgYBw==
+
+highlightjs-jexl@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/highlightjs-jexl/-/highlightjs-jexl-0.0.5.tgz#5b00dd3cf6654b950138386eb77ea1f7366b5441"
+  integrity sha512-3zuT/nc0/sn+YiDU9ztC4EiHO8FN5IUcvMhprbNET554vym+guPa2pzHb+Vg1VRIYz8jW0vtfL/agAMoswj1nA==
 
 hmac-drbg@^1.0.1:
   version "1.0.1"
@@ -14769,11 +14778,6 @@ printf@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/printf/-/printf-0.6.1.tgz#b9afa3d3b55b7f2e8b1715272479fc756ed88650"
   integrity sha512-is0ctgGdPJ5951KulgfzvHGwJtZ5ck8l042vRkV6jrkpBzTmb/lueTqguWHy2JfVA+RY6gFVlaZgUS0j7S/dsw==
-
-prismjs@^1.27.0:
-  version "1.27.0"
-  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.27.0.tgz#bb6ee3138a0b438a3653dd4d6ce0cc6510a45057"
-  integrity sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==
 
 private@^0.1.6, private@^0.1.8:
   version "0.1.8"


### PR DESCRIPTION
This is to prevent them from clashing in the addon docs, as they use the
same tags.

How the form-builder editors with highlighting look like now
![image](https://user-images.githubusercontent.com/30687616/161007249-86183a21-7a51-4b54-9375-f00fd000a086.png)
![image](https://user-images.githubusercontent.com/30687616/161007425-fdae0a84-8fa5-4117-808f-fa075ad8f220.png)

fixes #1864 