### PR TITLE
feat(distribution): add button to create new inquiry in dialog

### DIFF
--- a/packages/distribution/addon/components/cd-inquiry-dialog.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-dialog.hbs
@@ -1,6 +1,19 @@
 {{#if this._inquiries.isRunning}}
   <div class="uk-text-center"><UkSpinner @ratio={{2}} /></div>
 {{else if this.inquiries.length}}
+  {{#if
+    (and (can "create inquiry of distribution") this.currentGroupIsCreator)
+  }}
+    <div class="uk-text-center uk-margin">
+      <CdIconButton
+        @title={{t "caluma.distribution.new.title"}}
+        @icon="plus"
+        @loading={{this.createInquiry.isRunning}}
+        @onClick={{perform this.createInquiry}}
+        data-test-new-inquiry
+      />
+    </div>
+  {{/if}}
   <section>
     {{#each this.inquiries as |inquiry|}}
       <CdInquiryDialog::Inquiry @inquiry={{inquiry}} />

--- a/packages/distribution/addon/components/cd-inquiry-new-form.js
+++ b/packages/distribution/addon/components/cd-inquiry-new-form.js
@@ -9,7 +9,6 @@ import { useTask } from "ember-resources";
 
 import { decodeId } from "@projectcaluma/ember-core/helpers/decode-id";
 import config from "@projectcaluma/ember-distribution/config";
-import createInquiryMutation from "@projectcaluma/ember-distribution/gql/mutations/create-inquiry.graphql";
 
 const toggle = (value, array) => {
   const set = new Set(array);
@@ -78,45 +77,20 @@ export default class CdInquiryNewFormComponent extends Component {
 
     if (!this.selectedGroups.length) return;
 
-    try {
-      // get create inquiry work item to complete
-      const createId = decodeId(
-        this.distribution.controls.value?.create.edges[0].node.id
-      );
+    yield this.distribution.createInquiry.perform(this.selectedGroups);
 
-      // create new inquiries
-      yield this.apollo.mutate({
-        mutation: createInquiryMutation,
-        variables: {
-          id: createId,
-          context: JSON.stringify({
-            addressed_groups: this.selectedGroups.map(String),
-          }),
-        },
-      });
+    const lastControlling =
+      this.distribution.navigation.value.controlling.edges[0].node;
 
-      // refetch navigation and controls data
-      yield this.distribution.refetch();
-
-      const lastControlling =
-        this.distribution.navigation.value.controlling.edges[0].node;
-
-      // transition to last added inquiry
-      this.router.transitionTo(
-        "inquiry.detail.index",
-        {
-          from: lastControlling.controllingGroups[0],
-          to: lastControlling.addressedGroups[0],
-        },
-        decodeId(lastControlling.id)
-      );
-    } catch (e) {
-      this.notification.danger(
-        this.intl.t("caluma.distribution.new.error", {
-          count: this.selectedGroups.length,
-        })
-      );
-    }
+    // transition to last added inquiry
+    this.router.transitionTo(
+      "inquiry.detail.index",
+      {
+        from: lastControlling.controllingGroups[0],
+        to: lastControlling.addressedGroups[0],
+      },
+      decodeId(lastControlling.id)
+    );
   }
 
   @task

--- a/packages/distribution/addon/components/cd-navigation/controls.hbs
+++ b/packages/distribution/addon/components/cd-navigation/controls.hbs
@@ -1,6 +1,10 @@
 <div class="uk-text-center uk-margin-small-top">
   {{#if (can "create inquiry of distribution")}}
-    <CdIconButton @route="new" @icon="plus" />
+    <CdIconButton
+      @title={{t "caluma.distribution.new.title"}}
+      @icon="plus"
+      @route="new"
+    />
   {{/if}}
   {{#if (can "send inquiries of distribution")}}
     <CdIconButton


### PR DESCRIPTION
This adds a button to create a new inquiry for the target group of the current dialog directly in the dialog itself.