### PR TITLE
fix(distribution): refetch inquiry answer after work-item completion

### DIFF
--- a/packages/distribution/addon/components/cd-inquiry-answer-form.js
+++ b/packages/distribution/addon/components/cd-inquiry-answer-form.js
@@ -1,6 +1,6 @@
 import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
-import { queryManager } from "ember-apollo-client";
+import { queryManager, getObservable } from "ember-apollo-client";
 import { dropTask } from "ember-concurrency";
 import { trackedTask } from "ember-resources/util/ember-concurrency";
 
@@ -79,6 +79,7 @@ export default class CdInquiryAnswerFormComponent extends Component {
         },
       });
 
+      yield getObservable(this._inquiry.value)?.refetch();
       yield this.router.transitionTo("inquiry.index");
     } catch (error) {
       this.notification.danger(

--- a/packages/distribution/addon/gql/queries/inquiry-answer.graphql
+++ b/packages/distribution/addon/gql/queries/inquiry-answer.graphql
@@ -14,6 +14,7 @@ query InquiryAnswer(
         addressedGroups
         controllingGroups
         createdAt
+        closedAt
         task {
           id
           slug


### PR DESCRIPTION
Refetch inquiry answer after work-item completion and include
closedAt work-item field in the graphql query to ensure the
completion date is updated correctly in the inquiry answer
dialog.