### PR TITLE
fix(datasources): add the `dataSourceContext` for table documents

### DIFF
--- a/packages/form/addon/lib/document.js
+++ b/packages/form/addon/lib/document.js
@@ -27,7 +27,8 @@ export default class Document extends Base {
     super({ raw, ...args });
 
     this.parentDocument = parentDocument;
-    this.dataSourceContext = dataSourceContext;
+    this.dataSourceContext =
+      dataSourceContext ?? parentDocument?.dataSourceContext;
 
     this.pushIntoStore();
 


### PR DESCRIPTION
## Description
If the document has no `dataSourceContext` but a `parentDocument` (table documents), pass the `dataSourceContext` of the `parentDocument` as `dataSourceContext`. This way dynamic questions on tables get a context because otherwise they don't.