### PR TITLE
feat(form-builder): allow editing of form meta

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/cfb-advanced-settings.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/cfb-advanced-settings.hbs
@@ -1,0 +1,16 @@
+<UkButton
+  @color="link"
+  @onClick={{toggle-action "showAdvanced" this}}
+  class="uk-flex uk-flex-middle uk-margin"
+>
+  {{#if this.showAdvanced}}
+    <UkIcon @icon="triangle-down" />
+  {{else}}
+    <UkIcon @icon="triangle-right" />
+  {{/if}}
+  {{t "caluma.form-builder.question.advancedSettings"}}
+</UkButton>
+
+{{#if this.showAdvanced}}
+  {{yield}}
+{{/if}}

--- a/packages/form-builder/addon/components/cfb-form-editor/cfb-advanced-settings.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/cfb-advanced-settings.js
@@ -1,0 +1,6 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+
+export default class CfbFormEditorCfbAdvancedSettings extends Component {
+  @tracked showAdvanced = false;
+}

--- a/packages/form-builder/addon/components/cfb-form-editor/general.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/general.hbs
@@ -49,6 +49,14 @@
       @renderComponent={{component "cfb-toggle-switch" size="small"}}
     />
 
+    <CfbFormEditor::CfbAdvancedSettings>
+      <f.input
+        @label={{t "caluma.form-builder.question.meta"}}
+        @name="meta"
+        @renderComponent={{component "cfb-code-editor" language="json"}}
+      />
+    </CfbFormEditor::CfbAdvancedSettings>
+
     <div class="uk-text-right">
       <f.submit
         @disabled={{f.loading}}

--- a/packages/form-builder/addon/components/cfb-form-editor/general.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/general.js
@@ -58,6 +58,8 @@ export default class CfbFormEditorGeneral extends Component {
 
   @dropTask
   *submit(changeset) {
+    const rawMeta = changeset.get("meta");
+
     try {
       const form = yield this.apollo.mutate(
         {
@@ -69,6 +71,7 @@ export default class CfbFormEditorGeneral extends Component {
               description: changeset.get("description"),
               isArchived: changeset.get("isArchived"),
               isPublished: changeset.get("isPublished"),
+              meta: JSON.stringify(rawMeta?.unwrap?.() ?? rawMeta),
             },
           },
         },

--- a/packages/form-builder/addon/components/cfb-form-editor/question.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.hbs
@@ -384,20 +384,7 @@
         @renderComponent={{component "cfb-toggle-switch" size="small"}}
       />
 
-      <UkButton
-        @color="link"
-        @onClick={{toggle-action "showAdvanced" this}}
-        class="uk-flex uk-flex-middle uk-margin"
-      >
-        {{#if this.showAdvanced}}
-          <UkIcon @icon="triangle-down" />
-        {{else}}
-          <UkIcon @icon="triangle-right" />
-        {{/if}}
-        {{t "caluma.form-builder.question.advancedSettings"}}
-      </UkButton>
-
-      {{#if this.showAdvanced}}
+      <CfbFormEditor::CfbAdvancedSettings>
         {{#if (has-question-type f.model "action-button")}}
           <f.input
             @name="validateOnEnter"
@@ -438,7 +425,7 @@
           @name="meta"
           @renderComponent={{component "cfb-code-editor" language="json"}}
         />
-      {{/if}}
+      </CfbFormEditor::CfbAdvancedSettings>
 
       <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-row-reverse">
         <CfbFormEditor::QuestionUsage @model={{f.model}} class="uk-flex-last" />

--- a/packages/form-builder/addon/gql/fragments/form-info.graphql
+++ b/packages/form-builder/addon/gql/fragments/form-info.graphql
@@ -5,4 +5,5 @@ fragment FormInfo on Form {
   description
   isArchived
   isPublished
+  meta
 }

--- a/packages/form-builder/app/components/cfb-form-editor/cfb-advanced-settings.js
+++ b/packages/form-builder/app/components/cfb-form-editor/cfb-advanced-settings.js
@@ -1,0 +1,1 @@
+export { default } from "@projectcaluma/ember-form-builder/components/cfb-form-editor/cfb-advanced-settings";


### PR DESCRIPTION
## Description

Allows editing of form meta (similar to the question meta).

![image](https://github.com/projectcaluma/ember-caluma/assets/88476449/0959212c-bcbf-42f5-aabb-d4c7919a6db1)