### PR TITLE
feat: enable feature to show all services when selecting services for…

### DIFF
--- a/packages/-ember-caluma/app/services/caluma-options.js
+++ b/packages/-ember-caluma/app/services/caluma-options.js
@@ -35,6 +35,11 @@ export default class CustomCalumaOptionsService extends CalumaOptionsService {
         infoQuestions: ["inquiry-answer-reason", "inquiry-answer-hint"],
       },
     },
+    ui: {
+      new: {
+        showAllServices: false, // if true all the services are shown in one big table
+      },
+    },
     new: {
       defaultTypes: ["suggestions", "private"],
       types: {

--- a/packages/distribution/addon/components/cd-inquiry-new-form/group-type.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-new-form/group-type.hbs
@@ -1,0 +1,23 @@
+{{! template-lint-disable require-presentational-children }}
+<tr
+  class="uk-background-muted uk-text-bold"
+  role="button"
+  {{on "click" (fn (mut this.isExpanded) (not this.isExpanded))}}
+  data-test-group-type={{@type.name}}
+>
+  <td colspan="3" class="">
+    <div class="uk-flex uk-flex-between">
+      {{t @type.name}}
+      <UkIcon @icon={{if this.isExpanded "chevron-up" "chevron-down"}} />
+    </div>
+  </td>
+</tr>
+{{#if this.isExpanded}}
+  {{#each @type.groups as |group|}}
+    <CdInquiryNewForm::Group
+      @group={{group}}
+      @selectedGroups={{@selectedGroups}}
+      @updateSelectedGroups={{@updateSelectedGroups}}
+    />
+  {{/each}}
+{{/if}}

--- a/packages/distribution/addon/components/cd-inquiry-new-form/group-type.js
+++ b/packages/distribution/addon/components/cd-inquiry-new-form/group-type.js
@@ -1,0 +1,15 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+
+export default class CdInquiryNewFormGroupTypeComponent extends Component {
+  @tracked _isExpanded = true;
+
+  get isExpanded() {
+    // if we are searching all the groups need to be expanded anyway
+    return this.args.search !== "" ? true : this._isExpanded;
+  }
+
+  set isExpanded(value) {
+    this._isExpanded = value;
+  }
+}

--- a/packages/distribution/addon/components/cd-inquiry-new-form/group.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-new-form/group.hbs
@@ -1,0 +1,25 @@
+{{! template-lint-disable require-presentational-children }}
+<tr
+  role="checkbox"
+  data-test-group={{@group.identifier}}
+  aria-checked={{includes @group.identifier @selectedGroups}}
+  {{on "click" (fn @updateSelectedGroups @group.identifier)}}
+>
+  <td class="uk-padding-remove-right">
+    {{! template-lint-disable require-input-label no-nested-interactive }}
+    <input
+      type="checkbox"
+      class="uk-checkbox"
+      checked={{includes @group.identifier @selectedGroups}}
+    />
+  </td>
+  <td class="uk-width-expand">{{group-name @group.identifier}}</td>
+  <td class="uk-text-right">
+    {{#if @group.config.icon}}
+      <UkIcon
+        @icon={{@group.config.icon}}
+        class="uk-display-block uk-text-{{@group.config.iconColor}}"
+      />
+    {{/if}}
+  </td>
+</tr>

--- a/packages/distribution/addon/components/cd-inquiry-new-form/select.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-new-form/select.hbs
@@ -1,15 +1,17 @@
-<div class="uk-margin-bottom uk-button-group">
-  {{#each-in this.config.new.types as |slug config|}}
-    {{#unless config.disabled}}
-      <UkButton
-        data-test-type={{slug}}
-        @label={{t config.label}}
-        @color={{if (includes slug @selectedTypes) "primary" "default"}}
-        @onClick={{fn this.updateSelectedTypes slug}}
-      />
-    {{/unless}}
-  {{/each-in}}
-</div>
+{{#unless this.showAllServices}}
+  <div class="uk-margin-bottom uk-button-group" data-test-group-toggle-bar>
+    {{#each-in this.config.new.types as |slug config|}}
+      {{#unless config.disabled}}
+        <UkButton
+          data-test-type={{slug}}
+          @label={{t config.label}}
+          @color={{if (includes slug @selectedTypes) "primary" "default"}}
+          @onClick={{fn this.updateSelectedTypes slug}}
+        />
+      {{/unless}}
+    {{/each-in}}
+  </div>
+{{/unless}}
 
 <div class="uk-search uk-search-default uk-width-1-1">
   <span class="uk-search-icon-flip" uk-search-icon></span>
@@ -30,36 +32,30 @@
   </div>
 {{else if this.groups.value.length}}
   <table
-    class="uk-table uk-table-striped uk-table-hover uk-table-small uk-table-middle group-list"
+    class={{concat
+      "uk-table uk-table-hover uk-table-small uk-table-middle group-list "
+      (if this.showAllServices "uk-table-divider" "uk-table-striped")
+    }}
   >
     <tbody>
-      {{#each this.groups.value as |group|}}
-        {{! template-lint-disable require-presentational-children }}
-        <tr
-          role="checkbox"
-          data-test-group={{group.identifier}}
-          aria-checked={{includes group.identifier @selectedGroups}}
-          {{on "click" (fn this.updateSelectedGroups group.identifier)}}
-        >
-          <td class="uk-padding-remove-right">
-            {{! template-lint-disable require-input-label no-nested-interactive }}
-            <input
-              type="checkbox"
-              class="uk-checkbox"
-              checked={{includes group.identifier @selectedGroups}}
-            />
-          </td>
-          <td class="uk-width-expand">{{group-name group.identifier}}</td>
-          <td class="uk-text-right">
-            {{#if group.config.icon}}
-              <UkIcon
-                @icon={{group.config.icon}}
-                class="uk-display-block uk-text-{{group.config.iconColor}}"
-              />
-            {{/if}}
-          </td>
-        </tr>
-      {{/each}}
+      {{#if this.showAllServices}}
+        {{#each this.groupTypes as |type|}}
+          <CdInquiryNewForm::GroupType
+            @type={{type}}
+            @selectedGroups={{@selectedGroups}}
+            @updateSelectedGroups={{this.updateSelectedGroups}}
+            @search={{@search}}
+          />
+        {{/each}}
+      {{else}}
+        {{#each this.groups.value as |group|}}
+          <CdInquiryNewForm::Group
+            @group={{group}}
+            @selectedGroups={{@selectedGroups}}
+            @updateSelectedGroups={{this.updateSelectedGroups}}
+          />
+        {{/each}}
+      {{/if}}
     </tbody>
   </table>
 {{else}}

--- a/packages/distribution/addon/components/cd-inquiry-new-form/select.js
+++ b/packages/distribution/addon/components/cd-inquiry-new-form/select.js
@@ -20,8 +20,28 @@ export default class CdInquiryNewFormSelectComponent extends Component {
 
   @config config;
 
+  get showAllServices() {
+    return this.config.ui?.new?.showAllServices;
+  }
+
+  get groupTypes() {
+    return Object.entries(this.config.new.types)
+      .filter(([, { disabled }]) => !disabled)
+      .map(([identifier, group]) => ({
+        identifier,
+        name: group.label,
+        config: group.config,
+        groups: this.groups?.value?.filter(
+          (group) => group.type === identifier,
+        ),
+      }));
+  }
+
   groups = trackedTask(this, this.fetchGroups, () => [
-    this.args.selectedTypes,
+    // if we want to show all services we need to fetch all groups
+    this.showAllServices
+      ? Object.keys(this.config.new.types)
+      : this.args.selectedTypes,
     this.args.search,
   ]);
 
@@ -69,6 +89,7 @@ export default class CdInquiryNewFormSelectComponent extends Component {
           identifier: group[this.calumaOptions.groupIdentifierProperty],
           name: group[this.calumaOptions.groupNameProperty],
           config: this.config.new.types[type],
+          type,
         }));
       })
       .sort((a, b) => a.name.localeCompare(b.name));

--- a/packages/distribution/app/components/cd-inquiry-new-form/group-type.js
+++ b/packages/distribution/app/components/cd-inquiry-new-form/group-type.js
@@ -1,0 +1,1 @@
+export { default } from "@projectcaluma/ember-distribution/components/cd-inquiry-new-form/group-type";

--- a/packages/distribution/app/components/cd-inquiry-new-form/group.js
+++ b/packages/distribution/app/components/cd-inquiry-new-form/group.js
@@ -1,0 +1,1 @@
+export { default } from "@projectcaluma/ember-distribution/components/cd-inquiry-new-form/group";


### PR DESCRIPTION
Enables a new way to select services to be invited to an inquiry:
![image](https://github.com/projectcaluma/ember-caluma/assets/88476449/bb12173a-20ab-4fff-9e3a-12bcb1d6df9c)
![image](https://github.com/projectcaluma/ember-caluma/assets/88476449/fac3af2d-e6b3-4547-82b2-9f76ff1c59f0)
![image](https://github.com/projectcaluma/ember-caluma/assets/88476449/c16aa934-305d-499d-b0da-d0b14360cac8)


- Individual sections can be shown/hidden
- When searching all the sections are shown automatically: