### PR TITLE
fix(form): correct import path after ember-uikit upgrade

### DIFF
--- a/packages/form/app/styles/@projectcaluma/ember-form.scss
+++ b/packages/form/app/styles/@projectcaluma/ember-form.scss
@@ -1,4 +1,4 @@
-@import "ember-uikit/variables-theme";
+@import "ember-uikit";
 
 @import "../cf-field";
 @import "../cf-navigation";


### PR DESCRIPTION
## Description

While upgrading ember-uikit to v7.0.2 in our application, we get an error with ember-caluma trying to import ember-uikit/variables-theme. This tries to resolve the import error.

Local verification of this *fix* was sadly not affordable due too many conflicts in our currently installed ember-caluma version and the latest one. :man_shrugging: 

Fixes #2378