### PR TITLE
fix: add ember-data version check to check if calling `.toArray` on ember-data arrays is deprecated

### DIFF
--- a/packages/core/addon/services/-scheduler.js
+++ b/packages/core/addon/services/-scheduler.js
@@ -2,9 +2,12 @@ import { assert } from "@ember/debug";
 import { once } from "@ember/runloop";
 import Service, { inject as service } from "@ember/service";
 import { camelize } from "@ember/string";
+import { dependencySatisfies } from "@embroider/macros";
 import { tracked } from "@glimmer/tracking";
 import { task } from "ember-concurrency";
 import { pluralize } from "ember-inflector";
+
+const toArrayIsDeprecated = dependencySatisfies("ember-data", "^4.7.0");
 
 /**
  * Decorator to define a type resolver in the scheduler service.
@@ -37,7 +40,9 @@ function typeResolver(type) {
       ? yield this.calumaOptions[methodName]?.(uncachedIdentifiers)
       : [];
 
-    const allResults = [...cached, ...(result?.toArray?.() ?? result ?? [])];
+    const allResults = toArrayIsDeprecated
+      ? [...cached, ...(result ?? [])]
+      : [...cached, ...(result?.toArray?.() ?? result ?? [])];
 
     if (result?.length) {
       this[`${type}Cache`] = allResults;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@apollo/client": "^3.7.17",
     "@ember/string": "^3.1.1",
+    "@embroider/macros": "^1.13.0",
     "@glimmer/tracking": "^1.1.2",
     "ember-apollo-client": "~4.0.2",
     "ember-auto-import": "^2.6.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -462,6 +462,9 @@ importers:
       '@ember/string':
         specifier: ^3.1.1
         version: 3.1.1
+      '@embroider/macros':
+        specifier: ^1.13.0
+        version: 1.13.0(@glint/template@1.0.2)
       '@glimmer/tracking':
         specifier: ^1.1.2
         version: 1.1.2


### PR DESCRIPTION
Calling `.toArray` on ember-data arrays is deprecated since `ember-data@4.7.0`. Therefore we make the `.toArray` call conditional.