### PR TITLE
fix(analytics): fix table reordering breaking the table

### DIFF
--- a/packages/-ember-caluma/package.json
+++ b/packages/-ember-caluma/package.json
@@ -58,6 +58,7 @@
     "ember-power-select": "6.0.1",
     "ember-resolver": "8.1.0",
     "ember-source": "4.10.0",
+    "ember-sortable": "5.0.0",
     "ember-truth-helpers": "3.1.1",
     "ember-uikit": "6.1.1",
     "ember-validated-form": "^6.2.0",

--- a/packages/analytics/addon/components/ca-field-selector-list.hbs
+++ b/packages/analytics/addon/components/ca-field-selector-list.hbs
@@ -1,8 +1,4 @@
-<table
-  class="uk-table uk-table-divider uk-table-hover"
-  uk-overflow-auto
-  {{did-insert this.setupUIkit}}
->
+<table class="uk-table uk-table-divider uk-table-hover uk-overflow-auto">
   <thead>
     <tr>
       <th></th>
@@ -18,20 +14,19 @@
   </thead>
   <tbody
     data-test-field-list
-    uk-sortable="handle: .uk-sortable-handle;"
     class="uk-list"
     id="field-list"
+    {{sortable-group onChange=(perform this.reorderFields)}}
   >
     {{#each this.fields as |field|}}
       {{#let (fn this.updateField field) as |update|}}
-        <tr id={{field.id}}>
-          <td>
-            <span
-              data-test-sort-handle
-              uk-icon="menu"
-              class="uk-sortable-handle"
-              role="button"
-            ></span>
+        <tr
+          id={{field.id}}
+          class="uk-position-relative"
+          {{sortable-item model=field}}
+        >
+          <td data-test-sort-handle {{sortable-handle}}>
+            <span uk-icon="menu" role="button" class="uk-drag"></span>
           </td>
           <td>
             {{field.dataSource}}

--- a/packages/analytics/addon/components/ca-filter-modal.hbs
+++ b/packages/analytics/addon/components/ca-filter-modal.hbs
@@ -32,8 +32,7 @@
 
     <UkList
       @divider="true"
-      class="uk-padding-small uk-padding-remove-left"
-      uk-overflow-auto
+      class="uk-padding-small uk-padding-remove-left uk-overflow-auto"
       as |List|
     >
       {{#each this.filters as |filter|}}

--- a/packages/analytics/app/styles/@projectcaluma/ember-analytics.scss
+++ b/packages/analytics/app/styles/@projectcaluma/ember-analytics.scss
@@ -1,1 +1,6 @@
 @import "../ca-uikit-powerselect";
+
+.sortable-item.is-dropping,
+.sortable-item.is-dragging {
+  z-index: 10;
+}

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -32,6 +32,7 @@
     "ember-intl": "^5.7.0",
     "ember-power-select": "6.0.1",
     "ember-resources": "^5.6.2",
+    "ember-sortable": "^5.0.0",
     "ember-uikit": "^6.1.1",
     "ember-validated-form": "^6.2.0",
     "graphql": "^15.6.1"

--- a/packages/analytics/tests/integration/components/ca-field-selector-list-test.js
+++ b/packages/analytics/tests/integration/components/ca-field-selector-list-test.js
@@ -1,6 +1,7 @@
-import { render } from "@ember/test-helpers";
+import { render, findAll } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupIntl } from "ember-intl/test-support";
+import { reorder } from "ember-sortable/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -9,9 +10,193 @@ module("Integration | Component | ca-field-selector-list", function (hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
 
-  test.skip("it renders", async function (assert) {
-    await render(hbs`<CaFieldSelectorList />`);
+  hooks.beforeEach(function () {
+    const edges = [
+      {
+        node: {
+          id: "QW5hbHl0aWNzRmllbGQ6MDc5ZmY2OGYtMWExOS00ZGI0LWIwOWEtMTY3Zjc3NjY5Yzhl",
+          alias: "id",
+          meta: {},
+          dataSource: "id",
+          function: "VALUE",
+          showOutput: true,
+          filters: [],
+          __typename: "AnalyticsField",
+        },
+        __typename: "AnalyticsFieldEdge",
+      },
+      {
+        node: {
+          id: "QW5hbHl0aWNzRmllbGQ6MGZmZDM5NTEtOWJkMC00NGYwLThkZDEtMzZkYjg0ZjQzODEz",
+          alias: "answer",
+          meta: {},
+          dataSource: "answers[formular].frage",
+          function: "COUNT",
+          showOutput: true,
+          filters: [],
+          __typename: "AnalyticsField",
+        },
+        __typename: "AnalyticsFieldEdge",
+      },
+      {
+        node: {
+          id: "QW5hbHl0aWNzRmllbGQ6ZmQxZjNiM2ItNjQ2NC00ZmE2LWEwNGQtNDAwM2YzOTA2OWI0",
+          alias: "created_at",
+          meta: {},
+          dataSource: "created_at",
+          function: "VALUE",
+          showOutput: true,
+          filters: [],
+          __typename: "AnalyticsField",
+        },
+        __typename: "AnalyticsFieldEdge",
+      },
+    ];
+    this.set("order", edges);
+    this.set("analyticsTable", {
+      id: "QW5hbHl0aWNzVGFibGU6ZG9jdW1lbnQ=",
+      slug: "document",
+      name: "document",
+      fields: {
+        edges,
+        __typename: "AnalyticsFieldConnection",
+      },
+      availableFields: {
+        edges: [
+          {
+            node: {
+              id: "QXZhaWxhYmxlRmllbGQ6YW5zd2Vyc1szLXF1ZXN0aW9uc10=",
+              label: "answers[3-questions]",
+              isLeaf: false,
+              isValue: false,
+              sourcePath: "answers[3-questions]",
+              supportedFunctions: [],
+              __typename: "AvailableField",
+            },
+            __typename: "AvailableFieldEdge",
+          },
+          {
+            node: {
+              id: "QXZhaWxhYmxlRmllbGQ6YW5zd2Vyc1tmb3JtdWxhci0xXQ==",
+              label: "answers[formular-1]",
+              isLeaf: false,
+              isValue: false,
+              sourcePath: "answers[formular-1]",
+              supportedFunctions: [],
+              __typename: "AvailableField",
+            },
+            __typename: "AvailableFieldEdge",
+          },
+          {
+            node: {
+              id: "QXZhaWxhYmxlRmllbGQ6YW5zd2Vyc1tmb3JtdWxhcl0=",
+              label: "answers[formular]",
+              isLeaf: false,
+              isValue: false,
+              sourcePath: "answers[formular]",
+              supportedFunctions: [],
+              __typename: "AvailableField",
+            },
+            __typename: "AvailableFieldEdge",
+          },
+          {
+            node: {
+              id: "QXZhaWxhYmxlRmllbGQ6Y3JlYXRlZF9hdA==",
+              label: "created_at",
+              isLeaf: false,
+              isValue: true,
+              sourcePath: "created_at",
+              supportedFunctions: ["VALUE", "MAX", "MIN", "COUNT"],
+              __typename: "AvailableField",
+            },
+            __typename: "AvailableFieldEdge",
+          },
+          {
+            node: {
+              id: "QXZhaWxhYmxlRmllbGQ6Zm9ybV9pZA==",
+              label: "form_id",
+              isLeaf: true,
+              isValue: true,
+              sourcePath: "form_id",
+              supportedFunctions: ["COUNT", "VALUE"],
+              __typename: "AvailableField",
+            },
+            __typename: "AvailableFieldEdge",
+          },
+          {
+            node: {
+              id: "QXZhaWxhYmxlRmllbGQ6aWQ=",
+              label: "id",
+              isLeaf: true,
+              isValue: true,
+              sourcePath: "id",
+              supportedFunctions: ["COUNT", "VALUE"],
+              __typename: "AvailableField",
+            },
+            __typename: "AvailableFieldEdge",
+          },
+          {
+            node: {
+              id: "QXZhaWxhYmxlRmllbGQ6bWV0YQ==",
+              label: "Meta",
+              isLeaf: false,
+              isValue: false,
+              sourcePath: "meta",
+              supportedFunctions: [
+                "VALUE",
+                "SUM",
+                "COUNT",
+                "AVG",
+                "MAX",
+                "MIN",
+              ],
+              __typename: "AvailableField",
+            },
+            __typename: "AvailableFieldEdge",
+          },
+        ],
+        __typename: "AvailableFieldConnection",
+      },
+      startingObject: "DOCUMENTS",
+      __typename: "AnalyticsTable",
+    });
+  });
 
-    assert.dom(this.element).hasText("");
+  test("it renders fields", async function (assert) {
+    await render(
+      hbs`<CaFieldSelectorList @analyticsTable={{this.analyticsTable}} />`
+    );
+
+    assert.dom("tbody tr").exists({ count: 3 });
+  });
+
+  test("it reorders", async function (assert) {
+    await render(
+      hbs`<CaFieldSelectorList @analyticsTable={{this.analyticsTable}} />`
+    );
+
+    assert
+      .dom("tbody tr:nth-child(1)")
+      .hasAttribute("id", this.order[0].node.id);
+    assert
+      .dom("tbody tr:nth-child(2)")
+      .hasAttribute("id", this.order[1].node.id);
+    assert
+      .dom("tbody tr:nth-child(3)")
+      .hasAttribute("id", this.order[2].node.id);
+
+    const order = findAll("[data-test-sort-handle]").reverse();
+    // reorder fails on floating and compatibility tests
+    await reorder("mouse", "[data-test-sort-handle]", ...order);
+
+    assert
+      .dom("tbody tr:nth-child(1)")
+      .hasAttribute("id", this.order[2].node.id);
+    assert
+      .dom("tbody tr:nth-child(2)")
+      .hasAttribute("id", this.order[1].node.id);
+    assert
+      .dom("tbody tr:nth-child(3)")
+      .hasAttribute("id", this.order[0].node.id);
   });
 });

--- a/packages/analytics/tests/integration/components/ca-report-builder-test.js
+++ b/packages/analytics/tests/integration/components/ca-report-builder-test.js
@@ -1,28 +1,11 @@
 import { render } from "@ember/test-helpers";
-import { tracked } from "@glimmer/tracking";
-import { Changeset } from "ember-changeset";
-import lookupValidator from "ember-changeset-validations";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { setupIntl } from "ember-intl/test-support";
 import { module, test, todo } from "qunit";
 
-import AnalyticsTableValidations from "@projectcaluma/ember-analytics/validations/analytics-table";
-import slugify from "@projectcaluma/ember-core/utils/slugify";
+import ReportsNewRoute from "@projectcaluma/ember-analytics/routes/reports/new";
 import { setupRenderingTest } from "dummy/tests/helpers";
-
-class AnalyticsTable {
-  constructor({ name, startingObject } = {}) {
-    this.name = name;
-    this.startingObject = startingObject;
-  }
-
-  get slug() {
-    return slugify(this.name ?? "");
-  }
-  @tracked name;
-  @tracked startingObject;
-}
 
 module("Integration | Component | ca-report-builder", function (hooks) {
   setupRenderingTest(hooks);
@@ -39,15 +22,7 @@ module("Integration | Component | ca-report-builder", function (hooks) {
     });
     this.set("route", "demo.analytics");
     this.set("slug", "test");
-    this.set("analyticsTable", () => {
-      return new Changeset(
-        new AnalyticsTable({
-          startingObject: "CASES",
-        }),
-        lookupValidator(AnalyticsTableValidations),
-        AnalyticsTableValidations
-      );
-    });
+    this.set("analyticsTable", new ReportsNewRoute().model());
   });
 
   test("it renders the table from slug", async function (assert) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9216,6 +9216,13 @@ ember-set-helper@^2.0.1:
   dependencies:
     ember-cli-babel "^7.18.0"
 
+ember-sortable@5.0.0, ember-sortable@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/ember-sortable/-/ember-sortable-5.0.0.tgz#0634f3d4c5c6bdd27968bd885ed44bec64f86710"
+  integrity sha512-Wwc3/h0jamQEHFcrZ0YWoUkDh7s4YgSe26+eJP0QNyyR3t3MyGoi2klqsULqPuLzuXcWsio9Z+dGxFdCW1L//g==
+  dependencies:
+    "@embroider/addon-shim" "^1.8.4"
+
 ember-source-channel-url@3.0.0, ember-source-channel-url@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ember-source-channel-url/-/ember-source-channel-url-3.0.0.tgz#bcd5be72c63fa0b8c390b3121783b462063e2a1b"


### PR DESCRIPTION
replace uikit sortable with ember-sortable

With uikit sortable the table can break when dragging to specific locations
![Peek 2023-03-17 10-17](https://user-images.githubusercontent.com/30687616/225863690-cbe15ef7-50ff-45b8-b2b5-1e63fdf3980e.gif)

With ember-sortable it works and uses modifieres which is nice and relativly easily testable
![Peek 2023-03-17 11-37](https://user-images.githubusercontent.com/30687616/225881705-37aad481-22d3-409a-a2d4-0d93c8d2ff63.gif)
