### PR TITLE
fix: add optional peer dep on ember data

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "stylelint-prettier": "^5.0.0",
     "stylelint-scss": "6.1.0"
   },
-  "packageManager": "pnpm@8.11.0",
+  "packageManager": "pnpm@8.15.4",
   "pnpm": {
     "peerDependencyRules": {
       "ignoreMissing": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -65,11 +65,17 @@
     "webpack": "5.90.0"
   },
   "peerDependencies": {
-    "ember-source": "^4.0.0"
+    "ember-source": "^4.0.0",
+    "ember-data": "*"
   },
   "dependenciesMeta": {
     "@projectcaluma/ember-testing": {
       "injected": true
+    }
+  },
+  "peerDependenciesMeta": {
+    "ember-data": {
+      "optional": true
     }
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -322,7 +322,7 @@ importers:
         version: 1.1.2
       '@projectcaluma/ember-core':
         specifier: workspace:^
-        version: file:packages/core(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+        version: file:packages/core(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0)
       ember-apollo-client:
         specifier: ~4.0.2
         version: 4.0.2(@glint/template@1.3.0)(graphql@15.8.0)(webpack@5.90.0)
@@ -506,6 +506,9 @@ importers:
       ember-concurrency:
         specifier: ^3.1.1
         version: 3.1.1(@babel/core@7.23.9)(ember-source@5.6.0)
+      ember-data:
+        specifier: '*'
+        version: 5.3.0(@babel/core@7.23.9)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)
       ember-fetch:
         specifier: ^8.1.2
         version: 8.1.2
@@ -647,7 +650,7 @@ importers:
         version: 1.1.2
       '@projectcaluma/ember-core':
         specifier: workspace:^
-        version: file:packages/core(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+        version: file:packages/core(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0)
       '@projectcaluma/ember-form':
         specifier: workspace:^
         version: file:packages/form(@glint/template@1.3.0)(@projectcaluma/ember-workflow@12.9.0)(ember-source@5.6.0)(webpack@5.90.0)
@@ -834,7 +837,7 @@ importers:
         version: 1.1.2
       '@projectcaluma/ember-core':
         specifier: workspace:^
-        version: file:packages/core(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+        version: file:packages/core(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0)
       ember-apollo-client:
         specifier: ~4.0.2
         version: 4.0.2(@glint/template@1.3.0)(graphql@15.8.0)(webpack@5.90.0)
@@ -1025,10 +1028,10 @@ importers:
         version: 1.1.2
       '@projectcaluma/ember-core':
         specifier: workspace:^
-        version: file:packages/core(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+        version: file:packages/core(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0)
       '@projectcaluma/ember-form':
         specifier: workspace:^
-        version: file:packages/form(@glint/template@1.3.0)(@projectcaluma/ember-workflow@12.9.0)(ember-source@5.6.0)(webpack@5.90.0)
+        version: file:packages/form(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0)
       codejar:
         specifier: ^4.2.0
         version: 4.2.0
@@ -1337,7 +1340,7 @@ importers:
         version: 1.1.2(@babel/core@7.23.9)
       '@projectcaluma/ember-core':
         specifier: workspace:^
-        version: file:packages/core(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+        version: file:packages/core(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0)
       ember-apollo-client:
         specifier: ~4.0.2
         version: 4.0.2(@glint/template@1.3.0)(graphql@15.8.0)(webpack@5.90.0)
@@ -1743,7 +1746,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.9
       '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -1757,7 +1760,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.9
       '@babel/helper-compilation-targets': 7.23.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       debug: 4.3.4
       lodash.debounce: 4.0.8
       resolve: 1.22.8
@@ -1819,7 +1822,6 @@ packages:
   /@babel/helper-plugin-utils@7.24.0:
     resolution: {integrity: sha512-9cUznXMG0+FxRuJfvL82QlTqIzhVW9sL0KjMPHhAOOvpQGL8QtdxnBKILjBqxlHyliz0yCa1G903ZXI/FuHy2w==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-remap-async-to-generator@7.22.20(@babel/core@7.23.9):
     resolution: {integrity: sha512-pBGyV4uBqOns+0UvhsTO8qgl8hO89PmiDYv+/COyp1aeMcmfrfruz+/nCMFiYyFF/Knn0yfrC85ZzNFjembFTw==}
@@ -2229,7 +2231,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
 
   /@babel/plugin-transform-class-properties@7.23.3(@babel/core@7.23.9):
     resolution: {integrity: sha512-uM+AN8yCIjDPccsKGlw271xjJtGii+xQIF/uMPS8H15L12jZTsLfF4o5vNO7d/oUguOyfdikHGc/yi9ge4SGIg==}
@@ -2660,7 +2662,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.23.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.24.0
       '@babel/plugin-syntax-typescript': 7.23.3(@babel/core@7.23.9)
     dev: true
 
@@ -19681,13 +19683,17 @@ packages:
   /zen-observable@0.8.15:
     resolution: {integrity: sha512-PQ2PC7R9rslx84ndNBZB/Dkv8V8fZEpk83RLgXtYd0fwUgEjseMn1Dgajh2x6S8QbZAFa9p2qVCEuYZNgve0dQ==}
 
-  file:packages/core(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0):
+  file:packages/core(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0):
     resolution: {directory: packages/core, type: directory}
     id: file:packages/core
     name: '@projectcaluma/ember-core'
     engines: {node: '>= 18'}
     peerDependencies:
+      ember-data: '*'
       ember-source: ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      ember-data:
+        optional: true
     dependencies:
       '@apollo/client': 3.9.5(graphql@15.8.0)
       '@babel/core': 7.23.9
@@ -19699,6 +19705,57 @@ packages:
       ember-cli-babel: 8.2.0(@babel/core@7.23.9)
       ember-cli-htmlbars: 6.3.0
       ember-concurrency: 3.1.1(@babel/core@7.23.9)(ember-source@5.6.0)
+      ember-data: 5.3.0(@babel/core@7.23.9)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)
+      ember-fetch: 8.1.2
+      ember-inflector: 4.0.2
+      ember-intl: 6.4.0(@babel/core@7.23.9)(@glint/template@1.3.0)(webpack@5.90.0)
+      ember-resources: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@3.1.1)(ember-source@5.6.0)
+      ember-source: 5.6.0(@babel/core@7.23.9)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.90.0)
+      ember-uikit: 9.0.0(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+      graphql: 15.8.0
+      graphql-tag: 2.12.6(graphql@15.8.0)
+      jexl: 2.3.0
+      lodash.clonedeep: 4.5.0
+      slugify: 1.6.6
+    transitivePeerDependencies:
+      - '@ember/test-waiters'
+      - '@glimmer/component'
+      - '@glint/environment-ember-loose'
+      - '@glint/template'
+      - '@types/react'
+      - encoding
+      - graphql-ws
+      - react
+      - react-dom
+      - subscriptions-transport-ws
+      - supports-color
+      - typescript
+      - webpack
+    dev: false
+
+  file:packages/core(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0):
+    resolution: {directory: packages/core, type: directory}
+    id: file:packages/core
+    name: '@projectcaluma/ember-core'
+    engines: {node: '>= 18'}
+    peerDependencies:
+      ember-data: '*'
+      ember-source: ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      ember-data:
+        optional: true
+    dependencies:
+      '@apollo/client': 3.9.5(graphql@15.8.0)
+      '@babel/core': 7.23.9
+      '@ember/string': 3.1.1
+      '@embroider/macros': 1.13.4(@glint/template@1.3.0)
+      '@glimmer/tracking': 1.1.2
+      ember-apollo-client: 4.0.2(@glint/template@1.3.0)(graphql@15.8.0)(webpack@5.90.0)
+      ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.0)
+      ember-cli-babel: 8.2.0(@babel/core@7.23.9)
+      ember-cli-htmlbars: 6.3.0
+      ember-concurrency: 3.1.1(@babel/core@7.23.9)(ember-source@5.6.0)
+      ember-data: 5.3.0(@babel/core@7.23.9)(@ember/string@3.1.1)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)
       ember-fetch: 8.1.2
       ember-inflector: 4.0.2
       ember-intl: 6.4.0(@babel/core@7.23.9)(@glint/template@1.3.0)(webpack@5.90.0)
@@ -19743,7 +19800,7 @@ packages:
       '@embroider/util': 1.12.1(@glint/template@1.3.0)(ember-source@5.6.0)
       '@glimmer/component': 1.1.2(@babel/core@7.23.9)
       '@glimmer/tracking': 1.1.2
-      '@projectcaluma/ember-core': file:packages/core(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+      '@projectcaluma/ember-core': file:packages/core(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0)
       '@projectcaluma/ember-workflow': file:packages/workflow(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
       ember-apollo-client: 4.0.2(@glint/template@1.3.0)(graphql@15.8.0)(webpack@5.90.0)
       ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.0)
@@ -19775,6 +19832,67 @@ packages:
       - '@glint/environment-ember-loose'
       - '@glint/template'
       - '@types/react'
+      - ember-data
+      - encoding
+      - graphql-ws
+      - react
+      - react-dom
+      - subscriptions-transport-ws
+      - supports-color
+      - typescript
+      - webpack
+    dev: false
+
+  file:packages/form(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0):
+    resolution: {directory: packages/form, type: directory}
+    id: file:packages/form
+    name: '@projectcaluma/ember-form'
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@projectcaluma/ember-workflow': workspace:^
+      ember-source: ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      '@projectcaluma/ember-workflow':
+        optional: true
+    dependencies:
+      '@babel/core': 7.23.9
+      '@ember/string': 3.1.1
+      '@embroider/macros': 1.13.4(@glint/template@1.3.0)
+      '@embroider/util': 1.12.1(@glint/template@1.3.0)(ember-source@5.6.0)
+      '@glimmer/component': 1.1.2(@babel/core@7.23.9)
+      '@glimmer/tracking': 1.1.2
+      '@projectcaluma/ember-core': file:packages/core(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+      ember-apollo-client: 4.0.2(@glint/template@1.3.0)(graphql@15.8.0)(webpack@5.90.0)
+      ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.0)
+      ember-autoresize-modifier: 0.7.0(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+      ember-cli-babel: 8.2.0(@babel/core@7.23.9)
+      ember-cli-htmlbars: 6.3.0
+      ember-cli-showdown: 8.0.0(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+      ember-composable-helpers: 5.0.0
+      ember-concurrency: 3.1.1(@babel/core@7.23.9)(ember-source@5.6.0)
+      ember-fetch: 8.1.2
+      ember-flatpickr: 6.0.0(@babel/core@7.23.9)(@glint/template@1.3.0)(ember-source@5.6.0)(flatpickr@4.6.13)
+      ember-in-viewport: 4.1.0(@babel/core@7.23.9)(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+      ember-intl: 6.4.0(@babel/core@7.23.9)(@glint/template@1.3.0)(webpack@5.90.0)
+      ember-math-helpers: 4.0.0(ember-source@5.6.0)
+      ember-power-select: 7.2.0(@babel/core@7.23.9)(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+      ember-resources: 6.5.1(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glimmer/tracking@1.1.2)(@glint/template@1.3.0)(ember-concurrency@3.1.1)(ember-source@5.6.0)
+      ember-source: 5.6.0(@babel/core@7.23.9)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.90.0)
+      ember-truth-helpers: 4.0.3(ember-source@5.6.0)
+      ember-uikit: 9.0.0(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+      ember-validators: 4.1.2(@glint/template@1.3.0)
+      flatpickr: 4.6.13
+      graphql: 15.8.0
+      jexl: 2.3.0
+      lodash.isequal: 4.5.0
+      luxon: 3.4.4
+      tracked-toolbox: 2.0.0(@babel/core@7.23.9)(ember-source@5.6.0)
+    transitivePeerDependencies:
+      - '@ember/test-waiters'
+      - '@glint/environment-ember-loose'
+      - '@glint/template'
+      - '@types/react'
+      - ember-data
       - encoding
       - graphql-ws
       - react
@@ -19837,7 +19955,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.9
       '@glimmer/component': 1.1.2(@babel/core@7.23.9)
-      '@projectcaluma/ember-core': file:packages/core(@ember/test-waiters@3.1.0)(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-source@5.6.0)(webpack@5.90.0)
+      '@projectcaluma/ember-core': file:packages/core(@glimmer/component@1.1.2)(@glint/template@1.3.0)(ember-data@5.3.0)(ember-source@5.6.0)(webpack@5.90.0)
       ember-apollo-client: 4.0.2(@glint/template@1.3.0)(graphql@15.8.0)(webpack@5.90.0)
       ember-auto-import: 2.7.2(@glint/template@1.3.0)(webpack@5.90.0)
       ember-cli-babel: 8.2.0(@babel/core@7.23.9)
@@ -19857,6 +19975,7 @@ packages:
       - '@glint/environment-ember-loose'
       - '@glint/template'
       - '@types/react'
+      - ember-data
       - encoding
       - graphql-ws
       - react


### PR DESCRIPTION
Without this, the `dependencyStatisfies` embroider macro won't work -
see https://github.com/embroider-build/embroider/issues/1169#issuecomment-1081943925
for details.