### PR TITLE
fix(translations): change "optional" to "optionnelle"

### DIFF
--- a/packages/form/translations/fr.yaml
+++ b/packages/form/translations/fr.yaml
@@ -1,6 +1,6 @@
 caluma:
   form:
-    optional: "optional"
+    optional: "optionnelle"
     save: "sauvegarder"
     delete: "supprimer"
     edit: "modifier"


### PR DESCRIPTION
## Description

Changes "optional" in French to "optionnelle". That is, according to one of our French speaking clients, the correct translation.
