### PR TITLE
fix(distribution): fix redirect after inquiry creation in dialog

### DIFF
--- a/packages/distribution/addon/components/cd-inquiry-dialog.js
+++ b/packages/distribution/addon/components/cd-inquiry-dialog.js
@@ -84,6 +84,8 @@ export default class CdInquiryDialogComponent extends Component {
 
     yield this.distribution.createInquiry.perform([this.args.to]);
 
+    yield getObservable(this._inquiries.value).refetch();
+
     this.router.transitionTo(
       "inquiry.detail.index",
       {


### PR DESCRIPTION
Currently the user will be redirected to the first inquiry that already exists, not the one that was just created. If we refresh the dialog query after creating we have current data and the redirect works as expected.