### PR TITLE
fix(form): use defaults to mimic previous behaviour

### DIFF
--- a/packages/form/addon/components/cf-field/input/date.js
+++ b/packages/form/addon/components/cf-field/input/date.js
@@ -20,7 +20,11 @@ export default class CfFieldInputDateComponent extends Component {
 
   get dateFormat() {
     const {
-      FLATPICKR_DATE_FORMAT = {},
+      FLATPICKR_DATE_FORMAT = {
+        de: "d.m.Y",
+        fr: "d.m.Y",
+        en: "m/d/Y",
+      },
       FLATPICKR_DATE_FORMAT_DEFAULT = "m/d/Y",
     } = this.config["ember-caluma"] || {};
 


### PR DESCRIPTION
without settings defaults it would always choose the en format, when the options arent configured