### PR TITLE
feat(distribution): improve edit and answer inquiry UI and UX

### DIFF
--- a/packages/distribution/addon/components/cd-document-header.hbs
+++ b/packages/distribution/addon/components/cd-document-header.hbs
@@ -1,0 +1,20 @@
+<p class="uk-text-large uk-margin-remove">
+  {{@name}}
+  {{#if @isDraft}}
+    <UkLabel
+      @label={{t "caluma.distribution.status.draft"}}
+      class="uk-margin-left"
+    />
+  {{/if}}
+</p>
+
+{{#if (and @modifiedBy @modifiedAt)}}
+  <p class="uk-text-meta uk-margin-remove-bottom uk-margin-small-top">
+    {{t
+      "caluma.distribution.last-modified"
+      user=(user-name @modifiedBy)
+      date=(format-date @modifiedAt)
+      time=(format-time @modifiedAt hour="2-digit" minute="2-digit")
+    }}
+  </p>
+{{/if}}

--- a/packages/distribution/addon/components/cd-inquiry-answer-form.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-answer-form.hbs
@@ -4,15 +4,32 @@
   @loading={{this._inquiry.isRunning}}
 >
   <:default as |content|>
-    <h1 class="uk-flex uk-flex-middle">
-      {{t "caluma.distribution.answer.title"}}
-      {{#if (eq this.inquiry.status "RUNNING")}}
-        <UkLabel
-          class="uk-margin-left"
-          @label={{t "caluma.distribution.status.draft"}}
-        />
-      {{/if}}
-    </h1>
+
+    <div class="uk-position-relative">
+      <CdDocumentHeader
+        @name={{content.document.rootForm.raw.name}}
+        @isDraft={{eq this.inquiry.status "READY"}}
+        @modifiedAt={{this.inquiry.childCase.document.modifiedContentAt}}
+        @modifiedBy={{this.inquiry.childCase.document.modifiedContentByUser}}
+      />
+
+      <CdInquiryDialog::InquiryDeadline
+        @inquiry={{this.inquiry}}
+        class="uk-margin-remove uk-position-center-right"
+      />
+    </div>
+
+    <hr />
+
+    <div
+      class="uk-padding uk-padding-remove-vertical uk-padding-remove-right uk-margin uk-text-italic inquiry-answer-form__request"
+    >
+      <CdInquiryDialog::InquiryPart
+        @inquiry={{this.inquiry}}
+        @type="request"
+        @disabled={{true}}
+      />
+    </div>
 
     <content.form />
 
@@ -23,6 +40,7 @@
             @type="submit"
             @color={{buttonConfig.color}}
             @disabled={{or (not isValid) this.completeWorkItem.isRunning}}
+            @loading={{this.completeWorkItem.isRunning}}
             @onClick={{fn
               (perform this.completeWorkItem)
               buttonConfig.workItemId
@@ -35,6 +53,7 @@
           @type="button"
           @color={{buttonConfig.color}}
           @disabled={{this.completeWorkItem.isRunning}}
+          @loading={{this.completeWorkItem.isRunning}}
           @onClick={{fn
             (perform this.completeWorkItem)
             buttonConfig.workItemId

--- a/packages/distribution/addon/components/cd-inquiry-answer-form.js
+++ b/packages/distribution/addon/components/cd-inquiry-answer-form.js
@@ -45,6 +45,8 @@ export default class CdInquiryAnswerFormComponent extends Component {
         variables: {
           inquiry: this.args.inquiry,
           buttonTasks: Object.keys(this.config.inquiry.answer.buttons),
+          infoQuestion: this.config.inquiry.infoQuestion,
+          deadlineQuestion: this.config.inquiry.deadlineQuestion,
         },
       },
       "allWorkItems.edges"

--- a/packages/distribution/addon/components/cd-inquiry-dialog/inquiry-deadline.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-dialog/inquiry-deadline.hbs
@@ -12,6 +12,7 @@
         (concat 'uk-text-' this.deadline.color)
       }}
       uk-flex-inline uk-flex-middle"
+    ...attributes
   >
     {{svg-jar
       (if this.isWithdrawn "ban-outline" "alarm-outline")

--- a/packages/distribution/addon/components/cd-inquiry-dialog/inquiry-part.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-dialog/inquiry-part.hbs
@@ -1,49 +1,69 @@
-<p class="uk-flex uk-flex-middle uk-text-large uk-margin-remove">
-  {{#if (eq @type "request")}}
-    {{svg-jar "arrow-redo-outline" height=24 class="uk-margin-small-right"}}
-    {{group-name @inquiry.controllingGroups}}
-  {{else if (eq @type "answer")}}
-    {{svg-jar "arrow-undo-outline" height=24 class="uk-margin-small-right"}}
-    {{group-name @inquiry.addressedGroups}}
-  {{/if}}
-</p>
-
-<ul
-  class="uk-subnav uk-subnav-divider
-    {{if
-      this.config.ui.small
-      'uk-margin-remove-top uk-margin-small-bottom'
-      'uk-margin-small-top'
-    }}"
->
-  <li>
-    <span>
-      {{format-date this.date}}
-      {{format-time this.date hour="2-digit" minute="2-digit"}}
-    </span>
-  </li>
-  {{#if (can "edit inquiry" @inquiry)}}
-    <li>
-      <LinkTo @route="inquiry.detail.index" @model={{decode-id @inquiry.id}}>
-        {{t "caluma.distribution.edit.link"}}
-      </LinkTo>
-    </li>
-    <li>
-      <a href="" {{on "click" (perform this.withdraw)}} data-test-withdraw>
-        {{t "caluma.distribution.withdraw.link"}}
-      </a>
-    </li>
-  {{/if}}
-  {{#if (can "answer inquiry" @inquiry)}}
-    <li>
-      <LinkTo @route="inquiry.detail.answer" @model={{decode-id @inquiry.id}}>
-        {{t "caluma.distribution.answer.link"}}
-      </LinkTo>
-    </li>
-  {{/if}}
-</ul>
-
 <div class="uk-margin-remove-last-child">
+  <p class="uk-flex uk-flex-middle uk-text-large uk-margin-remove">
+    {{#if (eq @type "request")}}
+      {{svg-jar "arrow-redo-outline" height=24 class="uk-margin-small-right"}}
+      {{group-name @inquiry.controllingGroups}}
+    {{else if (eq @type "answer")}}
+      {{svg-jar "arrow-undo-outline" height=24 class="uk-margin-small-right"}}
+      {{group-name @inquiry.addressedGroups}}
+    {{/if}}
+  </p>
+
+  <ul
+    class="uk-subnav uk-subnav-divider
+      {{if
+        this.config.ui.small
+        'uk-margin-remove-top uk-margin-small-bottom'
+        'uk-margin-small-top'
+      }}"
+  >
+    <li>
+      <span>
+        {{format-date this.date}}
+        {{format-time this.date hour="2-digit" minute="2-digit"}}
+      </span>
+    </li>
+    {{#unless @disabled}}
+      {{#if (or (eq @type "answer") (cannot "edit inquiry" @inquiry))}}
+        <li>
+          <LinkTo
+            data-test-details
+            @route="inquiry.detail.{{if (eq @type 'answer') 'answer' 'index'}}"
+            @model={{decode-id @inquiry.id}}
+          >
+            {{t "caluma.distribution.details"}}
+          </LinkTo>
+        </li>
+      {{/if}}
+      {{#if (can "edit inquiry" @inquiry)}}
+        <li>
+          <LinkTo
+            data-test-edit
+            @route="inquiry.detail.index"
+            @model={{decode-id @inquiry.id}}
+          >
+            {{t "caluma.distribution.edit.link"}}
+          </LinkTo>
+        </li>
+        <li>
+          <a href="" {{on "click" (perform this.withdraw)}} data-test-withdraw>
+            {{t "caluma.distribution.withdraw.link"}}
+          </a>
+        </li>
+      {{else if (can "answer inquiry" @inquiry)}}
+        <li>
+          <LinkTo
+            data-test-answer
+            @route="inquiry.detail.answer"
+            @model={{decode-id @inquiry.id}}
+          >
+            {{t "caluma.distribution.answer.link"}}
+          </LinkTo>
+        </li>
+      {{/if}}
+    {{/unless}}
+  </ul>
+
   {{#if this.requestInfo}}
     <CdTruncated
       data-test-inquiry-request

--- a/packages/distribution/addon/components/cd-inquiry-edit-form.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-edit-form.hbs
@@ -4,26 +4,28 @@
   @loading={{this._inquiry.isRunning}}
 >
   <:default as |content|>
-    <h1 class="uk-flex uk-flex-middle">
-      {{t "caluma.distribution.edit.title"}}
-      {{#if (eq this.inquiry.status "RUNNING")}}
-        <UkLabel
-          class="uk-margin-left"
-          @label={{t "caluma.distribution.status.draft"}}
-        />
-      {{/if}}
-    </h1>
+    <CdDocumentHeader
+      @name={{content.document.rootForm.raw.name}}
+      @isDraft={{eq this.inquiry.status "SUSPENDED"}}
+      @modifiedAt={{this.inquiry.document.modifiedContentAt}}
+      @modifiedBy={{this.inquiry.document.modifiedContentByUser}}
+    />
+
+    <hr />
 
     <content.form />
 
-    <DocumentValidity @document={{content.document}} as |isValid validate|>
-      <UkButton
-        @type="submit"
-        @color="primary"
-        @disabled={{or (not isValid) this.send.isRunning}}
-        @onClick={{perform this.send validate}}
-      >{{t "caluma.distribution.edit.send"}}</UkButton>
-    </DocumentValidity>
+    {{#if (can "edit inquiry" this.inquiry)}}
+      <DocumentValidity @document={{content.document}} as |isValid validate|>
+        <UkButton
+          @type="submit"
+          @color="primary"
+          @disabled={{or (not isValid) this.send.isRunning}}
+          @onClick={{perform this.send validate}}
+          @loading={{this.send.isRunning}}
+        >{{t "caluma.distribution.edit.send"}}</UkButton>
+      </DocumentValidity>
+    {{/if}}
   </:default>
   <:notfound><CdNotfound /></:notfound>
 </CfContent>

--- a/packages/distribution/addon/components/cd-inquiry-new-form.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-new-form.hbs
@@ -1,7 +1,9 @@
 {{#if this.controls.workItems.isRunning}}
   <div class="uk-text-center"><UkSpinner @ratio={{2}} /></div>
 {{else if (can "create inquiry of distribution")}}
-  <h1>{{t "caluma.distribution.new.title"}}</h1>
+  <p class="uk-text-large">{{t "caluma.distribution.new.title"}}</p>
+
+  <hr />
 
   {{#if this.selectedGroups.length}}
     <div class="uk-flex uk-flex-middle">

--- a/packages/distribution/addon/gql/fragments/inquiry.graphql
+++ b/packages/distribution/addon/gql/fragments/inquiry.graphql
@@ -30,6 +30,21 @@ fragment InquiryStatusDocument on Document {
   }
 }
 
+fragment InquiryRequest on Document {
+  id
+  ...InquiryDeadlineDocument
+  info: answers(question: $infoQuestion) {
+    edges {
+      node {
+        id
+        ... on StringAnswer {
+          value
+        }
+      }
+    }
+  }
+}
+
 fragment InquiryDialog on WorkItem {
   id
   addressedGroups
@@ -42,17 +57,7 @@ fragment InquiryDialog on WorkItem {
     slug
   }
   document {
-    ...InquiryDeadlineDocument
-    info: answers(question: $infoQuestion) {
-      edges {
-        node {
-          id
-          ... on StringAnswer {
-            value
-          }
-        }
-      }
-    }
+    ...InquiryRequest
   }
   childCase {
     id

--- a/packages/distribution/addon/gql/queries/inquiry-answer.graphql
+++ b/packages/distribution/addon/gql/queries/inquiry-answer.graphql
@@ -1,19 +1,33 @@
-query InquiryAnswer($inquiry: ID!, $buttonTasks: [String]!) {
+#import InquiryDeadlineDocument, InquiryRequest from '../fragments/inquiry.graphql'
+
+query InquiryAnswer(
+  $inquiry: ID!
+  $buttonTasks: [String]!
+  $infoQuestion: ID!
+  $deadlineQuestion: ID!
+) {
   allWorkItems(filter: [{ id: $inquiry }]) {
     edges {
       node {
         id
         status
         addressedGroups
+        controllingGroups
+        createdAt
         task {
           id
           slug
+        }
+        document {
+          ...InquiryRequest
         }
         childCase {
           id
           status
           document {
             id
+            modifiedContentAt
+            modifiedContentByUser
           }
           workItems(tasks: $buttonTasks, status: READY) {
             edges {

--- a/packages/distribution/addon/gql/queries/inquiry-dialog.graphql
+++ b/packages/distribution/addon/gql/queries/inquiry-dialog.graphql
@@ -1,4 +1,4 @@
-#import InquiryDialog, InquiryDeadlineDocument, InquiryStatusDocument from '../fragments/inquiry.graphql'
+#import InquiryDialog, InquiryDeadlineDocument, InquiryStatusDocument, InquiryRequest from '../fragments/inquiry.graphql'
 
 query InquiryDialog(
   $task: ID!

--- a/packages/distribution/addon/gql/queries/inquiry-edit.graphql
+++ b/packages/distribution/addon/gql/queries/inquiry-edit.graphql
@@ -11,6 +11,8 @@ query InquiryEdit($inquiry: ID!) {
         }
         document {
           id
+          modifiedContentAt
+          modifiedContentByUser
         }
       }
     }

--- a/packages/distribution/app/components/cd-document-header.js
+++ b/packages/distribution/app/components/cd-document-header.js
@@ -1,0 +1,1 @@
+export { default } from "@projectcaluma/ember-distribution/components/cd-document-header";

--- a/packages/distribution/app/styles/@projectcaluma/ember-distribution.scss
+++ b/packages/distribution/app/styles/@projectcaluma/ember-distribution.scss
@@ -1,3 +1,4 @@
+@import "../answer-form";
 @import "../icon-button";
 @import "../inquiry-divider";
 @import "../status-indicator";

--- a/packages/distribution/app/styles/_answer-form.scss
+++ b/packages/distribution/app/styles/_answer-form.scss
@@ -1,0 +1,3 @@
+.inquiry-answer-form__request {
+  border-left: 5px solid $global-border;
+}

--- a/packages/distribution/tests/integration/components/cd-document-header-test.js
+++ b/packages/distribution/tests/integration/components/cd-document-header-test.js
@@ -1,0 +1,44 @@
+import { render } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { setupIntl } from "ember-intl/test-support";
+import { setupRenderingTest } from "ember-qunit";
+import { module, test } from "qunit";
+
+module("Integration | Component | cd-document-header", function (hooks) {
+  setupRenderingTest(hooks);
+  setupIntl(hooks);
+
+  test("it renders", async function (assert) {
+    this.isDraft = true;
+    this.modifiedAt = new Date(2022, 4, 3, 14, 43);
+    this.modifiedBy = 1;
+
+    await render(hbs`
+      <CdDocumentHeader
+        @name="Test"
+        @isDraft={{this.isDraft}}
+        @modifiedAt={{this.modifiedAt}}
+        @modifiedBy={{this.modifiedBy}}
+      />
+    `);
+
+    assert.dom("p.uk-text-large").containsText("Test");
+    assert
+      .dom("p.uk-text-large .uk-label")
+      .hasText("t:caluma.distribution.status.draft:()");
+
+    assert
+      .dom("p.uk-text-meta")
+      .hasText(
+        't:caluma.distribution.last-modified:("date":"5/3/2022","time":"02:43 PM","user":1)'
+      );
+
+    this.set("isDraft", false);
+
+    assert.dom("p.uk-text-large .uk-label").doesNotExist();
+
+    this.set("modifiedBy", null);
+
+    assert.dom("p.uk-text-meta").doesNotExist();
+  });
+});

--- a/packages/distribution/tests/integration/components/cd-inquiry-answer-form-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-answer-form-test.js
@@ -41,7 +41,9 @@ module("Integration | Component | cd-inquiry-answer-form", function (hooks) {
   test("it renders an inquiry answer form with a button for each ready work item", async function (assert) {
     await render(hbs`<CdInquiryAnswerForm @inquiry={{this.inquiry.id}} />`);
 
-    assert.dom("h1").hasText("t:caluma.distribution.answer.title:()");
+    assert
+      .dom("p.uk-text-large")
+      .hasText("Inquiry answer t:caluma.distribution.status.draft:()");
     assert.dom("form").exists();
     assert
       .dom("button.uk-button-primary")

--- a/packages/distribution/tests/integration/components/cd-inquiry-dialog/inquiry-part-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-dialog/inquiry-part-test.js
@@ -78,18 +78,21 @@ module(
         hbs`<CdInquiryDialog::InquiryPart @inquiry={{this.inquiry}} @type={{this.type}} />`
       );
 
-      assert.dom("ul.uk-subnav > li:nth-of-type(2)").doesNotExist();
+      assert.dom("ul.uk-subnav > li > a[data-test-edit]").doesNotExist();
+      assert.dom("ul.uk-subnav > li > a[data-test-details]").exists();
 
       this.owner.lookup("service:caluma-options").currentGroupId =
         "controlling";
 
-      assert.dom("ul.uk-subnav > li:nth-of-type(2)").doesNotExist();
+      assert.dom("ul.uk-subnav > li > a[data-test-edit]").doesNotExist();
+      assert.dom("ul.uk-subnav > li > a[data-test-details]").exists();
 
       await this.inquiry.setSuspended();
 
       assert
-        .dom("ul.uk-subnav > li:nth-of-type(2)")
+        .dom("ul.uk-subnav > li > a[data-test-edit]")
         .hasText("t:caluma.distribution.edit.link:()");
+      assert.dom("ul.uk-subnav > li > a[data-test-details]").doesNotExist();
     });
 
     test("it renders a link for answering the inquiry when permitted", async function (assert) {
@@ -99,17 +102,20 @@ module(
         hbs`<CdInquiryDialog::InquiryPart @inquiry={{this.inquiry}} @type={{this.type}} />`
       );
 
-      assert.dom("ul.uk-subnav > li:nth-of-type(2)").doesNotExist();
+      assert.dom("ul.uk-subnav > li > a[data-test-answer]").doesNotExist();
+      assert.dom("ul.uk-subnav > li > a[data-test-details]").exists();
 
       this.owner.lookup("service:caluma-options").currentGroupId = "addressed";
 
-      assert.dom("ul.uk-subnav > li:nth-of-type(2)").doesNotExist();
+      assert.dom("ul.uk-subnav > li > a[data-test-answer]").doesNotExist();
+      assert.dom("ul.uk-subnav > li > a[data-test-details]").exists();
 
       await this.inquiry.setReady();
 
       assert
-        .dom("ul.uk-subnav > li:nth-of-type(2)")
+        .dom("ul.uk-subnav > li > a[data-test-answer]")
         .hasText("t:caluma.distribution.answer.link:()");
+      assert.dom("ul.uk-subnav > li > a[data-test-details]").exists();
     });
   }
 );

--- a/packages/distribution/tests/integration/components/cd-inquiry-edit-form-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-edit-form-test.js
@@ -33,7 +33,9 @@ module("Integration | Component | cd-inquiry-edit-form", function (hooks) {
   test("it renders an inquiry form with a send button", async function (assert) {
     await render(hbs`<CdInquiryEditForm @inquiry={{this.inquiry.id}} />`);
 
-    assert.dom("h1").hasText("t:caluma.distribution.edit.title:()");
+    assert
+      .dom("p.uk-text-large")
+      .hasText("Inquiry t:caluma.distribution.status.draft:()");
     assert.dom("form").exists();
     assert
       .dom("button.uk-button-primary")

--- a/packages/distribution/translations/de.yaml
+++ b/packages/distribution/translations/de.yaml
@@ -14,17 +14,16 @@ caluma:
     more: "mehr"
     less: "weniger"
 
-    edit:
-      title: "Anfrage bearbeiten"
-      link: "Bearbeiten"
+    last-modified: "Zuletzt bearbeitet von {user} am {date} um {time}"
+    details: "Details"
 
+    edit:
+      link: "Bearbeiten"
       send: "Senden"
       send-error: "Fehler beim Senden der Anfrage"
 
     answer:
-      title: "Anfrage beantworten"
       link: "Beantworten"
-
       release-for-review: "Zur Kontrolle freigeben"
       release-adjustment-for-review: "Anpassung zur Kontrolle freigeben"
       confirm: "Bestätigen"

--- a/packages/distribution/translations/en.yaml
+++ b/packages/distribution/translations/en.yaml
@@ -15,17 +15,16 @@ caluma:
     more: "more"
     less: "less"
 
-    edit:
-      title: "Edit inquiry"
-      link: "Edit"
+    last-modified: "Last modified by {user} on {date} at {time}"
+    details: "Details"
 
+    edit:
+      link: "Edit"
       send: "Send"
       send-error: "Error while sending the inquiry"
 
     answer:
-      title: "Answer inquiry"
       link: "Answer"
-
       release-for-review: "Release for review"
       release-adjustment-for-review: "Release adjustment for review"
       confirm: "Confirm"

--- a/packages/distribution/translations/fr.yaml
+++ b/packages/distribution/translations/fr.yaml
@@ -14,17 +14,16 @@ caluma:
     more: "plus"
     less: "moins"
 
-    edit:
-      title: "Modifier la demande"
-      link: "Modifier"
+    last-modified: "Dernière modification par {user} le {date} à {time}"
+    details: "Détails"
 
+    edit:
+      link: "Modifier"
       send: "Envoyer"
       send-error: "Erreur lors de l'envoi de la demande"
 
     answer:
-      title: "Répondre à la demande"
       link: "Répondre"
-
       release-for-review: "Valider pour vérification"
       release-adjustment-for-review: "Valider la révision pour vérification"
       confirm: "Confirmer"

--- a/packages/testing/addon-mirage-support/factories/document.js
+++ b/packages/testing/addon-mirage-support/factories/document.js
@@ -3,4 +3,6 @@ import { Factory } from "miragejs";
 
 export default Factory.extend({
   id: () => faker.datatype.uuid(),
+  modifiedContentByUser: () => faker.datatype.uuid(),
+  modifiedContentAt: () => faker.date.past(),
 });

--- a/packages/testing/addon/scenarios/distribution.js
+++ b/packages/testing/addon/scenarios/distribution.js
@@ -94,7 +94,10 @@ export function createInquiry(
   { from, to, remark, deadline },
   workItemAttrs = {}
 ) {
-  const document = server.create("document", { formId: "inquiry" });
+  const document = server.create("document", {
+    formId: "inquiry",
+    modifiedContentByUser: "1",
+  });
 
   server.create("answer", {
     document,
@@ -129,7 +132,10 @@ export function sendInquiry(server, { inquiry }) {
   const childCase = server.create("case", {
     status: "RUNNING",
     workflowId: "inquiry",
-    document: server.create("document", { formId: "inquiry-answer" }),
+    document: server.create("document", {
+      formId: "inquiry-answer",
+      modifiedContentByUser: "1",
+    }),
   });
 
   server.create("work-item", {


### PR DESCRIPTION
Answer inquiry with new title design and request as context:
![Screenshot from 2022-05-03 11-33-21](https://user-images.githubusercontent.com/6150577/166433229-a3dafc0c-d24a-4e96-a408-fd4702067010.png)
Edit inquiry with new title design:
![Screenshot from 2022-05-03 11-33-35](https://user-images.githubusercontent.com/6150577/166433231-7b4afcc9-c7f0-4fab-b203-4ef7d858f0ba.png)
New inquiry with new title design:
![Screenshot from 2022-05-03 11-33-53](https://user-images.githubusercontent.com/6150577/166433232-0ef6504e-a8bc-4ea3-a5db-5839a8d22436.png)
Inquiry dialog with new "detail" links for a readonly view of the filled form:
![Screenshot from 2022-05-03 11-34-09](https://user-images.githubusercontent.com/6150577/166433233-a22ade6a-abff-42d6-b00e-03103388c931.png)
