### PR TITLE
feat(form): add case infos to jexl context

### DIFF
--- a/packages/form/addon/gql/fragments/case-form-and-workflow.graphql
+++ b/packages/form/addon/gql/fragments/case-form-and-workflow.graphql
@@ -1,0 +1,28 @@
+fragment CaseFormAndWorkflow on Case {
+  id
+  workflow {
+    id
+    slug
+  }
+  document {
+    id
+    form {
+      id
+      slug
+    }
+  }
+  family {
+    id
+    workflow {
+      id
+      slug
+    }
+    document {
+      id
+      form {
+        id
+        slug
+      }
+    }
+  }
+}

--- a/packages/form/addon/gql/queries/document-answers.graphql
+++ b/packages/form/addon/gql/queries/document-answers.graphql
@@ -1,4 +1,5 @@
 #import * from '../fragments/field.graphql'
+#import * from '../fragments/case-form-and-workflow.graphql'
 
 query DocumentAnswers($id: ID!) {
   allDocuments(filter: [{ id: $id }]) {
@@ -12,21 +13,11 @@ query DocumentAnswers($id: ID!) {
         workItem {
           id
           case {
-            id
-            family {
-              id
-              document {
-                id
-                form {
-                  id
-                  slug
-                }
-              }
-            }
+            ...CaseFormAndWorkflow
           }
         }
         case {
-          id
+          ...CaseFormAndWorkflow
           workItems {
             edges {
               node {

--- a/packages/form/addon/gql/queries/document-answers.graphql
+++ b/packages/form/addon/gql/queries/document-answers.graphql
@@ -11,6 +11,19 @@ query DocumentAnswers($id: ID!) {
         }
         workItem {
           id
+          case {
+            id
+            family {
+              id
+              document {
+                id
+                form {
+                  id
+                  slug
+                }
+              }
+            }
+          }
         }
         case {
           id

--- a/packages/form/addon/lib/document.js
+++ b/packages/form/addon/lib/document.js
@@ -198,6 +198,7 @@ export default class Document extends Base {
    * @property {Object} jexlContext
    */
   get jexlContext() {
+    const _case = this.raw.workItem?.case ?? this.raw.case;
     return (
       this.parentDocument?.jexlContext ?? {
         // JEXL interprets null in an expression as variable instead of a
@@ -208,6 +209,14 @@ export default class Document extends Base {
           root: {
             form: this.rootForm.slug,
             formMeta: this.rootForm.raw.meta,
+          },
+          case: {
+            form: _case?.document?.form.slug,
+            workflow: _case?.workflow.slug,
+            root: {
+              form: _case?.family.document?.form.slug,
+              workflow: _case?.family.workflow.slug,
+            },
           },
         },
       }

--- a/packages/form/addon/lib/field.js
+++ b/packages/form/addon/lib/field.js
@@ -413,6 +413,7 @@ export default class Field extends Base {
    * - `form`: Legacy property pointing to the root form.
    * - `info.form`: The form this question is attached to.
    * - `info.formMeta`: The meta of the form this question is attached to.
+   * - `info.mainCaseForm`: The main cases' form (can give useful context in task forms).
    * - `info.parent.form`: The parent form if applicable.
    * - `info.parent.formMeta`: The parent form meta if applicable.
    * - `info.root.form`: The new property for the root form.
@@ -423,12 +424,16 @@ export default class Field extends Base {
   get jexlContext() {
     const parent = this.fieldset.field?.fieldset.form;
 
+    const rootDocument = this.document.parentDocument ?? this.document;
+
     return {
       ...this.document.jexlContext,
       info: {
         ...this.document.jexlContext.info,
         form: this.fieldset.form.slug,
         formMeta: this.fieldset.form.raw.meta,
+        mainCaseForm:
+          rootDocument.raw.workItem?.case.family.document?.form.slug,
         parent: parent
           ? {
               form: parent.slug,

--- a/packages/form/addon/lib/field.js
+++ b/packages/form/addon/lib/field.js
@@ -413,18 +413,19 @@ export default class Field extends Base {
    * - `form`: Legacy property pointing to the root form.
    * - `info.form`: The form this question is attached to.
    * - `info.formMeta`: The meta of the form this question is attached to.
-   * - `info.mainCaseForm`: The main cases' form (can give useful context in task forms).
    * - `info.parent.form`: The parent form if applicable.
    * - `info.parent.formMeta`: The parent form meta if applicable.
    * - `info.root.form`: The new property for the root form.
    * - `info.root.formMeta`: The new property for the root form meta.
+   * - `info.case.form`: The cases' form (works for task forms and case forms).
+   * - `info.case.workflow`: The cases' workflow (works for task forms and case forms).
+   * - `info.case.root.form`: The _root_ cases' form (works for task forms and case forms).
+   * - `info.case.root.workflow`: The _root_ cases' workflow (works for task forms and case forms).
    *
    * @property {Object} jexlContext
    */
   get jexlContext() {
     const parent = this.fieldset.field?.fieldset.form;
-
-    const rootDocument = this.document.parentDocument ?? this.document;
 
     return {
       ...this.document.jexlContext,
@@ -432,8 +433,6 @@ export default class Field extends Base {
         ...this.document.jexlContext.info,
         form: this.fieldset.form.slug,
         formMeta: this.fieldset.form.raw.meta,
-        mainCaseForm:
-          rootDocument.raw.workItem?.case.family.document?.form.slug,
         parent: parent
           ? {
               form: parent.slug,

--- a/packages/form/tests/integration/components/document-validity-test.js
+++ b/packages/form/tests/integration/components/document-validity-test.js
@@ -3,7 +3,7 @@ import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { module, test } from "qunit";
 
-import data from "../../unit/lib/data";
+import { rawDocumentWithWorkItem } from "../../unit/lib/data";
 
 import { parseDocument } from "@projectcaluma/ember-form/lib/parsers";
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -14,7 +14,7 @@ module("Integration | Component | document-validity", function (hooks) {
 
   hooks.beforeEach(function () {
     this.document = new (this.owner.factoryFor("caluma-model:document").class)({
-      raw: parseDocument(data),
+      raw: parseDocument(rawDocumentWithWorkItem),
       owner: this.owner,
     });
 

--- a/packages/form/tests/unit/lib/data.js
+++ b/packages/form/tests/unit/lib/data.js
@@ -236,9 +236,26 @@ const answers = {
   ],
 };
 
+const workItem = {
+  id: id("WorkItem"),
+  case: {
+    id: id("Case"),
+    family: {
+      id: id("Case"),
+      document: {
+        id: id("Document"),
+        form: {
+          slug: "main-case-form",
+        },
+      },
+    },
+  },
+};
+
 export default {
   id: id("Document"),
   answers,
   form,
+  workItem,
   __typename: "Document",
 };

--- a/packages/form/tests/unit/lib/data.js
+++ b/packages/form/tests/unit/lib/data.js
@@ -236,26 +236,59 @@ const answers = {
   ],
 };
 
-const workItem = {
-  id: id("WorkItem"),
-  case: {
+const _case = {
+  id: id("Case"),
+  workflow: {
+    id: id("Workflow", "child-case-workflow"),
+    slug: "child-case-workflow",
+  },
+  document: {
+    id: id("Document"),
+    form: {
+      id: id("Form", "child-case-form"),
+      slug: "child-case-form",
+    },
+  },
+  family: {
     id: id("Case"),
-    family: {
-      id: id("Case"),
-      document: {
-        id: id("Document"),
-        form: {
-          slug: "main-case-form",
-        },
+    workflow: {
+      id: id("Workflow", "root-case-workflow"),
+      slug: "root-case-workflow",
+    },
+    document: {
+      id: id("Document"),
+      form: {
+        id: id("Form", "root-case-form"),
+        slug: "root-case-form",
       },
     },
   },
 };
 
-export default {
+const workItem = {
+  id: id("WorkItem"),
+  case: _case,
+};
+
+export const rawDocumentWithCase = {
+  id: id("Document"),
+  answers,
+  form,
+  case: _case,
+  __typename: "Document",
+};
+
+export const rawDocumentWithWorkItem = {
   id: id("Document"),
   answers,
   form,
   workItem,
+  __typename: "Document",
+};
+
+export const rawUnlinkedDocument = {
+  id: id("Document"),
+  answers,
+  form,
   __typename: "Document",
 };

--- a/packages/form/tests/unit/lib/document-test.js
+++ b/packages/form/tests/unit/lib/document-test.js
@@ -1,7 +1,11 @@
 import { settled } from "@ember/test-helpers";
 import { module, test, skip } from "qunit";
 
-import data from "./data";
+import {
+  rawDocumentWithCase,
+  rawDocumentWithWorkItem,
+  rawUnlinkedDocument,
+} from "./data";
 
 import { parseDocument } from "@projectcaluma/ember-form/lib/parsers";
 import { setupTest } from "dummy/tests/helpers";
@@ -23,7 +27,7 @@ module("Unit | Library | document", function (hooks) {
     this.set(
       "document",
       new (this.owner.factoryFor("caluma-model:document").class)({
-        raw: parseDocument(data),
+        raw: parseDocument(rawDocumentWithWorkItem),
         owner: this.owner,
       }),
     );
@@ -261,13 +265,73 @@ module("Unit | Library | document", function (hooks) {
     );
   });
 
-  test("computes the correct jexl context", async function (assert) {
+  test("computes the correct jexl context (task form)", async function (assert) {
     assert.expect(1);
 
     assert.deepEqual(this.document.jexlContext, {
       null: null,
       form: "form",
       info: {
+        case: {
+          form: "child-case-form",
+          root: {
+            form: "root-case-form",
+            workflow: "root-case-workflow",
+          },
+          workflow: "child-case-workflow",
+        },
+        root: { form: "form", formMeta: { "is-top-form": true, level: 0 } },
+      },
+    });
+  });
+
+  test("computes the correct jexl context (case form)", async function (assert) {
+    assert.expect(1);
+
+    const documentWithCase = new (this.owner.factoryFor(
+      "caluma-model:document",
+    ).class)({
+      raw: parseDocument(rawDocumentWithCase),
+      owner: this.owner,
+    });
+    assert.deepEqual(documentWithCase.jexlContext, {
+      null: null,
+      form: "form",
+      info: {
+        case: {
+          form: "child-case-form",
+          root: {
+            form: "root-case-form",
+            workflow: "root-case-workflow",
+          },
+          workflow: "child-case-workflow",
+        },
+        root: { form: "form", formMeta: { "is-top-form": true, level: 0 } },
+      },
+    });
+  });
+
+  test("computes the correct jexl context (unlinked document)", async function (assert) {
+    assert.expect(1);
+
+    const documentWithCase = new (this.owner.factoryFor(
+      "caluma-model:document",
+    ).class)({
+      raw: parseDocument(rawUnlinkedDocument),
+      owner: this.owner,
+    });
+    assert.deepEqual(documentWithCase.jexlContext, {
+      null: null,
+      form: "form",
+      info: {
+        case: {
+          form: undefined,
+          root: {
+            form: undefined,
+            workflow: undefined,
+          },
+          workflow: undefined,
+        },
         root: { form: "form", formMeta: { "is-top-form": true, level: 0 } },
       },
     });

--- a/packages/form/tests/unit/lib/field-test.js
+++ b/packages/form/tests/unit/lib/field-test.js
@@ -146,6 +146,7 @@ module("Unit | Library | field", function (hooks) {
           "is-top-form": false,
           level: 1,
         },
+        mainCaseForm: "main-case-form",
         parent: null,
         root: {
           form: "form",

--- a/packages/form/tests/unit/lib/field-test.js
+++ b/packages/form/tests/unit/lib/field-test.js
@@ -3,7 +3,7 @@ import { setupMirage } from "ember-cli-mirage/test-support";
 import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
-import data from "./data";
+import { rawDocumentWithWorkItem } from "./data";
 
 import { getDependenciesFromJexl } from "@projectcaluma/ember-form/lib/dependencies";
 import { parseDocument } from "@projectcaluma/ember-form/lib/parsers";
@@ -18,7 +18,7 @@ module("Unit | Library | field", function (hooks) {
     this.set(
       "document",
       new (this.owner.factoryFor("caluma-model:document").class)({
-        raw: parseDocument(data),
+        raw: parseDocument(rawDocumentWithWorkItem),
         owner: this.owner,
       }),
     );
@@ -146,13 +146,20 @@ module("Unit | Library | field", function (hooks) {
           "is-top-form": false,
           level: 1,
         },
-        mainCaseForm: "main-case-form",
         parent: null,
         root: {
           form: "form",
           formMeta: {
             "is-top-form": true,
             level: 0,
+          },
+        },
+        case: {
+          form: "child-case-form",
+          workflow: "child-case-workflow",
+          root: {
+            form: "root-case-form",
+            workflow: "root-case-workflow",
           },
         },
       },


### PR DESCRIPTION
This is convenient when you'd like to write a JEXL expression in a task form attached to some work item, that depends on the case's main documents' form.

Related backend MRs: 
- https://github.com/projectcaluma/caluma/pull/2204
- https://github.com/projectcaluma/caluma/pull/2205
