### PR TITLE
fix(docs): explicitly install ember-engines

### DIFF
--- a/packages/-ember-caluma/app/templates/docs/index.md
+++ b/packages/-ember-caluma/app/templates/docs/index.md
@@ -11,7 +11,7 @@ There are various addons for using Caluma in Ember.js:
 Choose your needed packages and install them:
 
 ```bash
-ember install @projectcaluma/ember-form
+ember install ember-engines @projectcaluma/ember-form
 ```
 
 # Usage


### PR DESCRIPTION
Without this, running the setup command in a newly created Ember app triggers the following error:
```
$ ember install @projectcaluma/ember-form-builder @projectcaluma/ember-form              

🚧  Installing packages... This might take a couple of minutes.
yarn: Installed @projectcaluma/ember-form-builder and @projectcaluma/ember-form
Cannot find module 'ember-engines/lib/engine-addon'
Require stack:
- /tmp/caluma-test/caluma-demo/node_modules/@projectcaluma/ember-form-builder/index.js
- /tmp/caluma-test/caluma-demo/node_modules/ember-cli/lib/models/package-info-cache/package-info.js
- /tmp/caluma-test/caluma-demo/node_modules/ember-cli/lib/models/package-info-cache/index.js
- /tmp/caluma-test/caluma-demo/node_modules/ember-cli/lib/models/project.js
- /tmp/caluma-test/caluma-demo/node_modules/ember-cli/lib/utilities/get-config.js
- /tmp/caluma-test/caluma-demo/node_modules/ember-cli/lib/utilities/instrumentation.js
- /tmp/caluma-test/caluma-demo/node_modules/ember-cli/lib/cli/index.js
- /home/christian/.nvm/versions/node/v16.18.1/lib/node_modules/ember-cli/bin/ember
```
