### PR TITLE
fix: load the correct widget override options for a question

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/question.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.hbs
@@ -3,7 +3,7 @@
     <div class="uk-flex uk-flex-center uk-flex-middle uk-height-small">
       <UkSpinner @ratio={{2}} />
     </div>
-  {{else if this.model}}
+  {{else if this.changeset}}
     <ValidatedForm
       @model={{this.changeset}}
       @on-submit={{perform this.submit}}

--- a/packages/form-builder/addon/components/cfb-form-editor/question.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.js
@@ -80,6 +80,7 @@ export default class CfbFormEditorQuestion extends Component {
   @queryManager apollo;
 
   @tracked linkSlug = true;
+  @tracked changeset;
 
   @restartableTask
   *data() {
@@ -192,10 +193,6 @@ export default class CfbFormEditorQuestion extends Component {
 
   get model() {
     return this.data.lastSuccessful?.value?.[0]?.node;
-  }
-
-  get changeset() {
-    return new Changeset(this.model, lookupValidator(validations), validations);
   }
 
   get prefix() {
@@ -480,6 +477,13 @@ export default class CfbFormEditorQuestion extends Component {
     await this.data.perform();
     await this.availableForms.perform();
     await this.availableDataSources.perform();
+    if (this.model) {
+      this.changeset = new Changeset(
+        this.model,
+        lookupValidator(validations),
+        validations
+      );
+    }
   }
 
   @action

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question-test.js
@@ -1,4 +1,4 @@
-import { render, fillIn, blur, click } from "@ember/test-helpers";
+import { render, fillIn, blur, click, select } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { setupIntl } from "ember-intl/test-support";
@@ -667,5 +667,44 @@ module("Integration | Component | cfb-form-editor/question", function (hooks) {
     );
 
     assert.dom(".ember-power-select-multiple-option").exists();
+  });
+
+  test("it loads the correct widget overrides", async function (assert) {
+    const calumaOptions = this.owner.lookup("service:caluma-options");
+
+    calumaOptions.registerComponentOverride({
+      label: "a widget override for all types",
+      component: "dummy-component-1",
+    });
+    calumaOptions.registerComponentOverride({
+      label: "a widget override for float questions only",
+      component: "dummy-component-2",
+      types: ["FloatQuestion"],
+    });
+
+    await render(hbs`<CfbFormEditor::Question @slug={{null}} />`);
+
+    assert
+      .dom('select[name="meta.widgetOverride"]')
+      .includesText(
+        "a widget override for all types",
+        "it contains option for the all types override"
+      );
+
+    await select("select[name='__typename']", "FloatQuestion");
+
+    assert
+      .dom('select[name="meta.widgetOverride"]')
+      .includesText(
+        "a widget override for all types",
+        "it contains option for the all types override"
+      );
+
+    assert
+      .dom('select[name="meta.widgetOverride"]')
+      .includesText(
+        "a widget override for float questions only",
+        "it contains option for the float question override"
+      );
   });
 });


### PR DESCRIPTION
## Description

Currently, the options for widget overrides are not being loaded correctly when changing the question type. This means that any widget override that has a question type specified is not available.

### correct behaviour (fixed):
[Screencast from 27.03.2023 16:42:30.webm](https://user-images.githubusercontent.com/88476449/227975707-d678c4fa-6cfb-40f8-a972-92d1276ddadd.webm)

### incorrect behaviour (before):
[Screencast from 27.03.2023 16:45:04.webm](https://user-images.githubusercontent.com/88476449/227975674-f9ff7531-6f2a-4410-970b-e14d4d35a222.webm)

## DISCLAIMER

I think the issue is that we are creating the changeset in a getter:

```javascript
get changeset () {
  return new Changeset(this.model, ...)
}
```

which messes up the reactivity when trying to watch changes on the changeset (I think?). Instead, I made the changeset a tracked property and initialise it after the data is loaded. However, this might mess up some other stuff, so I hope there is a cleaner solution.