### PR TITLE
feat: pass selectedGroups as context to form wrapper in inquiry form

### DIFF
--- a/packages/distribution/addon/components/cd-inquiry-new-form/bulk-edit.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-new-form/bulk-edit.hbs
@@ -5,6 +5,7 @@
     @document={{this.document.value}}
     @fieldset={{this.fieldset}}
     @onSave={{this.saveField}}
+    @context={{hash selectedGroups=@selectedGroups}}
   />
   <DocumentValidity @document={{this.document.value}} as |isValid validate|>
     <UkButton


### PR DESCRIPTION
## Description

Pass the selectedGroups as a context prop to the form wrapper in an inquiry (we need this for a customer because we need to use a widget override for the date)
