### PR TITLE
feat(distribution): extensible inquiry answer status configuration

### DIFF
--- a/packages/distribution/addon/utils/inquiry-status.js
+++ b/packages/distribution/addon/utils/inquiry-status.js
@@ -94,14 +94,23 @@ function decorator(
         ? INQUIRY_STATUS.SENT
         : this.config.inquiry.answer.statusMapping[answer.value];
 
+      const iconMap = {
+        ...ICON_MAP,
+        ...this.config.inquiry.answer?.statusIconMap,
+      };
+      const colorMap = {
+        ...COLOR_MAP,
+        ...this.config.inquiry.answer?.statusColorMap,
+      };
+
       return {
         slug,
         label:
           !isSkipped && !isDraft && !isSent
             ? answer?.selectedOption.label
             : this.intl.t(`caluma.distribution.status.${slug}`),
-        color: COLOR_MAP[slug][inquiryType] ?? COLOR_MAP[slug],
-        icon: ICON_MAP[slug],
+        color: colorMap[slug][inquiryType] ?? colorMap[slug],
+        icon: iconMap[slug],
       };
     },
   };

--- a/packages/distribution/tests/unit/utils/inquiry-status-test.js
+++ b/packages/distribution/tests/unit/utils/inquiry-status-test.js
@@ -63,6 +63,29 @@ module("Unit | Utility | inquiry-status", function (hooks) {
       slug: "needs-interaction",
     });
 
+    // extensible inquiry answer status
+    this.obj.config.inquiry.answer = {
+      ...this.obj.config.inquiry.answer,
+      statusIconMap: { custom: "code" },
+      statusColorMap: { custom: "primary" },
+      statusMapping: {
+        ...this.obj.config.inquiry.answer.statusMapping,
+        "inquiry-answer-status-custom": "custom",
+      },
+    };
+
+    await this.obj.inquiry.setStatus(
+      "inquiry-answer-status-custom",
+      "Custom answer status"
+    );
+
+    assert.deepEqual(this.obj.status, {
+      color: "primary",
+      icon: "code",
+      label: "Custom answer status",
+      slug: "custom",
+    });
+
     await this.obj.inquiry.setSuspended();
 
     assert.deepEqual(this.obj.status, {


### PR DESCRIPTION
Allow the host application to configure further inquiry answer status icons and colors for more specialized answer mappings.
