### PR TITLE
feat: modal which shows in which form the question is used

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/question-usage.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-usage.hbs
@@ -1,0 +1,56 @@
+<UkButton
+  {{on "click" (fn (mut this.modalVisible) true)}}
+  data-test-show-question-usage-modal-btn
+>
+  {{t "caluma.form-builder.question.usage.button"}}
+</UkButton>
+
+<UkModal
+  @visible={{this.modalVisible}}
+  @stack={{true}}
+  @onHide={{fn (mut this.modalVisible) false}}
+  data-test-question-usage-modal
+  as |modal|
+>
+  <modal.header>
+    {{t "caluma.form-builder.question.usage.title"}}
+  </modal.header>
+  <modal.body>
+    {{#if this.forms.isLoading}}
+      <div class="uk-text-center">
+        <UkSpinner @ratio={{1}} />
+      </div>
+    {{else}}
+      <ul class="uk-list uk-list-divider" id="question-list">
+        {{#each this.forms.value as |form|}}
+          <li data-test-question-form-item={{form.node.slug}}>
+            <div class="uk-flex uk-flex-middle">
+              <span class="uk-width-expand">
+                <LinkTo @route="edit" @model={{form.node.slug}}>
+                  {{form.node.name}}
+                </LinkTo>
+              </span>
+
+              {{#if form.node.isArchived}}
+                <UkBadge>
+                  {{t "caluma.form-builder.form.isArchived"}}
+                </UkBadge>
+              {{/if}}
+
+              {{#unless form.node.isPublished}}
+                <UkBadge class="uk-margin-small-left">
+                  {{t "caluma.form-builder.question.usage.not-published"}}
+                </UkBadge>
+              {{/unless}}
+            </div>
+            <div class="uk-text-muted uk-text-small">{{form.node.slug}}</div>
+          </li>
+        {{else}}
+          <li class="uk-text-muted">
+            {{t "caluma.form-builder.question.usage.no-forms-found"}}
+          </li>
+        {{/each}}
+      </ul>
+    {{/if}}
+  </modal.body>
+</UkModal>

--- a/packages/form-builder/addon/components/cfb-form-editor/question-usage.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-usage.hbs
@@ -1,28 +1,28 @@
-<UkButton
-  {{on "click" (fn (mut this.modalVisible) true)}}
-  data-test-show-question-usage-modal-btn
->
-  {{t "caluma.form-builder.question.usage.button"}}
-</UkButton>
+{{#let this.forms.value as |forms|}}
+  {{#if this.otherForms}}
+    <a
+      ...attributes
+      href="#"
+      {{on "click" (fn (mut this.modalVisible) true)}}
+      data-test-show-question-usage-modal-btn
+    >
+      {{this.title}}
+    </a>
+  {{/if}}
 
-<UkModal
-  @visible={{this.modalVisible}}
-  @stack={{true}}
-  @onHide={{fn (mut this.modalVisible) false}}
-  data-test-question-usage-modal
-  as |modal|
->
-  <modal.header>
-    {{t "caluma.form-builder.question.usage.title"}}
-  </modal.header>
-  <modal.body>
-    {{#if this.forms.isLoading}}
-      <div class="uk-text-center">
-        <UkSpinner @ratio={{1}} />
-      </div>
-    {{else}}
-      <ul class="uk-list uk-list-divider" id="question-list">
-        {{#each this.forms.value as |form|}}
+  <UkModal
+    @visible={{this.modalVisible}}
+    @stack={{true}}
+    @onHide={{fn (mut this.modalVisible) false}}
+    data-test-question-usage-modal
+    as |modal|
+  >
+    <modal.header>
+      {{t "caluma.form-builder.question.usage.references-heading"}}
+    </modal.header>
+    <modal.body>
+      <ul class="uk-list uk-list-divider">
+        {{#each forms as |form|}}
           <li data-test-question-form-item={{form.node.slug}}>
             <div class="uk-flex uk-flex-middle">
               <span class="uk-width-expand">
@@ -45,12 +45,8 @@
             </div>
             <div class="uk-text-muted uk-text-small">{{form.node.slug}}</div>
           </li>
-        {{else}}
-          <li class="uk-text-muted">
-            {{t "caluma.form-builder.question.usage.no-forms-found"}}
-          </li>
         {{/each}}
       </ul>
-    {{/if}}
-  </modal.body>
-</UkModal>
+    </modal.body>
+  </UkModal>
+{{/let}}

--- a/packages/form-builder/addon/components/cfb-form-editor/question-usage.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-usage.hbs
@@ -4,7 +4,7 @@
       ...attributes
       href="#"
       {{on "click" (fn (mut this.modalVisible) true)}}
-      data-test-show-question-usage-modal-btn
+      data-test-show-question-usage-modal-link
     >
       {{this.title}}
     </a>

--- a/packages/form-builder/addon/components/cfb-form-editor/question-usage.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-usage.hbs
@@ -1,52 +1,50 @@
-{{#let this.forms.value as |forms|}}
-  {{#if this.otherForms}}
-    <a
-      ...attributes
-      href="#"
-      {{on "click" (fn (mut this.modalVisible) true)}}
-      data-test-show-question-usage-modal-link
-    >
-      {{this.title}}
-    </a>
-  {{/if}}
-
-  <UkModal
-    @visible={{this.modalVisible}}
-    @stack={{true}}
-    @onHide={{fn (mut this.modalVisible) false}}
-    data-test-question-usage-modal
-    as |modal|
+{{#if this.otherForms}}
+  <a
+    ...attributes
+    href="#"
+    {{on "click" (fn (mut this.modalVisible) true)}}
+    data-test-show-question-usage-modal-link
   >
-    <modal.header>
-      {{t "caluma.form-builder.question.usage.references-heading"}}
-    </modal.header>
-    <modal.body>
-      <ul class="uk-list uk-list-divider">
-        {{#each forms as |form|}}
-          <li data-test-question-form-item={{form.node.slug}}>
-            <div class="uk-flex uk-flex-middle">
-              <span class="uk-width-expand">
-                <LinkTo @route="edit" @model={{form.node.slug}}>
-                  {{form.node.name}}
-                </LinkTo>
-              </span>
+    {{this.title}}
+  </a>
+{{/if}}
 
-              {{#if form.node.isArchived}}
-                <UkBadge>
-                  {{t "caluma.form-builder.form.isArchived"}}
-                </UkBadge>
-              {{/if}}
+<UkModal
+  @visible={{this.modalVisible}}
+  @stack={{true}}
+  @onHide={{fn (mut this.modalVisible) false}}
+  data-test-question-usage-modal
+  as |modal|
+>
+  <modal.header>
+    {{t "caluma.form-builder.question.usage.references-heading"}}
+  </modal.header>
+  <modal.body>
+    <ul class="uk-list uk-list-divider">
+      {{#each this.forms.value as |form|}}
+        <li data-test-question-form-item={{form.node.slug}}>
+          <div class="uk-flex uk-flex-middle">
+            <span class="uk-width-expand">
+              <LinkTo @route="edit" @model={{form.node.slug}}>
+                {{form.node.name}}
+              </LinkTo>
+            </span>
 
-              {{#unless form.node.isPublished}}
-                <UkBadge class="uk-margin-small-left">
-                  {{t "caluma.form-builder.question.usage.not-published"}}
-                </UkBadge>
-              {{/unless}}
-            </div>
-            <div class="uk-text-muted uk-text-small">{{form.node.slug}}</div>
-          </li>
-        {{/each}}
-      </ul>
-    </modal.body>
-  </UkModal>
-{{/let}}
+            {{#if form.node.isArchived}}
+              <UkBadge>
+                {{t "caluma.form-builder.form.isArchived"}}
+              </UkBadge>
+            {{/if}}
+
+            {{#unless form.node.isPublished}}
+              <UkBadge class="uk-margin-small-left">
+                {{t "caluma.form-builder.question.usage.not-published"}}
+              </UkBadge>
+            {{/unless}}
+          </div>
+          <div class="uk-text-muted uk-text-small">{{form.node.slug}}</div>
+        </li>
+      {{/each}}
+    </ul>
+  </modal.body>
+</UkModal>

--- a/packages/form-builder/addon/components/cfb-form-editor/question-usage.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-usage.js
@@ -1,3 +1,4 @@
+import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { queryManager } from "ember-apollo-client";
@@ -6,24 +7,40 @@ import { trackedFunction } from "ember-resources/util/function";
 import allFormsForQuestionQuery from "@projectcaluma/ember-form-builder/gql/queries/all-forms-for-question.graphql";
 
 export default class CfbFormEditorQuestionUsage extends Component {
-  @tracked modalVisible = false;
+  @service intl;
   @queryManager apollo;
 
+  @tracked modalVisible = false;
+
+  get title() {
+    return this.intl.t("caluma.form-builder.question.usage.title", {
+      n: this.otherForms,
+      // for highlighting the number we use the <b> tag
+      htmlSafe: true,
+    });
+  }
+
+  get otherForms() {
+    return this.forms.value?.length - 1 ?? 0;
+  }
+
   forms = trackedFunction(this, async () => {
-    if (!this.modalVisible) {
-      return null;
-    }
-
-    const forms = await this.apollo.query(
-      {
-        query: allFormsForQuestionQuery,
-        variables: {
-          slug: this.args.model.slug,
+    try {
+      const forms = await this.apollo.query(
+        {
+          query: allFormsForQuestionQuery,
+          variables: {
+            slug: this.args.model.slug,
+          },
+          fetchPolicy: "no-cache",
         },
-      },
-      "allForms.edges",
-    );
+        "allForms.edges",
+      );
 
-    return forms;
+      return forms;
+    } catch (error) {
+      console.error(error);
+      return { value: [] };
+    }
   });
 }

--- a/packages/form-builder/addon/components/cfb-form-editor/question-usage.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-usage.js
@@ -1,0 +1,29 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+import { queryManager } from "ember-apollo-client";
+import { trackedFunction } from "ember-resources/util/function";
+
+import allFormsForQuestionQuery from "@projectcaluma/ember-form-builder/gql/queries/all-forms-for-question.graphql";
+
+export default class CfbFormEditorQuestionUsage extends Component {
+  @tracked modalVisible = false;
+  @queryManager apollo;
+
+  forms = trackedFunction(this, async () => {
+    if (!this.modalVisible) {
+      return null;
+    }
+
+    const forms = await this.apollo.query(
+      {
+        query: allFormsForQuestionQuery,
+        variables: {
+          slug: this.args.model.slug,
+        },
+      },
+      "allForms.edges",
+    );
+
+    return forms;
+  });
+}

--- a/packages/form-builder/addon/components/cfb-form-editor/question.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.hbs
@@ -434,8 +434,8 @@
         />
       {{/if}}
 
-      <div class="uk-flex uk-flex-between">
-        <CfbFormEditor::QuestionUsage @model={{f.model}} />
+      <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-row-reverse">
+        <CfbFormEditor::QuestionUsage @model={{f.model}} class="uk-flex-last" />
 
         <f.submit
           @disabled={{f.loading}}

--- a/packages/form-builder/addon/components/cfb-form-editor/question.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.hbs
@@ -434,7 +434,9 @@
         />
       {{/if}}
 
-      <div class="uk-text-right">
+      <div class="uk-flex uk-flex-between">
+        <CfbFormEditor::QuestionUsage @model={{f.model}} />
+
         <f.submit
           @disabled={{f.loading}}
           @label={{t "caluma.form-builder.global.save"}}

--- a/packages/form-builder/addon/gql/queries/all-forms-for-question.graphql
+++ b/packages/form-builder/addon/gql/queries/all-forms-for-question.graphql
@@ -1,0 +1,13 @@
+query AllFormsForQuestion($slug: String!) {
+  allForms(filter: [{ questions: [$slug] }]) {
+    edges {
+      node {
+        id
+        slug
+        name
+        isArchived
+        isPublished
+      }
+    }
+  }
+}

--- a/packages/form-builder/app/components/cfb-form-editor/question-usage.js
+++ b/packages/form-builder/app/components/cfb-form-editor/question-usage.js
@@ -1,0 +1,1 @@
+export { default } from "@projectcaluma/ember-form-builder/components/cfb-form-editor/question-usage";

--- a/packages/form-builder/tests/acceptance/question-usage-test.js
+++ b/packages/form-builder/tests/acceptance/question-usage-test.js
@@ -29,7 +29,7 @@ module("Acceptance | question usage", function (hooks) {
 
     await visit("/test-form/questions/test-question");
 
-    await click("[data-test-show-question-usage-modal-btn]");
+    await click("[data-test-show-question-usage-modal-link]");
 
     assert.dom("[data-test-question-usage-modal]").isVisible();
 

--- a/packages/form-builder/tests/acceptance/question-usage-test.js
+++ b/packages/form-builder/tests/acceptance/question-usage-test.js
@@ -1,0 +1,46 @@
+import { visit, click } from "@ember/test-helpers";
+import { setupMirage } from "ember-cli-mirage/test-support";
+import { setupIntl } from "ember-intl/test-support";
+import { module, test } from "qunit";
+
+import { setupApplicationTest } from "dummy/tests/helpers";
+
+module("Acceptance | question usage", function (hooks) {
+  setupApplicationTest(hooks);
+  setupMirage(hooks);
+  setupIntl(hooks);
+
+  test("can show the question usage", async function (assert) {
+    assert.expect(4);
+
+    const firstForm = this.server.create("form", { slug: "test-form" });
+    const secondForm = this.server.create("form", {
+      slug: "second-form",
+      isArchived: true,
+      isPublished: false,
+    });
+
+    this.server.create("question", {
+      label: "Test Question?",
+      slug: "test-question",
+      type: "TEXT",
+      formIds: [firstForm.id, secondForm.id],
+    });
+
+    await visit("/test-form/questions/test-question");
+
+    await click("[data-test-show-question-usage-modal-btn]");
+
+    assert.dom("[data-test-question-usage-modal]").isVisible();
+
+    assert.dom("[data-test-question-form-item='test-form']").exists();
+
+    assert
+      .dom("[data-test-question-form-item='second-form']")
+      .containsText("Archived", "archived status is visible");
+
+    assert
+      .dom("[data-test-question-form-item='second-form']")
+      .containsText("not published", "not published status is visible");
+  });
+});

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question-usage-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question-usage-test.js
@@ -1,0 +1,58 @@
+import { render, click, waitFor } from "@ember/test-helpers";
+import { hbs } from "ember-cli-htmlbars";
+import { setupMirage } from "ember-cli-mirage/test-support";
+import { setupIntl } from "ember-intl/test-support";
+import { module, test } from "qunit";
+
+import { setupRenderingTest } from "dummy/tests/helpers";
+
+module(
+  "Integration | Component | cfb-form-editor/question-usage",
+  function (hooks) {
+    setupRenderingTest(hooks);
+    setupMirage(hooks);
+    setupIntl(hooks);
+
+    test("it renders", async function (assert) {
+      this.set(
+        "question",
+        this.server.create("question", {
+          label: "Test Label",
+          slug: "test-slug",
+          type: "TEXT",
+        }),
+      );
+
+      this.server.createList("form", 3, { questions: [this.question] });
+
+      await render(
+        hbs`<CfbFormEditor::QuestionUsage @model={{this.question}} />`,
+      );
+
+      await waitFor("[data-test-show-question-usage-modal-link]");
+      await click("[data-test-show-question-usage-modal-link]");
+
+      assert.dom("[data-test-question-usage-modal]").isVisible();
+      assert.dom("[data-test-question-form-item]").exists({ count: 3 });
+    });
+
+    test("it is hidden when no other reference to this question exists", async function (assert) {
+      this.set(
+        "question",
+        this.server.create("question", {
+          label: "Test Label",
+          slug: "test-slug",
+          type: "TEXT",
+        }),
+      );
+
+      this.server.create("form", { questions: [this.question] });
+
+      await render(
+        hbs`<CfbFormEditor::QuestionUsage @model={{this.question}} />`,
+      );
+
+      assert.dom("[data-test-show-question-usage-modal-link]").isNotVisible();
+    });
+  },
+);

--- a/packages/form-builder/translations/de.yaml
+++ b/packages/form-builder/translations/de.yaml
@@ -133,6 +133,12 @@ caluma:
 
       hideLabel: "Label verstecken"
 
+      usage:
+        button: "Formulare mit dieser Frage"
+        title: "Formulare mit dieser Frage"
+        no-forms-found: "Es wurde keine Formular gefunden welche diese Frage verwenden"
+        not-published: "nicht publiziert"
+
     options:
       delete: "Option löschen"
       archive: "Option archivieren (verstecken)"

--- a/packages/form-builder/translations/de.yaml
+++ b/packages/form-builder/translations/de.yaml
@@ -134,9 +134,8 @@ caluma:
       hideLabel: "Label verstecken"
 
       usage:
-        button: "Formulare mit dieser Frage"
-        title: "Formulare mit dieser Frage"
-        no-forms-found: "Es wurde keine Formular gefunden welche diese Frage verwenden"
+        title: "Diese Frage wird in {n,plural, =1 {<b>einem</b> Formular} other {<b>#</b> Formularen}} verwendet."
+        references-heading: "Alle Verweise auf diese Frage"
         not-published: "nicht publiziert"
 
     options:

--- a/packages/form-builder/translations/en.yaml
+++ b/packages/form-builder/translations/en.yaml
@@ -133,6 +133,12 @@ caluma:
 
       hideLabel: "Hide label"
 
+      usage:
+        button: "Forms with this question"
+        title: "Forms with this question"
+        no-forms-found: "No form was found that uses this question"
+        not-published: "not published"
+
     options:
       delete: "Delete option"
       archive: "Archive (hide) option"

--- a/packages/form-builder/translations/en.yaml
+++ b/packages/form-builder/translations/en.yaml
@@ -134,9 +134,8 @@ caluma:
       hideLabel: "Hide label"
 
       usage:
-        button: "Forms with this question"
-        title: "Forms with this question"
-        no-forms-found: "No form was found that uses this question"
+        title: "This question is used in {n,plural, =1 {<b>another</b> form} other {<b>#</b> other forms}}"
+        references-heading: "All references of this question"
         not-published: "not published"
 
     options:

--- a/packages/form-builder/translations/fr.yaml
+++ b/packages/form-builder/translations/fr.yaml
@@ -134,9 +134,8 @@ caluma:
       hideLabel: "Cacher l'étiquette"
 
       usage:
-        button: "Formulaires avec cette question"
-        title: "Formulaires avec cette question"
-        no-forms-found: "Aucun formulaire n'a été trouvé qui utilise cette question"
+        title: "Cette question est {n,plural, =1 {utilisé sous <b>une</b> forme} other {utilisé sous <b>#</b> formes}}."
+        references-heading: "Toutes les références à cette question"
         not-published: "non publié"
 
     options:

--- a/packages/form-builder/translations/fr.yaml
+++ b/packages/form-builder/translations/fr.yaml
@@ -133,6 +133,12 @@ caluma:
 
       hideLabel: "Cacher l'étiquette"
 
+      usage:
+        button: "Formulaires avec cette question"
+        title: "Formulaires avec cette question"
+        no-forms-found: "Aucun formulaire n'a été trouvé qui utilise cette question"
+        not-published: "non publié"
+
     options:
       delete: "Supprimer l'option"
       archive: "Archiver (masquer) l'option"


### PR DESCRIPTION
## Description

This MR introduces a new modal which shows in which form a question is being used (and if that form is archived or not published).

#### Button which opens the modal
![image](https://github.com/projectcaluma/ember-caluma/assets/88476449/9d7c49ee-e765-4dfb-99e6-1399fca31872)

(I'm not sure about the label)

#### Modal
![image](https://github.com/projectcaluma/ember-caluma/assets/88476449/1a144b08-b977-4223-8089-c56f5d4dbb8d)

