### PR TITLE
feat(testing): allow inverting of filters

### DIFF
--- a/packages/testing/addon/mirage-graphql/filters/answer.js
+++ b/packages/testing/addon/mirage-graphql/filters/answer.js
@@ -1,13 +1,11 @@
 import BaseFilter from "@projectcaluma/ember-testing/mirage-graphql/filters/base";
 
 export default class AnswerFilter extends BaseFilter {
-  questions(records, value, { invert = false }) {
-    return records.filter(
-      (record) => invert !== value.includes(record.questionId)
-    );
+  questions(records, value) {
+    return records.filter((record) => value.includes(record.questionId));
   }
 
-  question(records, value, { invert = false }) {
-    return this.questions(records, [value], { invert });
+  question(records, value) {
+    return this.questions(records, [value]);
   }
 }

--- a/packages/testing/addon/mirage-graphql/filters/base.js
+++ b/packages/testing/addon/mirage-graphql/filters/base.js
@@ -23,7 +23,12 @@ export default class BaseFilter {
       const fn = this[key];
 
       return typeof fn === "function" && ![null, undefined].includes(value)
-        ? (records) => fn.call(this, records, value, options)
+        ? (records) => {
+            const filteredRecords = fn.call(this, records, value, options);
+            return options?.invert
+              ? records.filter((record) => !filteredRecords.includes(record))
+              : filteredRecords;
+          }
         : (records) => records;
     });
   }

--- a/packages/testing/addon/mirage-graphql/filters/work-item.js
+++ b/packages/testing/addon/mirage-graphql/filters/work-item.js
@@ -1,27 +1,27 @@
 import BaseFilter from "@projectcaluma/ember-testing/mirage-graphql/filters/base";
 
 export default class WorkItemFilter extends BaseFilter {
-  status(records, value, { invert = false }) {
-    return records.filter(({ status }) => invert !== (status === value));
+  status(records, value) {
+    return records.filter(({ status }) => status === value);
   }
 
-  tasks(records, value, { invert = false }) {
-    return records.filter((record) => invert !== value.includes(record.taskId));
+  tasks(records, value) {
+    return records.filter((record) => value.includes(record.taskId));
   }
 
-  task(records, value, { invert = false }) {
-    return this.tasks(records, [value], { invert });
+  task(records, value) {
+    return this.tasks(records, [value]);
   }
 
-  controllingGroups(records, value, { invert = false }) {
+  controllingGroups(records, value) {
     return records.filter((record) =>
-      value.every((g) => invert !== record.controllingGroups?.includes(g))
+      value.every((g) => record.controllingGroups?.includes(g))
     );
   }
 
-  addressedGroups(records, value, { invert = false }) {
+  addressedGroups(records, value) {
     return records.filter((record) =>
-      value.every((g) => invert !== record.addressedGroups?.includes(g))
+      value.every((g) => record.addressedGroups?.includes(g))
     );
   }
 }

--- a/packages/testing/tests/unit/mirage/filters/answer-test.js
+++ b/packages/testing/tests/unit/mirage/filters/answer-test.js
@@ -1,0 +1,105 @@
+import { setupMirage } from "ember-cli-mirage/test-support";
+import { setupTest } from "ember-qunit";
+import { gql } from "graphql-tag";
+import { assert, module, test } from "qunit";
+
+module("Unit | Mirage GraphQL Filter | answer", function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    const { id: formId } = this.server.create("form", { slug: "test-form" });
+    const { id: documentId } = this.server.create("document", {
+      formId,
+    });
+
+    this.question = this.server.create("question", {
+      type: "TEXT",
+      formIds: [formId],
+    });
+    this.otherQuestion = this.server.create("question", {
+      type: "TEXT",
+      formIds: [formId],
+    });
+
+    this.answer = this.server.create("answer", {
+      questionId: this.question.id,
+      documentId,
+    });
+    this.otherAnswer = this.server.create("answer", {
+      questionId: this.otherQuestion.id,
+      documentId,
+    });
+
+    this.apollo = this.owner.lookup("service:apollo");
+    this.query = gql`
+      query documents($question: ID!, $invert: Boolean!) {
+        allDocuments {
+          edges {
+            node {
+              id
+              answers(filter: [{ question: $question, invert: $invert }]) {
+                edges {
+                  node {
+                    id
+                    question {
+                      slug
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    `;
+  });
+
+  test("can filter based on question", async function () {
+    const res = await this.apollo.query({
+      query: this.query,
+      variables: {
+        question: this.question.slug,
+        invert: false,
+      },
+    });
+
+    assert.deepEqual(
+      res.allDocuments.edges[0].node.answers.edges.map(({ node }) => node),
+      [
+        {
+          __typename: "StringAnswer",
+          id: window.btoa(`StringAnswer:${this.answer.id}`),
+          question: {
+            __typename: "TextQuestion",
+            slug: this.question.slug,
+          },
+        },
+      ]
+    );
+  });
+
+  test("can inverse filter based on question", async function () {
+    const res = await this.apollo.query({
+      query: this.query,
+      variables: {
+        question: this.question.slug,
+        invert: true,
+      },
+    });
+
+    assert.deepEqual(
+      res.allDocuments.edges[0].node.answers.edges.map(({ node }) => node),
+      [
+        {
+          __typename: "StringAnswer",
+          id: window.btoa(`StringAnswer:${this.otherAnswer.id}`),
+          question: {
+            __typename: "TextQuestion",
+            slug: this.otherQuestion.slug,
+          },
+        },
+      ]
+    );
+  });
+});

--- a/packages/testing/tests/unit/mirage/filters/base-test.js
+++ b/packages/testing/tests/unit/mirage/filters/base-test.js
@@ -120,4 +120,44 @@ module("Unit | Mirage GraphQL Filter | base", function (hooks) {
       this.collection
     );
   });
+
+  test("can inverse any filter", async function (assert) {
+    assert.deepEqual(
+      this.filter.filter(this.collection, {
+        filter: [
+          {
+            slug: "test-1",
+            invert: true,
+          },
+        ],
+      }),
+      this.collection.filter(({ slug }) => slug !== "test-1")
+    );
+
+    assert.deepEqual(
+      this.filter.filter(this.collection, {
+        filter: [
+          {
+            slugs: ["test-1", "test-2"],
+            invert: true,
+          },
+        ],
+      }),
+      this.collection.filter(
+        ({ slug }) => slug !== "test-1" && slug !== "test-2"
+      )
+    );
+
+    assert.deepEqual(
+      this.filter.filter(this.collection, {
+        filter: [
+          {
+            createdByGroup: "1",
+            invert: true,
+          },
+        ],
+      }),
+      this.collection.filter(({ createdByGroup }) => createdByGroup !== "1")
+    );
+  });
 });

