### PR TITLE
feat(form-builder): highlight the slug of the question that is currently being edited in bold

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/question-list/item.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list/item.hbs
@@ -41,7 +41,11 @@
       <a
         data-test-edit-question
         href="#"
-        class="uk-width-auto uk-margin-small-right uk-text-bold"
+        class={{if
+          this.isActive
+          "uk-width-auto uk-margin-small-right uk-text-bold"
+          "uk-width-auto uk-margin-small-right"
+        }}
         {{on "click" (fn this.editQuestion @question)}}
       >
         {{@question.slug}}
@@ -51,7 +55,11 @@
       </a>
     {{else}}
       <span
-        class="uk-width-auto uk-margin-small-right uk-text-bold"
+        class={{if
+          this.isActive
+          "uk-width-auto uk-margin-small-right uk-text-bold"
+          "uk-width-auto uk-margin-small-right"
+        }}
       >{{@question.slug}}</span>
     {{/if}}
 

--- a/packages/form-builder/addon/components/cfb-form-editor/question-list/item.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list/item.js
@@ -1,11 +1,14 @@
 import { action } from "@ember/object";
 import { guidFor } from "@ember/object/internals";
+import { service } from "@ember/service";
 import Component from "@glimmer/component";
 import jexl from "jexl";
 
 import { hasQuestionType } from "@projectcaluma/ember-core/helpers/has-question-type";
 
 export default class CfbFormEditorQuestionListItem extends Component {
+  @service router;
+
   get elementId() {
     return guidFor(this);
   }
@@ -45,6 +48,14 @@ export default class CfbFormEditorQuestionListItem extends Component {
     return (
       this.args.mode === "reorder" &&
       (hasQuestionType(question, "form") || hasQuestionType(question, "table"))
+    );
+  }
+
+  get isActive() {
+    // we can't access this.router.applicationRouter.currentRoute.queryParams
+    // because it is non-reactive
+    return this.router.currentURL?.endsWith(
+      `/questions/${this.args.question.slug}`,
     );
   }
 


### PR DESCRIPTION
## Description

This is another small quality of life improvement.

### Before
![image](https://github.com/projectcaluma/ember-caluma/assets/88476449/84d1b968-00b3-49e8-a38d-5f67df836e0d)


### Afterwards

When editing a question:
![image](https://github.com/projectcaluma/ember-caluma/assets/88476449/9493b976-8e2d-4092-abb7-8e96e419cd65)

When removing a question:
![image](https://github.com/projectcaluma/ember-caluma/assets/88476449/7b189f41-af4a-4b5a-8846-4b9edddc26cd)

(it doesn't make a difference when adding a question because you can't add a question that is already in the form)
