### PR TITLE
feat(distribution): enable completing the distribution

### DIFF
--- a/packages/-ember-caluma/package.json
+++ b/packages/-ember-caluma/package.json
@@ -15,7 +15,7 @@
     "@ember/jquery": "2.0.0",
     "@ember/optional-features": "2.0.0",
     "@embroider/macros": "1.5.0",
-    "@faker-js/faker": "6.1.1",
+    "@faker-js/faker": "6.1.2",
     "@glimmer/component": "1.1.0",
     "@glimmer/tracking": "1.1.0",
     "@projectcaluma/ember-analytics": "0.0.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -38,7 +38,7 @@
     "@ember/test-helpers": "2.6.0",
     "@embroider/test-setup": "1.5.0",
     "@embroider/util": "^1.5.0",
-    "@faker-js/faker": "6.1.1",
+    "@faker-js/faker": "6.1.2",
     "@glimmer/component": "1.1.0",
     "@projectcaluma/ember-testing": "11.0.0-beta.5",
     "broccoli-asset-rev": "3.0.0",

--- a/packages/distribution/addon/components/cd-navigation/controls.hbs
+++ b/packages/distribution/addon/components/cd-navigation/controls.hbs
@@ -20,7 +20,9 @@
     <CdIconButton
       @icon="lock-closed-outline"
       @fromSvgJar={{true}}
-      @onClick={{this.noop}}
+      @onClick={{perform this.completeDistribution}}
+      @loading={{this.completeDistribution.isRunning}}
+      data-test-complete-distribution
     />
   {{/if}}
 </div>

--- a/packages/distribution/addon/gql/mutations/complete-work-item.graphql
+++ b/packages/distribution/addon/gql/mutations/complete-work-item.graphql
@@ -1,0 +1,8 @@
+mutation CompleteWorkItem($workItem: ID!) {
+  completeWorkItem(input: { id: $workItem }) {
+    workItem {
+      id
+      status
+    }
+  }
+}

--- a/packages/distribution/addon/gql/queries/incomplete-inquiries.graphql
+++ b/packages/distribution/addon/gql/queries/incomplete-inquiries.graphql
@@ -1,0 +1,13 @@
+query InquiryIncomplete($caseId: ID!, $task: ID!) {
+  allWorkItems(
+    filter: [
+      { case: $caseId }
+      { task: $task }
+      { status: CANCELED, invert: true }
+      { status: COMPLETED, invert: true }
+      { status: SKIPPED, invert: true }
+    ]
+  ) {
+    totalCount
+  }
+}

--- a/packages/distribution/package.json
+++ b/packages/distribution/package.json
@@ -50,7 +50,7 @@
     "@ember/optional-features": "2.0.0",
     "@ember/test-helpers": "2.6.0",
     "@embroider/test-setup": "1.5.0",
-    "@faker-js/faker": "6.1.1",
+    "@faker-js/faker": "6.1.2",
     "@projectcaluma/ember-testing": "11.0.0-beta.5",
     "broccoli-asset-rev": "3.0.0",
     "ember-cli": "3.28.5",

--- a/packages/distribution/translations/de.yaml
+++ b/packages/distribution/translations/de.yaml
@@ -4,7 +4,12 @@ caluma:
     start: "Starten"
     send: "Offene Anfragen versenden"
     send-confirm: "Wollen Sie wirklich alle offenen Anfragen versenden?"
+    complete-confirm:
+      "Es gibt noch <b>{count} offene {count, plural, =1 {Anfrage} other {Anfragen}}</b>
+      in der aktuellen Zirkulation. Wenn Sie die Zirkulation abschliessen, werden
+      alle verbleibenden offenen Anfragen abgebrochen. Möchten Sie fortfahren?"
     send-error: "Fehler beim Versenden der offenen Anfragen"
+    complete-error: "Fehler beim Abschliessen der Zirkulation"
 
     edit:
       title: "Anfrage bearbeiten"

--- a/packages/distribution/translations/en.yaml
+++ b/packages/distribution/translations/en.yaml
@@ -4,7 +4,13 @@ caluma:
     start: "Start"
     send: "Send pending inquiries"
     send-confirm: "Do you really want to send all pending inquiries?"
+    complete-confirm:
+      "There {count, plural, =1 {is} other {are}} <b>{count} pending
+      {count, plural, =1 {inquiry} other {inquiries}}</b> on the current
+      distribution. Completing the distribution will cause all remaining
+      pending inquiries to be canceled. Would you like to continue?"
     send-error: "Error while sending pending inquiries"
+    complete-error: "Error while completing distribution"
 
     edit:
       title: "Edit inquiry"

--- a/packages/distribution/translations/fr.yaml
+++ b/packages/distribution/translations/fr.yaml
@@ -4,7 +4,12 @@ caluma:
     start: "Lancer"
     send: "Envoyer les demandes ouvertes"
     send-confirm: "Voulez-vous vraiment envoyer toutes les demandes ouvertes ?"
