### PR TITLE
fix(distribution): remove suggestions from types and defaultTypes

### DIFF
--- a/packages/distribution/addon/config.js
+++ b/packages/distribution/addon/config.js
@@ -96,14 +96,8 @@ export default function config(target, property) {
           },
           new: {
             defaultDeadlineLeadTime: 30,
-            defaultTypes: ["suggestions"],
-            types: {
-              suggestions: {
-                label: "caluma.distribution.new.suggestions",
-                icon: "star",
-                iconColor: "warning",
-              },
-            },
+            defaultTypes: [],
+            types: {},
           },
           permissions: {},
           hooks: {},


### PR DESCRIPTION
## Description

Because we `merge` the default options with any custom supplied options, it is impossible to hide the `suggestions` from the distribution. One of our customers has the situation where a given service should **not** see the `suggestions` because they would always be empty for them.

Because I remove something from the default, this change is potentially breaking.
