### PR TITLE
fix(form): fix fast selection in checkboxes

### DIFF
--- a/packages/form/addon/components/cf-field/input/checkbox.js
+++ b/packages/form/addon/components/cf-field/input/checkbox.js
@@ -1,5 +1,6 @@
 import { action } from "@ember/object";
 import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
 
 /**
  * Input component for the checkbox question type
@@ -8,6 +9,8 @@ import Component from "@glimmer/component";
  * @argument {Field} field The field for this input type
  */
 export default class CfFieldInputCheckboxComponent extends Component {
+  @tracked selected = this.args.field.value;
+
   /**
    * Update the value of the field with the slugs of the currently checked
    * boxes.
@@ -16,7 +19,7 @@ export default class CfFieldInputCheckboxComponent extends Component {
    */
   @action
   update({ target: { value, checked } }) {
-    const valueSet = new Set(this.args.field.value);
+    const valueSet = new Set(this.selected);
 
     if (checked) {
       valueSet.add(value);
@@ -24,6 +27,7 @@ export default class CfFieldInputCheckboxComponent extends Component {
       valueSet.delete(value);
     }
 
-    this.args.onSave([...valueSet]);
+    this.selected = [...valueSet];
+    this.args.onSave(this.selected);
   }
 }


### PR DESCRIPTION
This fixes an issue where the value of a checkbox question was not properly updated to the answer model and therefore the backend. This happened because the save task uses a timeout to debounce value saving. As the update function of the component always used the value from the user model this caused a race condition if the user clicked the options too fast.