### PR TITLE
fix(form): validate table question every time the modal is closed

### DIFF
--- a/packages/form/addon/components/cf-field/input/table.js
+++ b/packages/form/addon/components/cf-field/input/table.js
@@ -126,6 +126,8 @@ export default class CfFieldInputTableComponent extends Component {
       this.documentToEditIsNew = false;
     }
 
+    yield this.args.field.validate.perform();
+
     this.showAddModal = false;
     this.documentToEdit = null;
   }


### PR DESCRIPTION
If a table is being closed (doesn't matter whether via close or save button) the table question must be validated as the data inside the row document might have changed.