### PR TITLE
fix(files): disable delete button when field is disabled

### DIFF
--- a/packages/form/addon/components/cf-field/input/files.hbs
+++ b/packages/form/addon/components/cf-field/input/files.hbs
@@ -23,12 +23,15 @@
         >
           {{file.name}}
         </UkButton>
-        <UkIcon
-          class="uk-icon-button uk-margin-small-left"
-          role="button"
-          @icon="trash"
-          {{on "click" (fn this.delete file.id)}}
-        />
+        {{#unless @disabled}}
+          <UkIcon
+            data-test-delete={{file.id}}
+            class="uk-icon-button uk-margin-small-left"
+            role="button"
+            @icon="trash"
+            {{on "click" (fn this.delete file.id)}}
+          />
+        {{/unless}}
       </li>
     {{/each}}
   </ul>

--- a/packages/form/tests/integration/components/cf-field/input/files-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/files-test.js
@@ -110,4 +110,26 @@ module("Integration | Component | cf-field/input/files", function (hooks) {
     // eslint-disable-next-line require-atomic-updates
     window.open = window_open;
   });
+
+  test("it disables all controls when field is disabled", async function (assert) {
+    assert.expect(2);
+
+    const file = this.server.create("file");
+
+    this.field = {
+      answer: {
+        raw: {
+          id: btoa("FilesAnswer:1"),
+        },
+        value: [file],
+      },
+    };
+
+    await render(
+      hbs`<CfField::Input::Files @field={{this.field}} @disabled={{true}} />`
+    );
+
+    assert.dom("input[type=file]").isDisabled();
+    assert.dom(`[data-test-delete="${file.id}"]`).isNotVisible();
+  });
 });


### PR DESCRIPTION
## Description

When a field is disabled one could still trigger the delete file action.

Fixes #2084