### PR TITLE
fix(form-builder): allow widget override to be removed

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/question.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.hbs
@@ -397,6 +397,7 @@
         @optionLabelPath="label"
         @options={{this.availableOverrides}}
         @prompt={{t "caluma.form-builder.question.no-selection"}}
+        @promptIsSelectable={{true}}
       />
 
       <f.input


### PR DESCRIPTION
## Description

currently once a override widget is selected, it cant be removed unless meta is edited