### PR TITLE
feat(distribution): enable reminders for overdue inquiries

### DIFF
--- a/packages/-ember-caluma/app/services/caluma-options.js
+++ b/packages/-ember-caluma/app/services/caluma-options.js
@@ -1,4 +1,5 @@
 import { inject as service } from "@ember/service";
+import fetch from "fetch";
 
 import CalumaOptionsService from "@projectcaluma/ember-core/services/caluma-options";
 import DummyOneComponent from "ember-caluma/components/dummy-one";
@@ -87,5 +88,11 @@ export default class CustomCalumaOptionsService extends CalumaOptionsService {
       }),
       {}
     );
+  }
+
+  async sendReminderDistributionInquiry(inquiryId) {
+    await fetch(`/${inquiryId}/send-reminder`, {
+      method: "POST",
+    });
   }
 }

--- a/packages/-ember-caluma/mirage/config.js
+++ b/packages/-ember-caluma/mirage/config.js
@@ -1,4 +1,5 @@
 import { discoverEmberDataModels } from "ember-cli-mirage";
+import { DateTime } from "luxon";
 import { createServer, Response } from "miragejs";
 
 import graphqlHandler from "@projectcaluma/ember-testing/mirage-graphql";
@@ -38,6 +39,17 @@ export default function makeServer(config) {
             (!types || types.split(",").includes(group.type?.name))
           );
         });
+      });
+
+      this.post(":inquiryId/send-reminder", ({ workItems }, request) => {
+        const inquiry = workItems.find(request.params.inquiryId);
+        inquiry.update("meta", {
+          reminders: [
+            DateTime.now().toJSDate(),
+            ...(inquiry.meta.reminders ?? []),
+          ],
+        });
+        return new Response(200);
       });
 
       this.passthrough();

--- a/packages/core/addon/services/caluma-options.js
+++ b/packages/core/addon/services/caluma-options.js
@@ -66,6 +66,18 @@ export default class CalumaOptionsService extends Service {
     return Object.values(this._overrides);
   }
 
+  /**
+   * Defines the behavior used when sending a reminder for
+   * an overdue inquiry. It should at least update the meta
+   * data on the inquiry work-item to update the reminder
+   * history and perform any application-specific behavior
+   * to send reminder notifications.
+   *
+   * @method sendReminderDistributionInquiry
+   * @param {String} inquiryId
+   */
+  async sendReminderDistributionInquiry() {}
+
   groupIdentifierProperty = "id";
   groupNameProperty = "name";
   resolveGroups(identifiers) {

--- a/packages/distribution/addon/components/cd-inquiry-dialog/inquiry-part.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-dialog/inquiry-part.hbs
@@ -85,6 +85,39 @@
         </li>
       {{/if}}
     {{/unless}}
+    {{#if (can "send reminder inquiry" @inquiry)}}
+      <li>
+        <a
+          data-test-send-reminder
+          href=""
+          {{on "click" (perform this.sendReminder)}}
+        >
+          {{t "caluma.distribution.reminder.link"}}
+        </a>
+        <div
+          uk-dropdown="mode: hover; pos: bottom"
+          class="uk-padding-small uk-width-small"
+        >
+          <div class="uk-text-center uk-text-bold uk-margin-small-bottom">
+            {{t "caluma.distribution.reminder.title"}}
+          </div>
+          {{#if @inquiry.meta.reminders}}
+            <div class="uk-height-max-small uk-overflow-auto">
+              {{#each @inquiry.meta.reminders as |reminder|}}
+                <div class="uk-text-center uk-text-small uk-text-muted">
+                  {{format-date reminder}}
+                  {{format-time reminder hour="2-digit" minute="2-digit"}}
+                </div>
+              {{/each}}
+            </div>
+          {{else}}
+            <div class="uk-text-center">
+              {{t "caluma.distribution.reminder.no-reminders"}}
+            </div>
+          {{/if}}
+        </div>
+      </li>
+    {{/if}}
   </ul>
 
   {{#if this.requestInfo}}

--- a/packages/distribution/addon/config.js
+++ b/packages/distribution/addon/config.js
@@ -69,6 +69,7 @@ export default function config(target, property) {
             },
           },
           permissions: {},
+          enableReminders: true,
         },
         getOwner(this).lookup("service:calumaOptions")?.distribution ?? {}
       );

--- a/packages/distribution/addon/gql/fragments/inquiry.graphql
+++ b/packages/distribution/addon/gql/fragments/inquiry.graphql
@@ -72,6 +72,7 @@ fragment InquiryDialog on WorkItem {
     id
     slug
   }
+  meta
   document {
     ...InquiryRequest
   }

--- a/packages/distribution/addon/gql/queries/inquiry-meta.graphql
+++ b/packages/distribution/addon/gql/queries/inquiry-meta.graphql
@@ -1,0 +1,10 @@
+query InquiryMeta($inquiry: ID!) {
+  allWorkItems(filter: [{ id: $inquiry }]) {
+    edges {
+      node {
+        id
+        meta
+      }
+    }
+  }
+}

--- a/packages/distribution/addon/utils/inquiry-deadline.js
+++ b/packages/distribution/addon/utils/inquiry-deadline.js
@@ -21,7 +21,7 @@ function decorator(
       const value = inquiry.document?.deadline.edges[0]?.node.value;
       const isDone = ["COMPLETED", "SKIPPED"].includes(inquiry.status);
 
-      const { days: diff } = DateTime.fromISO(value).diffNow("days").toObject();
+      const diff = DateTime.fromISO(value).diffNow("days").days;
 
       const isOverdue = !isDone && diff <= 0;
       const isWarning = !isDone && diff <= this.config.warningPeriod;

--- a/packages/distribution/tests/helpers/inquiry.js
+++ b/packages/distribution/tests/helpers/inquiry.js
@@ -20,6 +20,7 @@ class StubInquiry {
   }
 
   task = { slug: "inquiry" };
+  id = "18bedff9-796f-4946-8f74-c9081dfb47b7";
 
   constructor({
     deadline = DateTime.now().plus({ days: 5 }).toISODate(),

--- a/packages/distribution/tests/unit/config-test.js
+++ b/packages/distribution/tests/unit/config-test.js
@@ -33,6 +33,7 @@ module("Unit | config", function (hooks) {
         completeTask: "complete-distribution",
         createTask: "create-inquiry",
       },
+      enableReminders: true,
       inquiry: {
         answer: {
           buttons: {

--- a/packages/distribution/translations/de.yaml
+++ b/packages/distribution/translations/de.yaml
@@ -61,6 +61,14 @@ caluma:
       create-draft: "Entwurf erstellen"
       error: "Fehler beim Erstellen der {count, plural, =1 {Anfragen} other {Anfrage}}"
 
+    reminder:
+      link: "Erinnerung versenden"
+      confirm: "Wollen Sie wirklich eine Erinnerung für diese Anfrage versenden?"
+      title: "Versendete Erinnerungen"
+      no-reminders: "Es wurden noch keine Erinnerungen für diese Anfrage versendet."
+      success: "Die Erinnerung wurde erfolgreich versendet"
+      error: "Fehler beim Versenden der Erinnerung"
+
     types:
       controlling: "Angefordert"
       addressed: "Zu beantworten"

--- a/packages/distribution/translations/en.yaml
+++ b/packages/distribution/translations/en.yaml
@@ -62,6 +62,14 @@ caluma:
       create-draft: "Create draft"
       error: "Error while creating the {count, plural, =1 {inquiry} other {inquiries}}"
 
+    reminder:
+      link: "Send reminder"
+      confirm: "Do you really want to send a reminder for this inquiry?"
+      title: "Sent reminders"
+      no-reminders: "No reminders have been sent for this inquiry yet."
+      success: "The reminder has been sent successfully"
+      error: "Error while sending the reminder"
+
     types:
       controlling: "Requested"
       addressed: "To answer"

--- a/packages/distribution/translations/fr.yaml
+++ b/packages/distribution/translations/fr.yaml
@@ -61,6 +61,14 @@ caluma:
       create-draft: "Créer un brouillon"
       error: "Error lors de la création {count, plural, =1 {de la demande} other {des demandes}}"
 
+    reminder:
+      link: "Envoyer un rappel"
+      confirm: "Voulez-vous vraiment envoyer un rappel pour cette demande ?"
+      title: "Rappels envoyés"
+      no-reminders: Aucun rappel n'a encore été envoyé pour cette demande.
+      success: "Le rappel a été envoyé avec succès"
+      error: "Erreur lors de l'envoi du rappel"
+
     types:
       controlling: "Demandé"
       addressed: "A répondre"

--- a/packages/testing/addon/scenarios/distribution.js
+++ b/packages/testing/addon/scenarios/distribution.js
@@ -289,7 +289,7 @@ export default function (server, groups) {
         to: g2,
         deadline: faker.date.past(),
       },
-      { id: "6bbdc36a-3174-4578-93d4-0cb84d3dab97" }
+      { id: "6bbdc36a-3174-4578-93d4-0cb84d3dab97", meta: {} }
     ),
   });
   confirm({


### PR DESCRIPTION
Add a configurable functionality for sending reminders on overdue inquiries. A list of previous reminders are displayed and need to be updated through the meta field on the inquiry.
    
Co-authored-by: Jonas Metzener <jonas.metzener@adfinis.com>