### PR TITLE
feat: allow to disable the powerselect override in the form builder

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/question/default.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question/default.js
@@ -33,8 +33,10 @@ export default class CfbFormEditorQuestionDefault extends Component {
         this.args.model.__typename
       )
     ) {
-      // Use Power Select for choice questions to save space.
-      raw.meta = { widgetOverride: "cf-field/input/powerselect" };
+      if (!this.args.disableChoicePowerselectOverride) {
+        // Use Power Select for choice questions to save space.
+        raw.meta = { widgetOverride: "cf-field/input/powerselect" };
+      }
 
       const key = this.args.model.__typename
         .replace(/^./, (match) => match.toLowerCase())


### PR DESCRIPTION
## Description

This allows to disable the powerselect widget override that is active by default in the form builder.