### PR TITLE
fix(form): include disabled options in validation

### DIFF
--- a/packages/form/addon/lib/field.js
+++ b/packages/form/addon/lib/field.js
@@ -799,9 +799,7 @@ export default class Field extends Base {
       : this.selected?.label;
 
     return validate("inclusion", value, {
-      in: (this.options || [])
-        .filter((option) => !option.disabled)
-        .map(({ slug }) => slug),
+      in: (this.options || []).map(({ slug }) => slug),
       allowBlank,
       label: label ?? value,
     });


### PR DESCRIPTION
Include disabled options in validation of checked multiple choice
and choice questions. This allows a successful validation, even
when an option is disabled, after the option has been previously
selected (and therefore can no longer be changed).

![image](https://user-images.githubusercontent.com/32454507/180238271-309290d6-cc99-4205-ba13-afbbaa27eb07.png)
