### PR TITLE
fix(distribution): improve text when no action is available

### DIFF
--- a/packages/distribution/addon/templates/index.hbs
+++ b/packages/distribution/addon/templates/index.hbs
@@ -1,7 +1,17 @@
 <div class="uk-text-center uk-text-muted">
   {{svg-jar "distribution" class="uk-inline" width=200}}
   <p class="uk-margin-medium uk-margin-remove-horizontal">
-    {{t "caluma.distribution.empty"}}
+    {{#if
+      (or
+        (can "create inquiry of distribution")
+        (can "complete distribution")
+        (can "reopen distribution")
+      )
+    }}
+      {{t "caluma.distribution.empty"}}
+    {{else}}
+      {{t "caluma.distribution.no-actions"}}
+    {{/if}}
   </p>
   <CdNavigation::Controls @useButtons={{true}} />
 </div>

--- a/packages/distribution/translations/de.yaml
+++ b/packages/distribution/translations/de.yaml
@@ -1,6 +1,7 @@
 caluma:
   distribution:
     empty: "Es wurden noch keine Anfragen erstellt."
+    no-actions: "Keine Aktionen im aktuellen Zustand möglich."
     start: "Zirkulation starten"
     send: "Offene Anfragen versenden"
     complete: "Zirkulation abschliessen"

--- a/packages/distribution/translations/de.yaml
+++ b/packages/distribution/translations/de.yaml
@@ -1,7 +1,7 @@
 caluma:
   distribution:
     empty: "Es wurden noch keine Anfragen erstellt."
-    no-actions: "Keine Aktionen im aktuellen Zustand möglich."
+    no-actions: "Im aktuellen Zustand stehen keine Aktionen zur Verfügung."
     start: "Zirkulation starten"
     send: "Offene Anfragen versenden"
     complete: "Zirkulation abschliessen"

--- a/packages/distribution/translations/en.yaml
+++ b/packages/distribution/translations/en.yaml
@@ -1,6 +1,7 @@
 caluma:
   distribution:
     empty: "No inquiries have been created yet."
+    no-actions: "There are no actions available in the current state."
     start: "Start circulation"
     send: "Send pending inquiries"
     complete: "Complete circulation"

--- a/packages/distribution/translations/fr.yaml
+++ b/packages/distribution/translations/fr.yaml
@@ -1,6 +1,7 @@
 caluma:
   distribution:
     empty: "Aucune demande n'a encore été créée."
+    no-actions: "Aucune action n'est disponible dans l'état actuel."
     start: "Lancer la procédure de circulation"
     send: "Envoyer les demandes ouvertes"
     complete: "Clore la circulation"


### PR DESCRIPTION
## Description

The current text on the distribution index page is misleading when no actions are available

![image](https://github.com/projectcaluma/ember-caluma/assets/30687616/f25afd99-d148-49f0-948e-ad7560660bdb)