### PR TITLE
feat(form-builder): save the preference for "show advanced" settings in localStorage

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/cfb-advanced-settings.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/cfb-advanced-settings.hbs
@@ -1,6 +1,6 @@
 <UkButton
   @color="link"
-  @onClick={{toggle-action "showAdvanced" this}}
+  @onClick={{this.toggleAdvanced}}
   class="uk-flex uk-flex-middle uk-margin"
 >
   {{#if this.showAdvanced}}

--- a/packages/form-builder/addon/components/cfb-form-editor/cfb-advanced-settings.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/cfb-advanced-settings.js
@@ -1,6 +1,20 @@
+import { action } from "@ember/object";
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
-
 export default class CfbFormEditorCfbAdvancedSettings extends Component {
   @tracked showAdvanced = false;
+
+  constructor(owner, args) {
+    super(owner, args);
+
+    this.showAdvanced =
+      JSON.parse(localStorage.getItem("showAdvanced")) ?? false;
+  }
+
+  @action
+  toggleAdvanced() {
+    this.showAdvanced = !this.showAdvanced;
+
+    localStorage.setItem("showAdvanced", this.showAdvanced);
+  }
 }


### PR DESCRIPTION
## Description

Especially when jumping between questions and working on JEXLs it's inconvenient that the "advanced settings" always need to be reshown.
