### PR TITLE
chore: add default pr template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+
+Please include a summary of the change and which issue is fixed. Please provide the motivation for why this change is necessary at this stage of the product development cycle.
+
+Fixes # (issue)
+
+## Depedencies
+
+Does this PR depend on other PRs of the `ember-caluma` or `caluma` repository?
+
+Depends on # (pr)


### PR DESCRIPTION
After an *off the record* discussion, we came to the conclusion that we want to have a PR template, which reminds devs to list dependencies to other pull requests and prevent ill-timed merges.

Most commonly this will be the case for features which have cohesive parts in the `ember-caluma` and the `caluma` repos.