### PR TITLE
fix(form-builder): don't show the question usage when creating a new question

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/question.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.hbs
@@ -428,10 +428,12 @@
       </CfbFormEditor::CfbAdvancedSettings>
 
       <div class="uk-flex uk-flex-between uk-flex-middle uk-flex-row-reverse">
-        <CfbFormEditor::QuestionUsage
-          @slug={{changeset-get f.model "slug"}}
-          class="uk-flex-last"
-        />
+        {{#unless this.isNew}}
+          <CfbFormEditor::QuestionUsage
+            @slug={{changeset-get f.model "slug"}}
+            class="uk-flex-last"
+          />
+        {{/unless}}
 
         <f.submit
           @disabled={{f.loading}}

--- a/packages/form-builder/addon/components/cfb-form-editor/question.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.js
@@ -195,6 +195,10 @@ export default class CfbFormEditorQuestion extends Component {
     return this.data.lastSuccessful?.value?.[0]?.node;
   }
 
+  get isNew() {
+    return !this.changeset.get("id");
+  }
+
   get prefix() {
     return this.calumaOptions.namespace
       ? `${this.calumaOptions.namespace}-`


### PR DESCRIPTION
## Description

Currently, the form-builder shows "this question is being used in -1 forms" when creating a new question.
