### PR TITLE
fix(filters): use 'ids' instead of 'id' for `CaseFilterSetType`

### DIFF
--- a/packages/distribution/addon/gql/queries/controls.graphql
+++ b/packages/distribution/addon/gql/queries/controls.graphql
@@ -67,7 +67,7 @@ query Controls(
       }
     }
   }
-  case: allCases(filter: [{ id: $caseId }]) {
+  case: allCases(filter: [{ ids: [$caseId] }]) {
     edges {
       node {
         id


### PR DESCRIPTION
The 'id' filter was dropped in caluma and causes errors if still used.
