### PR TITLE
fix(distribution): enable pre-processing of category types

### DIFF
--- a/packages/distribution/addon/components/cd-inquiry-new-form.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-new-form.hbs
@@ -50,7 +50,10 @@
   {{/if}}
 
   <div class="uk-margin-bottom uk-button-group">
-    {{#each-in this.config.new.types as |slug config|}}
+    {{#each-in
+      (or this.calumaOptions.types this.config.new.types)
+      as |slug config|
+    }}
       {{#unless config.disabled}}
         <UkButton
           data-test-type={{slug}}

--- a/packages/distribution/addon/controllers/new.js
+++ b/packages/distribution/addon/controllers/new.js
@@ -13,7 +13,7 @@ export default class NewController extends Controller {
 
   @cached
   get selectedTypes() {
-    return this.types.split(",");
+    return this.types.split(",").filter(Boolean);
   }
 
   set selectedTypes(value) {


### PR DESCRIPTION
Allow category types for the displayed groups during inquiry
creation to be pre-processed through the caluma-options service.