### PR TITLE
feat(form): add data attributes for better field identification

### DIFF
--- a/packages/form/addon/components/cf-field.hbs
+++ b/packages/form/addon/components/cf-field.hbs
@@ -5,6 +5,8 @@
         (and @disabled (has-question-type @field.question 'action-button'))
         'uk-hidden'
       }}"
+    data-question-slug={{@field.question.slug}}
+    data-question-type={{@field.questionType}}
     {{did-insert this.registerComponent}}
     {{will-destroy this.unregisterComponent}}
     {{in-viewport onEnter=this.refreshDynamicOptions}}


### PR DESCRIPTION
## Description

We want to customize the layout of our caluma form. Therefore we have to identify the form field component, especially the wrapping `div`. Currently only the inputs are contextualized with the field/question id. Since CSS `:has` is not supported in Firefox yet, we have to mark the wrapping element as well.

![image](https://user-images.githubusercontent.com/10029904/234040965-b8615164-8958-4ead-b70b-cada79ba1c28.png)
