### PR TITLE
feat(testing): add createdBy and modifiedBy filters

### DIFF
--- a/packages/testing/addon-mirage-support/factories/form.js
+++ b/packages/testing/addon-mirage-support/factories/form.js
@@ -11,4 +11,8 @@ export default Factory.extend({
   isArchived: false,
   isPublished: true,
   meta: () => ({}),
+  createdByUser: () => faker.random.numeric(10),
+  createdByGroup: () => faker.random.numeric(10),
+  modifiedByUser: () => faker.random.numeric(10),
+  modifiedByGroup: () => faker.random.numeric(10),
 });

--- a/packages/testing/addon/mirage-graphql/filters/base.js
+++ b/packages/testing/addon/mirage-graphql/filters/base.js
@@ -64,6 +64,22 @@ export default class BaseFilter {
     return records.filter(({ slug }) => values.includes(slug));
   }
 
+  createdByUser(records, value) {
+    return records.filter(({ createdByUser }) => createdByUser === value);
+  }
+
+  createdByGroup(records, value) {
+    return records.filter(({ createdByGroup }) => createdByGroup === value);
+  }
+
+  modifiedByUser(records, value) {
+    return records.filter(({ modifiedByUser }) => modifiedByUser === value);
+  }
+
+  modifiedByGroup(records, value) {
+    return records.filter(({ modifiedByGroup }) => modifiedByGroup === value);
+  }
+
   id(records, value) {
     if (value === undefined || value === null) {
       return [];

--- a/packages/testing/tests/unit/mirage/filters/base-test.js
+++ b/packages/testing/tests/unit/mirage/filters/base-test.js
@@ -13,6 +13,10 @@ module("Unit | Mirage GraphQL Filter | base", function (hooks) {
       { slug: "test-1" },
       { slug: "test-2" },
       { slug: "test-3" },
+      { slug: "test-4", createdByUser: "1" },
+      { slug: "test-5", createdByGroup: "1" },
+      { slug: "test-6", modifiedByUser: "1" },
+      { slug: "test-7", modifiedByGroup: "1" },
     ];
   });
 
@@ -31,6 +35,70 @@ module("Unit | Mirage GraphQL Filter | base", function (hooks) {
     assert.deepEqual(this.filter.find(this.collection, { slug: "test-1" }), {
       slug: "test-1",
     });
+  });
+
+  test("can filter by createdByUser", async function (assert) {
+    assert.expect(1);
+
+    assert.deepEqual(
+      this.filter.filter(this.collection, {
+        filter: [{ createdByUser: "1" }],
+      }),
+      [
+        {
+          slug: "test-4",
+          createdByUser: "1",
+        },
+      ]
+    );
+  });
+
+  test("can filter by createdByGroup", async function (assert) {
+    assert.expect(1);
+
+    assert.deepEqual(
+      this.filter.filter(this.collection, {
+        filter: [{ createdByGroup: "1" }],
+      }),
+      [
+        {
+          slug: "test-5",
+          createdByGroup: "1",
+        },
+      ]
+    );
+  });
+
+  test("can filter by modifiedByUser", async function (assert) {
+    assert.expect(1);
+
+    assert.deepEqual(
+      this.filter.filter(this.collection, {
+        filter: [{ modifiedByUser: "1" }],
+      }),
+      [
+        {
+          slug: "test-6",
+          modifiedByUser: "1",
+        },
+      ]
+    );
+  });
+
+  test("can filter by modifiedByGroup", async function (assert) {
+    assert.expect(1);
+
+    assert.deepEqual(
+      this.filter.filter(this.collection, {
+        filter: [{ modifiedByGroup: "1" }],
+      }),
+      [
+        {
+          slug: "test-7",
+          modifiedByGroup: "1",
+        },
+      ]
+    );
   });
 
   test("does not fail if the filter is not defined", async function (assert) {


### PR DESCRIPTION
## Description

Currently it is not possible to filter by `createdBy` and `modifiedBy` filters on the miragejs backend.

This PR adds the `createdByUser`, `createdByGroup`, `modifiedByUser` and `modifiedByGroup` filters to the base filters.

## Depedencies

No dependencies