### PR TITLE
fix(deps): resolve dep issue of ember-cli-addon-docs and tracked-toolbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,10 +56,12 @@
     "semver": "7.3.7"
   },
   "//": [
-    "TODO: remove validated-changeset resolution when https://github.com/poteto/ember-changeset/issues/650 is addressed"
+    "TODO: remove validated-changeset resolution when https://github.com/poteto/ember-changeset/issues/650 is addressed",
+    "TODO: remove tracked-toolbox resolution when https://github.com/ember-learn/ember-cli-addon-docs/issues/1309 is addressed"
   ],
   "resolutions": {
-    "**/validated-changeset": "~1.3.2"
+    "**/validated-changeset": "~1.3.2",
+    "**/tracked-toolbox": "^1.2.3"
   },
   "release": {
     "extends": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,7 +1444,7 @@
     "@embroider/shared-internals" "^0.50.2"
     semver "^7.3.5"
 
-"@embroider/addon-shim@^1.0.0", "@embroider/addon-shim@^1.2.0", "@embroider/addon-shim@^1.5.0", "@embroider/addon-shim@^1.6.0":
+"@embroider/addon-shim@^1.0.0", "@embroider/addon-shim@^1.2.0", "@embroider/addon-shim@^1.5.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@embroider/addon-shim/-/addon-shim-1.8.0.tgz#a545d85991f033a7bac147fe720ff2a7a870731f"
   integrity sha512-iMD9Yzx24WY0/K42if2piWzkw+BFCpqxwbPaNWFqlTbNGzzd1UnNiFhtdjXT5vTyYSQRgbQwuFcr/04Rh8qF8A==
@@ -18125,21 +18125,13 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
 
-tracked-toolbox@^1.2.3:
+tracked-toolbox@^1.2.3, tracked-toolbox@^2.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/tracked-toolbox/-/tracked-toolbox-1.3.0.tgz#46aee42d71d97ceb48654f0785fb294d735fabf8"
   integrity sha512-KHfYLvNyRr0qQeXQPnmb6Z4JYZ0/47R7LjVwzUrsKc539eQi3Sz2z3mb7FJN9KgaJXVuM3GQ8zcwUFTf0hrOsQ==
   dependencies:
     ember-cache-primitive-polyfill "^1.0.0"
     ember-cli-babel "^7.26.6"
-
-tracked-toolbox@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/tracked-toolbox/-/tracked-toolbox-2.0.0.tgz#7862575527b4c633ef8f9b4111d9d64c07ef2a49"
-  integrity sha512-adZtX+RGN6F+pWs/5JqVuDxLhuia4uhqmQp+UlUaxpykWjDFETtAdQR+LdDJiFPXFAXnS6FBqn/tnSLJQCm3Yw==
-  dependencies:
-    "@embroider/addon-shim" "^1.6.0"
-    ember-cache-primitive-polyfill "^1.0.0"
 
 traverse@~0.6.6:
   version "0.6.6"


### PR DESCRIPTION
## Description

After latest dependency updates the CI went ok, but running the local docs app could not be accessed anymore. Until further investigation into the issue we downgrade the dependency.

Fixes # `Uncaught TypeError: decorator is not a function`