--- a/packages/testing/tests/unit/mirage/filters/work-item-test.js
+++ b/packages/testing/tests/unit/mirage/filters/work-item-test.js
@@ -1,0 +1,84 @@
+import { classify } from "@ember/string";
+import { setupMirage } from "ember-cli-mirage/test-support";
+import { setupTest } from "ember-qunit";
+import { gql } from "graphql-tag";
+import { module, test } from "qunit";
+
+module("Unit | Mirage GraphQL Filter | work-item", function (hooks) {
+  setupTest(hooks);
+  setupMirage(hooks);
+
+  hooks.beforeEach(function () {
+    this.apollo = this.owner.lookup("service:apollo");
+    const { id: formId } = this.server.create("form", { slug: "test-form" });
+    const { id: documentId } = this.server.create("document", {
+      formId,
+    });
+    this.case = this.server.create("case", {
+      documentId,
+    });
+    this.task = this.server.create("task");
+    this.otherTask = this.server.create("task");
+    this.workItem1 = this.server.create("workItem", {
+      caseId: this.case.id,
+      taskId: this.task.id,
+    });
+    this.workItem2 = this.server.create("workItem", {
+      caseId: this.case.id,
+      taskId: this.otherTask.id,
+    });
+
+    this.query = gql`
+      query workItems($taskId: ID!, $invert: Boolean!) {
+        allWorkItems(filter: [{ task: $taskId, invert: $invert }]) {
+          edges {
+            node {
+              id
+              task {
+                name
+              }
+            }
+          }
+        }
+      }
+    `;
+  });
+
+  test("can filter based on task", async function (assert) {
+    const res = await this.apollo.query({
+      query: this.query,
+      variables: {
+        taskId: this.task.id,
+        invert: false,
+      },
+    });
+
+    assert.deepEqual(res.allWorkItems.edges[0].node, {
+      __typename: "WorkItem",
+      id: window.btoa(`WorkItem:${this.workItem1.id}`),
+      task: {
+        __typename: `${classify(this.workItem1.task.type.toLowerCase())}Task`,
+        name: this.workItem1.task.name,
+      },
+    });
+  });
+
+  test("can invert filter based on task", async function (assert) {
+    const res = await this.apollo.query({
+      query: this.query,
+      variables: {
+        taskId: this.task.id,
+        invert: true,
+      },
+    });
+
+    assert.deepEqual(res.allWorkItems.edges[0].node, {
+      __typename: "WorkItem",
+      id: window.btoa(`WorkItem:${this.workItem2.id}`),
+      task: {
+        __typename: `${classify(this.workItem2.task.type.toLowerCase())}Task`,
+        name: this.workItem2.task.name,
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Description

Implements the `invert` option of the real caluma backend.

## Depedencies

No dependencies.
