### PR TITLE
fix(form): fix validation of dynamic option

### DIFF
--- a/packages/form/addon/components/cf-field.js
+++ b/packages/form/addon/components/cf-field.js
@@ -94,7 +94,10 @@ export default class CfFieldComponent extends Component {
 
   @action
   refreshDynamicOptions() {
-    if (this.args.field.question.isDynamic) {
+    if (
+      this.args.field.question.isDynamic &&
+      this.args.field.question.dynamicOptions.isResolved
+    ) {
       this.args.field.question.dynamicOptions.retry();
     }
   }

--- a/packages/form/addon/lib/field.js
+++ b/packages/form/addon/lib/field.js
@@ -360,7 +360,10 @@ export default class Field extends Base {
     );
 
     if (this.question.isDynamic && hasUnknownValue) {
-      if (!this._fetchUsedDynamicOptions.lastSuccessful) {
+      if (
+        !this._fetchUsedDynamicOptions.lastSuccessful &&
+        this.question.dynamicOptions.isResolved
+      ) {
         // Fetch used dynamic options if not done yet
         this._fetchUsedDynamicOptions.perform();
       }
@@ -776,7 +779,7 @@ export default class Field extends Base {
    * @private
    */
   async _validateDynamicChoiceQuestion() {
-    await this.question.dynamicOptions;
+    await this.question.dynamicOptions.retry();
 
     return this._validateOption(this.answer.value, true);
   }
@@ -796,7 +799,7 @@ export default class Field extends Base {
       return true;
     }
 
-    await this.question.dynamicOptions;
+    await this.question.dynamicOptions.retry();
 
     return this.answer.value
       ? value.map((value) => this._validateOption(value))


### PR DESCRIPTION
- Dynamic options *must* be refetched before validation
- Dynamic options should only be refetched on viewport enter if they were already fetched once. Otherwise initial fetching will be done twice.
- Used dynamic options should only be fetched if the dynamic options are resolved. Otherwise it will always fetch them as the value is initially unknown (while the dynamic options are being fetched)