+    complete-confirm:
+      "Il y a <b>{count} {count, plural, =1 {demande} other {demandes}} en
+      attente</b> sur la distribution actuelle. Si vous terminez la distribution,
+      toutes les demandes en attente seront annulées. Voulez-vous continuer ?"
     send-error: "Erreur lors de l'envoi des demandes ouvertes"
+    complete-error: "Erreur lors de la terminaison de la distribution"
 
     edit:
       title: "Modifier la demande"

--- a/packages/form-builder/package.json
+++ b/packages/form-builder/package.json
@@ -55,7 +55,7 @@
     "@ember/optional-features": "2.0.0",
     "@ember/test-helpers": "2.6.0",
     "@embroider/test-setup": "1.5.0",
-    "@faker-js/faker": "6.1.1",
+    "@faker-js/faker": "6.1.2",
     "@projectcaluma/ember-testing": "11.0.0-beta.5",
     "broccoli-asset-rev": "3.0.0",
     "ember-autoresize-modifier": "^0.5.0",

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -47,7 +47,7 @@
     "@ember/optional-features": "2.0.0",
     "@ember/test-helpers": "2.6.0",
     "@embroider/test-setup": "1.5.0",
-    "@faker-js/faker": "6.1.1",
+    "@faker-js/faker": "6.1.2",
     "@projectcaluma/ember-testing": "11.0.0-beta.5",
     "@projectcaluma/ember-workflow": "11.0.0-beta.6",
     "broccoli-asset-rev": "3.0.0",

--- a/packages/testing/addon/mirage-graphql/mocks/work-item.js
+++ b/packages/testing/addon/mirage-graphql/mocks/work-item.js
@@ -101,6 +101,14 @@ export default class WorkItemMock extends BaseMock {
         status: "READY",
         addressedGroups: workItem.addressedGroups,
       });
+    } else if (taskId === "complete-distribution") {
+      this.collection
+        .where({ caseId, status: "READY" })
+        .update({ status: "CANCELED" });
+
+      this.collection
+        .where({ caseId, status: "SUSPENDED" })
+        .update({ status: "CANCELED" });
     }
 
     return this.handleSavePayload.fn.call(this, _, {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@ember/string": "^3.0.0",
-    "@faker-js/faker": "^6.1.1",
+    "@faker-js/faker": "^6.1.2",
     "broccoli-funnel": "^3.0.8",
     "broccoli-merge-trees": "^4.2.0",
     "ember-apollo-client": "^4.0.2",

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -33,7 +33,7 @@
     "@ember/optional-features": "2.0.0",
     "@ember/test-helpers": "2.6.0",
     "@embroider/test-setup": "1.5.0",
-    "@faker-js/faker": "6.1.1",
+    "@faker-js/faker": "6.1.2",
     "@glimmer/tracking": "1.1.0",
     "@projectcaluma/ember-testing": "11.0.0-beta.5",
     "broccoli-asset-rev": "3.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1532,10 +1532,10 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@faker-js/faker@6.1.1", "@faker-js/faker@^6.1.1":
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-6.1.1.tgz#adf002d986e1751daadfcf65d1cc03944dab3ced"
-  integrity sha512-8yq1LJVGn4GY06riLddIU1LbJm15yjt46hjfkpWNpH/mqdciPOBVzicKOJxzQNrGgVHVBxcdm7sgwjI/Y19MYw==
+"@faker-js/faker@6.1.2", "@faker-js/faker@^6.1.2":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-6.1.2.tgz#7093ea65e6d78eae388918a46968c083366bd621"
+  integrity sha512-QSvmexHCxeRUk1/yKmoEDaWB5Hohjvtim5g2JJwy8S/l0L4b3y/GxSpE6vN4SBoVGGahEQW21uqyRr7EofI35A==
 
 "@formatjs/ecma402-abstract@1.11.3":
   version "1.11.3"
@@ -8183,7 +8183,6 @@ ember-engines-router-service@^0.3.0:
 
 ember-engines@0.8.20, "ember-engines@https://gitpkg.now.sh/ember-engines/ember-engines/packages/ember-engines?4d8a7607ed690053f6e8ab4f35f9dfa543a3697f":
   version "0.8.20"
-  uid dba02df86d214d12a4123f6967aebbd23d0b145b
   resolved "https://gitpkg.now.sh/ember-engines/ember-engines/packages/ember-engines?4d8a7607ed690053f6e8ab4f35f9dfa543a3697f#dba02df86d214d12a4123f6967aebbd23d0b145b"
   dependencies:
     "@embroider/macros" "^1.3.0"


### PR DESCRIPTION
Add functionality to complete the running distribution.
If incomplete inquiries (ready or suspended) remain on
the current distribution, a confirmation dialog will
appear. Add side effects in mirage-graphql to cancel
all remaining incomplete inquiries.