### PR TITLE
chore(deps): update ember-intl 

### DIFF
--- a/packages/-ember-caluma/package.json
+++ b/packages/-ember-caluma/package.json
@@ -57,7 +57,7 @@
     "ember-engines-router-service": "0.6.0",
     "ember-fetch": "8.1.2",
     "ember-flatpickr": "8.0.0",
-    "ember-intl": "6.5.3",
+    "ember-intl": "7.0.4",
     "ember-load-initializers": "2.1.2",
     "ember-math-helpers": "4.0.0",
     "ember-modifier": "4.2.0",

--- a/packages/analytics/package.json
+++ b/packages/analytics/package.json
@@ -30,7 +30,7 @@
     "ember-concurrency": "^4.0.2",
     "ember-engines-router-service": "^0.6.0",
     "ember-fetch": "^8.1.2",
-    "ember-intl": "^6.5.3",
+    "ember-intl": "^7.0.4",
     "ember-power-select": "^7.2.0",
     "ember-sortable": "^5.1.1",
     "ember-uikit": "^9.1.2",

--- a/packages/analytics/tests/helpers/index.js
+++ b/packages/analytics/tests/helpers/index.js
@@ -12,7 +12,7 @@ import {
 
 function setupApplicationTest(hooks, options) {
   upstreamSetupApplicationTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   // Additional setup for application tests can be done here.
   //
@@ -32,7 +32,7 @@ function setupApplicationTest(hooks, options) {
 
 function setupRenderingTest(hooks, options) {
   upstreamSetupRenderingTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
   setupEngine(hooks, "@projectcaluma/ember-analytics");
 
   // Additional setup for rendering tests can be done here.
@@ -40,7 +40,7 @@ function setupRenderingTest(hooks, options) {
 
 function setupTest(hooks, options) {
   upstreamSetupTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
   setupEngine(hooks, "@projectcaluma/ember-analytics");
 
   // Additional setup for unit tests can be done here.

--- a/packages/analytics/tests/integration/components/ca-field-form-test.js
+++ b/packages/analytics/tests/integration/components/ca-field-form-test.js
@@ -1,13 +1,11 @@
 import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | ca-field-form", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, ["en"]);
 
   test("it renders", async function (assert) {
     this.analyticsTable = {
@@ -19,9 +17,7 @@ module("Integration | Component | ca-field-form", function (hooks) {
     await render(hbs`<CaFieldForm @analyticsTable={{this.analyticsTable}} />`, {
       owner: this.engine,
     });
-    assert
-      .dom("[data-test-add-field-button]")
-      .hasText(this.intl.t("caluma.analytics.edit.add-field"));
+    assert.dom("[data-test-add-field-button]").hasText("Add field");
 
     await click("button[data-test-add-field-button]");
 

--- a/packages/analytics/tests/integration/components/ca-field-selector-list-test.js
+++ b/packages/analytics/tests/integration/components/ca-field-selector-list-test.js
@@ -1,6 +1,5 @@
 import { render, findAll } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { reorder } from "ember-sortable/test-support";
 import { module, test } from "qunit";
 
@@ -8,7 +7,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | ca-field-selector-list", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     const edges = [

--- a/packages/analytics/tests/integration/components/ca-field-selector-list/ca-field-alias-input-test.js
+++ b/packages/analytics/tests/integration/components/ca-field-selector-list/ca-field-alias-input-test.js
@@ -1,6 +1,5 @@
 import { render, fillIn } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -9,7 +8,6 @@ module(
   "Integration | Component | ca-field-selector-list/ca-field-alias-input",
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, ["en"]);
 
     test("it renders", async function (assert) {
       assert.expect(4);

--- a/packages/analytics/tests/integration/components/ca-field-selector-list/ca-field-function-select-test.js
+++ b/packages/analytics/tests/integration/components/ca-field-selector-list/ca-field-function-select-test.js
@@ -1,7 +1,6 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -10,7 +9,6 @@ module(
   "Integration | Component | ca-field-selector-list/ca-field-function-select",
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks, ["en"]);
     setupMirage(hooks);
 
     test("it renders", async function (assert) {

--- a/packages/analytics/tests/integration/components/ca-report-builder-test.js
+++ b/packages/analytics/tests/integration/components/ca-report-builder-test.js
@@ -1,7 +1,6 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test, todo } from "qunit";
 
 import ReportsNewRoute from "@projectcaluma/ember-analytics/routes/reports/new";
@@ -10,7 +9,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | ca-report-builder", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function (assert) {
     this.set("startingObjects", [

--- a/packages/analytics/tests/integration/components/ca-report-list-test.js
+++ b/packages/analytics/tests/integration/components/ca-report-list-test.js
@@ -1,13 +1,11 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | ca-report-list", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     assert.expect(2);
@@ -24,7 +22,7 @@ module("Integration | Component | ca-report-list", function (hooks) {
       { owner: this.engine },
     );
 
-    assert.dom(this.element).containsText("t:caluma.analytics.list.list-title");
+    assert.dom(this.element).containsText("All reports");
     assert.dom("[data-test-report-list-item]").exists({ count: 2 });
   });
 });

--- a/packages/analytics/tests/integration/components/ca-report-preview-test.js
+++ b/packages/analytics/tests/integration/components/ca-report-preview-test.js
@@ -1,18 +1,16 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test, todo } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | ca-report-preview", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     await render(hbs`<CaReportPreview />`, { owner: this.engine });
 
-    assert.dom(this.element).hasText("t:caluma.analytics.preview.export:()");
+    assert.dom(this.element).hasText("Export");
     assert.dom(this.element.querySelector("#reports-table")).exists();
   });
 

--- a/packages/analytics/tests/integration/components/ca-toggle-switch-test.js
+++ b/packages/analytics/tests/integration/components/ca-toggle-switch-test.js
@@ -1,13 +1,11 @@
 import { render, click, settled } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | ca-toggle-switch", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks, ["en"]);
 
   test("it renders", async function (assert) {
     assert.expect(2);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,7 @@
     "ember-concurrency": "^4.0.2",
     "ember-fetch": "^8.1.2",
     "ember-inflector": "^4.0.2",
-    "ember-intl": "^6.5.3",
+    "ember-intl": "^7.0.4",
     "ember-modify-based-class-resource": "^1.1.0",
     "ember-uikit": "^9.1.2",
     "graphql": "^15.8.0",

--- a/packages/core/tests/helpers/index.js
+++ b/packages/core/tests/helpers/index.js
@@ -11,7 +11,7 @@ import {
 
 function setupApplicationTest(hooks, options) {
   upstreamSetupApplicationTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   // Additional setup for application tests can be done here.
   //
@@ -31,14 +31,14 @@ function setupApplicationTest(hooks, options) {
 
 function setupRenderingTest(hooks, options) {
   upstreamSetupRenderingTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   // Additional setup for rendering tests can be done here.
 }
 
 function setupTest(hooks, options) {
   upstreamSetupTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   // Additional setup for unit tests can be done here.
 }

--- a/packages/core/tests/unit/caluma-query/models/work-item-test.js
+++ b/packages/core/tests/unit/caluma-query/models/work-item-test.js
@@ -1,5 +1,4 @@
 import { setOwner } from "@ember/application";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import WorkItemModel from "@projectcaluma/ember-core/caluma-query/models/work-item";
@@ -9,7 +8,6 @@ const UUID = "96accc67-95d6-4e5d-82c6-20f3f4bc5942";
 
 module("Unit | Caluma Query | Models | work-item", function (hooks) {
   setupTest(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     this.model = new WorkItemModel(
@@ -29,10 +27,7 @@ module("Unit | Caluma Query | Models | work-item", function (hooks) {
     assert.expect(10);
 
     assert.strictEqual(this.model.id, UUID);
-    assert.strictEqual(
-      this.model.status,
-      "t:caluma.caluma-query.work-item.status.COMPLETED:()",
-    );
+    assert.strictEqual(this.model.status, "Completed");
 
     ["createdAt", "closedAt", "modifiedAt", "deadline"].forEach((attr) => {
       assert.true(this.model[attr] instanceof Date);

--- a/packages/core/tests/unit/services/caluma-options-test.js
+++ b/packages/core/tests/unit/services/caluma-options-test.js
@@ -1,11 +1,9 @@
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupTest } from "dummy/tests/helpers";
 
 module("Unit | Service | options", function (hooks) {
   setupTest(hooks);
-  setupIntl(hooks);
 
   test("it exists", function (assert) {
     const service = this.owner.lookup("service:calumaOptions");

--- a/packages/distribution/package.json
+++ b/packages/distribution/package.json
@@ -32,7 +32,7 @@
     "ember-engines-router-service": "^0.6.0",
     "ember-fetch": "^8.1.2",
     "ember-flatpickr": "^8.0.0",
-    "ember-intl": "^6.5.3",
+    "ember-intl": "^7.0.4",
     "ember-svg-jar": "^2.4.9",
     "ember-test-selectors": "^7.0.0",
     "ember-uikit": "^9.1.2",

--- a/packages/distribution/tests/helpers/index.js
+++ b/packages/distribution/tests/helpers/index.js
@@ -12,7 +12,7 @@ import {
 
 function setupApplicationTest(hooks, options) {
   upstreamSetupApplicationTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   // Additional setup for application tests can be done here.
   //
@@ -32,7 +32,7 @@ function setupApplicationTest(hooks, options) {
 
 function setupRenderingTest(hooks, options) {
   upstreamSetupRenderingTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
   setupEngine(hooks, "@projectcaluma/ember-distribution");
 
   // Additional setup for rendering tests can be done here.
@@ -40,7 +40,7 @@ function setupRenderingTest(hooks, options) {
 
 function setupTest(hooks, options) {
   upstreamSetupTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
   setupEngine(hooks, "@projectcaluma/ember-distribution");
 
   // Additional setup for unit tests can be done here.

--- a/packages/distribution/tests/integration/components/cd-document-header-test.js
+++ b/packages/distribution/tests/integration/components/cd-document-header-test.js
@@ -1,13 +1,11 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cd-document-header", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     this.status = "Test";

--- a/packages/distribution/tests/integration/components/cd-inquiry-answer-form-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-answer-form-test.js
@@ -1,7 +1,6 @@
 import { click, fillIn, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import {
@@ -14,7 +13,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | cd-inquiry-answer-form", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function (assert) {
     createBlueprint(this.server);
@@ -45,13 +43,9 @@ module("Integration | Component | cd-inquiry-answer-form", function (hooks) {
 
     assert
       .dom("[data-test-document-header]")
-      .containsText(
-        "Inquiry answer t:caluma.distribution.answer.buttons.compose.status:()",
-      );
+      .containsText("Inquiry answer In progress");
     assert.dom("form").exists();
-    assert
-      .dom("button.uk-button-primary")
-      .hasText("t:caluma.distribution.answer.buttons.compose.label:()");
+    assert.dom("button.uk-button-primary").hasText("Release for review");
   });
 
   test("it renders the configured buttons for work items and completes them on click", async function (assert) {

--- a/packages/distribution/tests/integration/components/cd-inquiry-dialog-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-dialog-test.js
@@ -1,7 +1,6 @@
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import {
@@ -18,7 +17,6 @@ import confirm from "dummy/tests/helpers/confirm";
 module("Integration | Component | cd-inquiry-dialog", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     createBlueprint(this.server);
@@ -85,9 +83,7 @@ module("Integration | Component | cd-inquiry-dialog", function (hooks) {
     await click("[data-test-withdraw]");
     await confirm();
 
-    assert
-      .dom("[data-test-deadline]")
-      .containsText("t:caluma.distribution.withdraw.status:()");
+    assert.dom("[data-test-deadline]").containsText("Withdrawn");
 
     this.engine.lookup("service:router").transitionTo = (route) => {
       assert.strictEqual(route, "index");

--- a/packages/distribution/tests/integration/components/cd-inquiry-dialog/inquiry-deadline-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-dialog/inquiry-deadline-test.js
@@ -1,6 +1,5 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { DateTime } from "luxon";
 import { module, test } from "qunit";
 
@@ -11,7 +10,6 @@ module(
   "Integration | Component | cd-inquiry-dialog/inquiry-deadline",
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks);
 
     test("it renders", async function (assert) {
       const deadline = DateTime.now();
@@ -39,9 +37,7 @@ module(
         { owner: this.engine },
       );
 
-      assert
-        .dom(".uk-text-muted")
-        .hasText("t:caluma.distribution.withdraw.status:()");
+      assert.dom(".uk-text-muted").hasText("Withdrawn");
       assert.dom("[uk-icon]").hasAttribute("icon", "ban");
     });
 
@@ -53,9 +49,7 @@ module(
         { owner: this.engine },
       );
 
-      assert
-        .dom(".uk-text-muted")
-        .hasText("t:caluma.distribution.status.skipped:()");
+      assert.dom(".uk-text-muted").hasText("Aborted");
       assert.dom("[uk-icon]").hasAttribute("icon", "lock");
     });
   },

--- a/packages/distribution/tests/integration/components/cd-inquiry-dialog/inquiry-part-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-dialog/inquiry-part-test.js
@@ -1,7 +1,6 @@
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { DateTime } from "luxon";
 import { module, test } from "qunit";
 
@@ -14,7 +13,6 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
     setupMirage(hooks);
-    setupIntl(hooks);
 
     hooks.beforeEach(function () {
       this.createdAt = DateTime.fromObject({
@@ -95,9 +93,7 @@ module(
 
       await this.inquiry.setSuspended();
 
-      assert
-        .dom("ul.uk-subnav > li > a[data-test-edit]")
-        .hasText("t:caluma.distribution.edit.link:()");
+      assert.dom("ul.uk-subnav > li > a[data-test-edit]").hasText("Edit");
       assert.dom("ul.uk-subnav > li > a[data-test-details]").doesNotExist();
     });
 
@@ -119,9 +115,7 @@ module(
 
       await this.inquiry.setReady();
 
-      assert
-        .dom("ul.uk-subnav > li > a[data-test-answer]")
-        .hasText("t:caluma.distribution.answer.link:()");
+      assert.dom("ul.uk-subnav > li > a[data-test-answer]").hasText("Answer");
       assert.dom("ul.uk-subnav > li > a[data-test-details]").exists();
     });
 
@@ -135,9 +129,7 @@ module(
         { owner: this.engine },
       );
 
-      assert
-        .dom("[data-test-title] .uk-label")
-        .hasText("t:caluma.distribution.answer.buttons.confirm.status:()");
+      assert.dom("[data-test-title] .uk-label").hasText("In review");
 
       await this.inquiry.setReadyChildWorkItem("some-task");
 
@@ -145,9 +137,7 @@ module(
 
       await this.inquiry.setReadyChildWorkItem("adjust-inquiry-answer");
 
-      assert
-        .dom("[data-test-title] .uk-label")
-        .hasText("t:caluma.distribution.answer.buttons.adjust.status:()");
+      assert.dom("[data-test-title] .uk-label").hasText("In revision");
     });
 
     test("it renders a link for sending a reminder for the inquiry when permitted", async function (assert) {
@@ -171,9 +161,7 @@ module(
         DateTime.now().minus({ days: 2 }).toISODate(),
       );
 
-      assert
-        .dom("[data-test-send-reminder]")
-        .hasText("t:caluma.distribution.reminder.link:()");
+      assert.dom("[data-test-send-reminder]").hasText("Send reminder");
     });
 
     test("it can send a reminder for an overdue inquiry", async function (assert) {

--- a/packages/distribution/tests/integration/components/cd-inquiry-dialog/inquiry-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-dialog/inquiry-test.js
@@ -1,6 +1,5 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import inquiry from "dummy/tests/helpers/inquiry";
 
 module("Integration | Component | cd-inquiry-dialog/inquiry", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     this.inquiry = inquiry();

--- a/packages/distribution/tests/integration/components/cd-inquiry-edit-form-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-edit-form-test.js
@@ -1,7 +1,6 @@
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import {
@@ -13,7 +12,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | cd-inquiry-edit-form", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     createBlueprint(this.server);
@@ -35,13 +33,9 @@ module("Integration | Component | cd-inquiry-edit-form", function (hooks) {
       owner: this.engine,
     });
 
-    assert
-      .dom("[data-test-document-header]")
-      .hasText("Inquiry (group2) t:caluma.distribution.status.draft:()");
+    assert.dom("[data-test-document-header]").hasText("Inquiry (group2) Draft");
     assert.dom("form").exists();
-    assert
-      .dom("button.uk-button-primary")
-      .hasText("t:caluma.distribution.edit.send:()");
+    assert.dom("button.uk-button-primary").hasText("Send current inquiry");
   });
 
   test("it resumes the work item on send", async function (assert) {

--- a/packages/distribution/tests/integration/components/cd-inquiry-new-form-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-new-form-test.js
@@ -2,7 +2,6 @@ import { render, click, fillIn } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { setFlatpickrDate } from "ember-flatpickr/test-support/helpers";
-import { setupIntl } from "ember-intl/test-support";
 import { DateTime } from "luxon";
 import { module, test } from "qunit";
 
@@ -14,7 +13,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cd-inquiry-new-form", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {

--- a/packages/distribution/tests/integration/components/cd-navigation-test.js
+++ b/packages/distribution/tests/integration/components/cd-navigation-test.js
@@ -1,7 +1,6 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import distribution from "@projectcaluma/ember-testing/scenarios/distribution";
@@ -10,7 +9,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | cd-navigation", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     const distributionCase = distribution(this.server, [
@@ -37,12 +35,12 @@ module("Integration | Component | cd-navigation", function (hooks) {
 
     assert
       .dom("ul:first-child > li:nth-of-type(2) > a")
-      .hasText("t:caluma.distribution.types.addressed:()");
+      .hasText("Own inquiries");
     assert
       .dom("ul:first-child > li:nth-of-type(3) > a")
-      .hasText("t:caluma.distribution.types.controlling:()");
+      .hasText("Requested inquiries");
     assert
       .dom("ul:first-child > li:nth-of-type(4) > a")
-      .hasText("t:caluma.distribution.types.more:()");
+      .hasText("More inquiries");
   });
 });

--- a/packages/distribution/tests/integration/components/cd-navigation/controls-test.js
+++ b/packages/distribution/tests/integration/components/cd-navigation/controls-test.js
@@ -1,7 +1,6 @@
 import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import distribution from "@projectcaluma/ember-testing/scenarios/distribution";
@@ -11,7 +10,6 @@ import confirm from "dummy/tests/helpers/confirm";
 module("Integration | Component | cd-navigation/controls", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     const distributionCase = distribution(this.server, [

--- a/packages/distribution/tests/integration/components/cd-navigation/item-test.js
+++ b/packages/distribution/tests/integration/components/cd-navigation/item-test.js
@@ -1,6 +1,5 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import inquiry from "dummy/tests/helpers/inquiry";
 
 module("Integration | Component | cd-navigation/item", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     this.type = "controlling";
@@ -28,16 +26,9 @@ module("Integration | Component | cd-navigation/item", function (hooks) {
     assert.dom("li > a").hasText("addressed");
 
     this.set("type", "addressed");
-    assert
-      .dom("li > a")
-      .hasText(
-        't:caluma.distribution.attention-to:("abbr":true,"subject":"controlling")',
-      );
+    assert.dom("li > a").hasText("attn. controlling");
     assert
       .dom("li > a > span")
-      .hasAttribute(
-        "title",
-        't:caluma.distribution.attention-to:("abbr":false,"subject":"controlling")',
-      );
+      .hasAttribute("title", "attention to controlling");
   });
 });

--- a/packages/distribution/tests/integration/components/cd-navigation/section-test.js
+++ b/packages/distribution/tests/integration/components/cd-navigation/section-test.js
@@ -1,7 +1,6 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import {
@@ -14,7 +13,6 @@ import inquiry from "dummy/tests/helpers/inquiry";
 module("Integration | Component | cd-navigation/section", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     createBlueprint(this.server);
@@ -60,27 +58,21 @@ module("Integration | Component | cd-navigation/section", function (hooks) {
       owner: this.engine,
     });
 
-    assert
-      .dom("li:first-of-type > a")
-      .hasText("t:caluma.distribution.types.controlling:()");
+    assert.dom("li:first-of-type > a").hasText("Requested inquiries");
     assert.dom("ul > li:nth-of-type(1) > a").containsText("addressed1");
     assert.dom("ul > li:nth-of-type(2) > a").containsText("addressed2");
     assert.dom("ul > li:nth-of-type(3) > a").containsText("addressed3");
 
     this.set("type", "more");
 
-    assert
-      .dom("li:first-of-type > a")
-      .hasText("t:caluma.distribution.types.more:()");
+    assert.dom("li:first-of-type > a").hasText("More inquiries");
     assert.dom("ul > li:nth-of-type(1) > a").containsText("addressed1");
     assert.dom("ul > li:nth-of-type(2) > a").containsText("addressed2");
     assert.dom("ul > li:nth-of-type(3) > a").containsText("addressed3");
 
     this.set("type", "addressed");
 
-    assert
-      .dom("li:first-of-type > a")
-      .hasText("t:caluma.distribution.types.addressed:()");
+    assert.dom("li:first-of-type > a").hasText("Own inquiries");
     assert.dom("ul > li:nth-of-type(1) > a").containsText("controlling1");
     assert.dom("ul > li:nth-of-type(2) > a").containsText("controlling2");
     assert.dom("ul > li:nth-of-type(3) > a").containsText("controlling3");

--- a/packages/distribution/tests/integration/components/cd-notfound-test.js
+++ b/packages/distribution/tests/integration/components/cd-notfound-test.js
@@ -1,24 +1,18 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cd-notfound", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     await render(hbs`<CdNotfound />`, { owner: this.engine });
 
-    assert.dom("h1").hasText("t:caluma.distribution.notfound.title:()");
-    assert.dom("h2").hasText("t:caluma.distribution.notfound.subtitle:()");
-    assert
-      .dom("p")
-      .hasText(
-        "t:caluma.distribution.notfound.back:() t:caluma.distribution.notfound.link:()",
-      );
-    assert.dom("p > a").hasText("t:caluma.distribution.notfound.link:()");
+    assert.dom("h1").hasText("404");
+    assert.dom("h2").hasText("Page not found!");
+    assert.dom("p").hasText("Go back to the landing page");
+    assert.dom("p > a").hasText("landing page");
   });
 });

--- a/packages/distribution/tests/integration/components/cd-truncated-test.js
+++ b/packages/distribution/tests/integration/components/cd-truncated-test.js
@@ -1,20 +1,18 @@
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cd-truncated", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it truncates text", async function (assert) {
     await render(hbs`<CdTruncated @text="123456789" @length={{5}} />`, {
       owner: this.engine,
     });
 
-    assert.dom(this.element).hasText("12... t:caluma.distribution.more:()");
+    assert.dom(this.element).hasText("12... more");
   });
 
   test("it doesn't truncate text that is not longer than the given length", async function (assert) {
@@ -30,10 +28,10 @@ module("Integration | Component | cd-truncated", function (hooks) {
       owner: this.engine,
     });
 
-    assert.dom(this.element).hasText("12... t:caluma.distribution.more:()");
+    assert.dom(this.element).hasText("12... more");
 
     await click("a");
 
-    assert.dom(this.element).hasText("123456789 t:caluma.distribution.less:()");
+    assert.dom(this.element).hasText("123456789 less");
   });
 });

--- a/packages/distribution/tests/unit/utils/inquiry-answer-status-test.js
+++ b/packages/distribution/tests/unit/utils/inquiry-answer-status-test.js
@@ -1,7 +1,6 @@
 import { setOwner } from "@ember/application";
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import config from "@projectcaluma/ember-distribution/config";
@@ -18,7 +17,6 @@ class MyClass {
 
 module("Unit | Utility | inquiry-answer-status", function (hooks) {
   setupTest(hooks);
-  setupIntl(hooks);
 
   test("it works", function (assert) {
     this.obj = new MyClass();
@@ -26,17 +24,11 @@ module("Unit | Utility | inquiry-answer-status", function (hooks) {
 
     setOwner(this.obj, this.owner);
 
-    assert.strictEqual(
-      this.obj.status,
-      "t:caluma.distribution.answer.buttons.confirm.status:()",
-    );
+    assert.strictEqual(this.obj.status, "In review");
 
     this.obj.inquiry.setReadyChildWorkItem("adjust-inquiry-answer");
 
-    assert.strictEqual(
-      this.obj.status,
-      "t:caluma.distribution.answer.buttons.adjust.status:()",
-    );
+    assert.strictEqual(this.obj.status, "In revision");
 
     this.obj.inquiry.setReadyChildWorkItem("some-other-task");
 

--- a/packages/distribution/tests/unit/utils/inquiry-status-test.js
+++ b/packages/distribution/tests/unit/utils/inquiry-status-test.js
@@ -2,7 +2,6 @@ import { setOwner } from "@ember/application";
 import { inject as service } from "@ember/service";
 import { settled } from "@ember/test-helpers";
 import { tracked } from "@glimmer/tracking";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import config from "@projectcaluma/ember-distribution/config";
@@ -24,7 +23,6 @@ class MyClass {
 
 module("Unit | Utility | inquiry-status", function (hooks) {
   setupTest(hooks);
-  setupIntl(hooks);
 
   test("it works", async function (assert) {
     this.obj = new MyClass();
@@ -68,7 +66,7 @@ module("Unit | Utility | inquiry-status", function (hooks) {
     assert.deepEqual(this.obj.status, {
       color: "muted",
       icon: "commenting",
-      label: "t:caluma.distribution.status.draft:()",
+      label: "Draft",
       slug: "draft",
     });
 
@@ -77,7 +75,7 @@ module("Unit | Utility | inquiry-status", function (hooks) {
     assert.deepEqual(this.obj.status, {
       color: "muted",
       icon: "lock",
-      label: "t:caluma.distribution.status.skipped:()",
+      label: "Aborted",
       slug: "skipped",
     });
 
@@ -89,7 +87,7 @@ module("Unit | Utility | inquiry-status", function (hooks) {
     assert.deepEqual(this.obj.status, {
       color: "emphasis",
       icon: "user",
-      label: "t:caluma.distribution.answer.buttons.confirm.status:()",
+      label: "In review",
     });
 
     this.set("obj.type", "addressed");
@@ -97,7 +95,7 @@ module("Unit | Utility | inquiry-status", function (hooks) {
     assert.deepEqual(this.obj.status, {
       color: "muted",
       icon: "user",
-      label: "t:caluma.distribution.answer.buttons.confirm.status:()",
+      label: "In review",
     });
 
     this.set("obj.type", "more");
@@ -105,7 +103,7 @@ module("Unit | Utility | inquiry-status", function (hooks) {
     assert.deepEqual(this.obj.status, {
       color: "emphasis",
       icon: "comment",
-      label: "t:caluma.distribution.status.sent:()",
+      label: "Sent",
       slug: "sent",
     });
 
@@ -118,7 +116,7 @@ module("Unit | Utility | inquiry-status", function (hooks) {
     assert.deepEqual(this.obj.status, {
       color: "emphasis",
       icon: "comment",
-      label: "t:caluma.distribution.status.sent:()",
+      label: "Sent",
       slug: "sent",
     });
 
@@ -127,7 +125,7 @@ module("Unit | Utility | inquiry-status", function (hooks) {
     assert.deepEqual(this.obj.status, {
       color: "muted",
       icon: "commenting",
-      label: "t:caluma.distribution.status.draft:()",
+      label: "Draft",
       slug: "draft",
     });
 
@@ -136,7 +134,7 @@ module("Unit | Utility | inquiry-status", function (hooks) {
     assert.deepEqual(this.obj.status, {
       color: "emphasis",
       icon: "comment",
-      label: "t:caluma.distribution.status.sent:()",
+      label: "Sent",
       slug: "sent",
     });
 
@@ -149,7 +147,7 @@ module("Unit | Utility | inquiry-status", function (hooks) {
     assert.deepEqual(this.obj.status, {
       color: "emphasis",
       icon: "file-edit",
-      label: "t:caluma.distribution.status.in-progress:()",
+      label: "In Progress",
       slug: "in-progress",
     });
 
@@ -158,7 +156,7 @@ module("Unit | Utility | inquiry-status", function (hooks) {
     assert.deepEqual(this.obj.status, {
       color: "muted",
       icon: "file-edit",
-      label: "t:caluma.distribution.status.in-progress:()",
+      label: "In Progress",
       slug: "in-progress",
     });
 
@@ -167,7 +165,7 @@ module("Unit | Utility | inquiry-status", function (hooks) {
     assert.deepEqual(this.obj.status, {
       color: "emphasis",
       icon: "comment",
-      label: "t:caluma.distribution.status.sent:()",
+      label: "Sent",
       slug: "sent",
     });
   });

--- a/packages/form-builder/package.json
+++ b/packages/form-builder/package.json
@@ -35,7 +35,7 @@
     "ember-engines-router-service": "^0.6.0",
     "ember-fetch": "^8.1.2",
     "ember-flatpickr": "^8.0.0",
-    "ember-intl": "^6.5.3",
+    "ember-intl": "^7.0.4",
     "ember-math-helpers": "^4.0.0",
     "ember-power-select": "^7.2.0",
     "ember-test-selectors": "^7.0.0",

--- a/packages/form-builder/tests/acceptance/form-copy-test.js
+++ b/packages/form-builder/tests/acceptance/form-copy-test.js
@@ -1,6 +1,5 @@
 import { visit, click, fillIn, currentURL } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | form copy", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("can copy a form", async function (assert) {
     assert.expect(5);

--- a/packages/form-builder/tests/acceptance/form-edit-test.js
+++ b/packages/form-builder/tests/acceptance/form-edit-test.js
@@ -1,6 +1,5 @@
 import { visit, currentURL, click, fillIn } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | form edit", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("can edit a form", async function (assert) {
     assert.expect(3);

--- a/packages/form-builder/tests/acceptance/form-list-test.js
+++ b/packages/form-builder/tests/acceptance/form-list-test.js
@@ -1,6 +1,5 @@
 import { visit, click, fillIn, currentURL } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | form list", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("can list forms", async function (assert) {
     assert.expect(1);

--- a/packages/form-builder/tests/acceptance/form-new-test.js
+++ b/packages/form-builder/tests/acceptance/form-new-test.js
@@ -1,6 +1,5 @@
 import { visit, currentURL, click, fillIn } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | form new", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("can create a form", async function (assert) {
     assert.expect(3);

--- a/packages/form-builder/tests/acceptance/navigation-test.js
+++ b/packages/form-builder/tests/acceptance/navigation-test.js
@@ -1,6 +1,5 @@
 import { visit, currentURL, click } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | navigation", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     this.server.create("form", {

--- a/packages/form-builder/tests/acceptance/question-add-test.js
+++ b/packages/form-builder/tests/acceptance/question-add-test.js
@@ -1,6 +1,5 @@
 import { visit, currentURL, click, fillIn, settled } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | question add", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("can add an existing question", async function (assert) {
     assert.expect(3);

--- a/packages/form-builder/tests/acceptance/question-edit-test.js
+++ b/packages/form-builder/tests/acceptance/question-edit-test.js
@@ -1,6 +1,5 @@
 import { visit, currentURL, click, fillIn } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | question edit", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("can edit question", async function (assert) {
     assert.expect(3);

--- a/packages/form-builder/tests/acceptance/question-link-form-test.js
+++ b/packages/form-builder/tests/acceptance/question-link-form-test.js
@@ -1,6 +1,5 @@
 import { visit, click, currentURL } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | question link form", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("can link to subforms", async function (assert) {
     assert.expect(10);

--- a/packages/form-builder/tests/acceptance/question-new-test.js
+++ b/packages/form-builder/tests/acceptance/question-new-test.js
@@ -1,6 +1,5 @@
 import { visit, currentURL, click, fillIn } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | question new", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("can create a question", async function (assert) {
     assert.expect(4);

--- a/packages/form-builder/tests/acceptance/question-remove-test.js
+++ b/packages/form-builder/tests/acceptance/question-remove-test.js
@@ -1,6 +1,5 @@
 import { visit, currentURL, click } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | question remove", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("can remove a question", async function (assert) {
     assert.expect(4);

--- a/packages/form-builder/tests/acceptance/question-reorder-test.js
+++ b/packages/form-builder/tests/acceptance/question-reorder-test.js
@@ -1,6 +1,5 @@
 import { visit, triggerEvent, find } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | question reorder", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("can reorder questions", async function (assert) {
     assert.expect(2);

--- a/packages/form-builder/tests/acceptance/question-usage-test.js
+++ b/packages/form-builder/tests/acceptance/question-usage-test.js
@@ -1,6 +1,5 @@
 import { visit, click } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupApplicationTest } from "dummy/tests/helpers";
@@ -8,7 +7,6 @@ import { setupApplicationTest } from "dummy/tests/helpers";
 module("Acceptance | question usage", function (hooks) {
   setupApplicationTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("can show the question usage", async function (assert) {
     assert.expect(4);

--- a/packages/form-builder/tests/helpers/index.js
+++ b/packages/form-builder/tests/helpers/index.js
@@ -21,7 +21,7 @@ function setApplicationInstance() {
 
 function setupApplicationTest(hooks, options) {
   upstreamSetupApplicationTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   hooks.beforeEach(setApplicationInstance);
 
@@ -43,7 +43,7 @@ function setupApplicationTest(hooks, options) {
 
 function setupRenderingTest(hooks, options) {
   upstreamSetupRenderingTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
   setupEngine(hooks, "@projectcaluma/ember-form-builder");
 
   hooks.beforeEach(setApplicationInstance);
@@ -51,7 +51,7 @@ function setupRenderingTest(hooks, options) {
 
 function setupTest(hooks, options) {
   upstreamSetupTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
   setupEngine(hooks, "@projectcaluma/ember-form-builder");
 
   hooks.beforeEach(setApplicationInstance);

--- a/packages/form-builder/tests/integration/components/cfb-form-editor-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor-test.js
@@ -1,7 +1,6 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -9,7 +8,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | cfb-form-editor", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     this.form = this.server.create("form", {

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/general-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/general-test.js
@@ -1,7 +1,6 @@
 import { render, click, fillIn, blur } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl, t } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -10,7 +9,6 @@ import graphqlError from "dummy/tests/helpers/graphql-error";
 module("Integration | Component | cfb-form-editor/general", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, "en");
 
   test("it renders", async function (assert) {
     assert.expect(4);
@@ -190,9 +188,7 @@ module("Integration | Component | cfb-form-editor/general", function (hooks) {
       owner: this.engine,
     });
 
-    assert
-      .dom("p")
-      .hasText(t("caluma.form-builder.form.not-found", { slug: "test-slug" }));
+    assert.dom("p").hasText("No form with slug 'test-slug' found");
   });
 
   test("it validates the slug", async function (assert) {
@@ -210,7 +206,7 @@ module("Integration | Component | cfb-form-editor/general", function (hooks) {
 
     assert
       .dom("small.uk-text-danger")
-      .hasText(t("caluma.form-builder.validations.form.slug"));
+      .hasText("A form with this slug already exists");
 
     await fillIn("input[name=slug]", "valid-slug");
 
@@ -220,6 +216,6 @@ module("Integration | Component | cfb-form-editor/general", function (hooks) {
 
     assert
       .dom("small.uk-text-danger")
-      .hasText(t("caluma.form-builder.validations.form.slug"));
+      .hasText("A form with this slug already exists");
   });
 });

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question-list-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question-list-test.js
@@ -1,7 +1,6 @@
 import { render, click, find, fillIn, triggerEvent } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -12,7 +11,6 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
     setupMirage(hooks);
-    setupIntl(hooks);
 
     hooks.beforeEach(function () {
       this.form = this.server.create("form", {
@@ -47,19 +45,21 @@ module(
       assert.dom("[data-test-question-list-empty]").exists();
       assert
         .dom("[data-test-question-list-empty]")
-        .hasText("t:caluma.form-builder.question.empty:()");
+        .hasText(
+          "You have not yet added a question. Press the plus button above to do so!",
+        );
 
       await click("[data-test-add-question]");
       await fillIn("input[type=search]", "thisslugisveryunlikelytoexist");
       assert
         .dom("[data-test-question-list-empty]")
-        .hasText("t:caluma.form-builder.global.empty-search:()");
+        .hasText("No results found. Adjust your search to get better results.");
 
       this.set("mode", "remove");
       await fillIn("input[type=search]", "thisslugisveryunlikelytoexist");
       assert
         .dom("[data-test-question-list-empty]")
-        .hasText("t:caluma.form-builder.global.empty-search:()");
+        .hasText("No results found. Adjust your search to get better results.");
     });
 
     test("it links subforms in form questions", async function (assert) {

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question-list/item-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question-list/item-test.js
@@ -1,7 +1,6 @@
 import { render, settled } from "@ember/test-helpers";
 import { tracked } from "@glimmer/tracking";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -19,7 +18,6 @@ module(
   "Integration | Component | cfb-form-editor/question-list/item",
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks);
 
     test("it renders", async function (assert) {
       assert.expect(13);
@@ -35,11 +33,7 @@ module(
         { owner: this.engine },
       );
 
-      assert
-        .dom("li")
-        .hasText(
-          "test-question Test Question? t:caluma.form-builder.question.types.TextQuestion:()",
-        );
+      assert.dom("li").hasText("test-question Test Question? Text");
 
       assert.dom(".cfb-form-editor__question-list__item__required").exists();
       assert

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question-test.js
@@ -2,7 +2,6 @@ import { render, fillIn, blur, click, select } from "@ember/test-helpers";
 import Component from "@glimmer/component";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { selectChoose } from "ember-power-select/test-support";
 import { module, test } from "qunit";
 
@@ -12,7 +11,6 @@ import graphqlError from "dummy/tests/helpers/graphql-error";
 module("Integration | Component | cfb-form-editor/question", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     this.server.create("format-validator", { slug: "email" });
@@ -159,9 +157,7 @@ module("Integration | Component | cfb-form-editor/question", function (hooks) {
       owner: this.engine,
     });
 
-    assert
-      .dom("p")
-      .hasText('t:caluma.form-builder.question.not-found:("slug":"test-slug")');
+    assert.dom("p").hasText("No question with slug 'test-slug' found");
   });
 
   test("it suggests a slug", async function (assert) {
@@ -466,9 +462,7 @@ module("Integration | Component | cfb-form-editor/question", function (hooks) {
     await fillIn("[name=__typename]", "TableQuestion");
     await fillIn("[name=label]", "Label");
 
-    assert
-      .dom(".ember-power-select-trigger")
-      .hasText("t:caluma.form-builder.question.no-selection:()");
+    assert.dom(".ember-power-select-trigger").hasText("No selection");
     await click(".ember-power-select-trigger");
     const options = [
       ...document.querySelectorAll(".ember-power-select-option"),
@@ -547,9 +541,7 @@ module("Integration | Component | cfb-form-editor/question", function (hooks) {
     await fillIn("[name=__typename]", "FormQuestion");
     await fillIn("[name=label]", "Label");
 
-    assert
-      .dom(".ember-power-select-trigger")
-      .hasText("t:caluma.form-builder.question.no-selection:()");
+    assert.dom(".ember-power-select-trigger").hasText("No selection");
     await click(".ember-power-select-trigger");
     const options = [
       ...document.querySelectorAll(".ember-power-select-option"),
@@ -648,7 +640,7 @@ module("Integration | Component | cfb-form-editor/question", function (hooks) {
 
     assert
       .dom("small.uk-text-danger")
-      .hasText("t:caluma.form-builder.validations.question.slug:()");
+      .hasText("A question with this slug already exists");
 
     await fillIn("input[name=slug]", "valid-slug");
     await blur("input[name=slug]");
@@ -660,7 +652,7 @@ module("Integration | Component | cfb-form-editor/question", function (hooks) {
 
     assert
       .dom("small.uk-text-danger")
-      .hasText("t:caluma.form-builder.validations.question.slug:()");
+      .hasText("A question with this slug already exists");
   });
 
   test("it auto-suggests the slug if it has not been manually changed", async function (assert) {

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question-usage-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question-usage-test.js
@@ -1,7 +1,6 @@
 import { render, click, waitFor } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -11,7 +10,6 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
     setupMirage(hooks);
-    setupIntl(hooks);
 
     test("it renders", async function (assert) {
       this.set(

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question/options-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question/options-test.js
@@ -2,7 +2,6 @@ import { render, click } from "@ember/test-helpers";
 import Changeset from "ember-changeset";
 import lookupValidator from "ember-changeset-validations";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import optionValidations from "@projectcaluma/ember-form-builder/validations/option";
@@ -27,7 +26,6 @@ module(
   "Integration | Component | cfb-form-editor/question/options",
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks);
 
     hooks.beforeEach(function () {
       this.model = { slug: "prefix" };

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question/validation-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question/validation-test.js
@@ -1,7 +1,6 @@
 import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -11,7 +10,6 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
     setupMirage(hooks);
-    setupIntl(hooks);
 
     hooks.beforeEach(function () {
       this.server.createList("format-validator", 5);

--- a/packages/form-builder/tests/integration/components/cfb-form-list-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-list-test.js
@@ -1,7 +1,6 @@
 import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -9,7 +8,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | cfb-form-list", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.before(function () {
     this.noop = () => {};

--- a/packages/form-builder/tests/integration/components/cfb-form-list/item-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-list/item-test.js
@@ -1,13 +1,11 @@
 import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cfb-form-list/item", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     this.set("form", {

--- a/packages/form-builder/tests/integration/components/cfb-jexl-boolean-toggle-switch-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-jexl-boolean-toggle-switch-test.js
@@ -1,6 +1,5 @@
 import { render, click, settled } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -9,7 +8,6 @@ module(
   "Integration | Component | cfb-jexl-boolean-toggle-switch",
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks);
 
     test("it renders", async function (assert) {
       assert.expect(2);

--- a/packages/form-builder/tests/integration/components/cfb-navigation-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-navigation-test.js
@@ -1,6 +1,5 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 import { stub } from "sinon";
 
@@ -8,7 +7,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cfb-navigation", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     assert.expect(1);

--- a/packages/form-builder/tests/integration/components/cfb-toggle-switch-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-toggle-switch-test.js
@@ -1,13 +1,11 @@
 import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cfb-toggle-switch", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     assert.expect(2);

--- a/packages/form-builder/tests/unit/validators/slug-test.js
+++ b/packages/form-builder/tests/unit/validators/slug-test.js
@@ -1,5 +1,4 @@
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { SlugUniquenessValidator } from "@projectcaluma/ember-form-builder/validators/slug";
@@ -8,7 +7,6 @@ import { setupTest } from "dummy/tests/helpers";
 module("Unit | Validator | slug", function (hooks) {
   setupTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("it validates uniqueness of form slugs", async function (assert) {
     const validator = new SlugUniquenessValidator("form");
@@ -18,7 +16,7 @@ module("Unit | Validator | slug", function (hooks) {
     // count is 1 -> invalid
     assert.strictEqual(
       await validator.validate(null, "slug", null, null, { id: undefined }),
-      "t:caluma.form-builder.validations.form.slug:()",
+      "A form with this slug already exists",
     );
 
     // id is given -> valid
@@ -44,7 +42,7 @@ module("Unit | Validator | slug", function (hooks) {
     // count is 1 -> invalid
     assert.strictEqual(
       await validator.validate(null, "slug", null, null, { id: undefined }),
-      "t:caluma.form-builder.validations.question.slug:()",
+      "A question with this slug already exists",
     );
 
     // id is given -> valid
@@ -87,7 +85,7 @@ module("Unit | Validator | slug", function (hooks) {
         id: undefined,
         question: "question-slug",
       }),
-      "t:caluma.form-builder.validations.option.slug:()",
+      "An option with this slug already exists",
     );
 
     // id is given -> valid

--- a/packages/form-builder/translations/de.yaml
+++ b/packages/form-builder/translations/de.yaml
@@ -30,7 +30,7 @@ caluma:
       empty: "Wir haben keine Formulare gefunden. Klicken Sie den Knopf im der rechten oberen Ecke um ein Formular zu erstellen!"
       loadMore: "Mehr Formulare laden"
 
-      not-found: "Kein Formular mit dem Slug '{slug}' gefunden"
+      not-found: "Kein Formular mit dem Slug ''{slug}'' gefunden"
 
     question-list:
       required:
@@ -131,7 +131,7 @@ caluma:
         hidden: "Versteckt"
         number-separator: "Zahlentrennzeichen"
 
-      not-found: "Keine Frage mit dem Slug '{slug}' gefunden"
+      not-found: "Keine Frage mit dem Slug ''{slug}'' gefunden"
 
       hideLabel: "Label verstecken"
 

--- a/packages/form-builder/translations/en.yaml
+++ b/packages/form-builder/translations/en.yaml
@@ -30,7 +30,7 @@ caluma:
       empty: "We did not find any forms. Click the button in the top right corner to create a new form right now!"
       loadMore: "Load more forms"
 
-      not-found: "No form with slug '{slug}' found"
+      not-found: "No form with slug ''{slug}'' found"
 
     question-list:
       required:
@@ -131,7 +131,7 @@ caluma:
         hidden: "Hidden"
         number-separator: "Number separator"
 
-      not-found: "No question with slug '{slug}' found"
+      not-found: "No question with slug ''{slug}'' found"
 
       hideLabel: "Hide label"
 

--- a/packages/form-builder/translations/fr.yaml
+++ b/packages/form-builder/translations/fr.yaml
@@ -30,7 +30,7 @@ caluma:
       empty: "Nous n'avons trouvé aucun formulaire. Cliquez sur le bouton dans le coin supérieur droit pour créer un formulaire !"
       loadMore: "Télécharger plus de formulaires"
 
-      not-found: "Aucun formulaire trouvé avec le slug '{slug}'"
+      not-found: "Aucun formulaire trouvé avec le slug ''{slug}''"
 
     question-list:
       required:
@@ -131,7 +131,7 @@ caluma:
         hidden: "Caché"
         number-separator: "Séparateur de chiffres"
 
-      not-found: "Aucune question trouvée avec le slug '{slug}'"
+      not-found: "Aucune question trouvée avec le slug ''{slug}''"
 
       hideLabel: "Cacher l'étiquette"
 

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -31,7 +31,7 @@
     "ember-fetch": "^8.1.2",
     "ember-flatpickr": "^8.0.0",
     "ember-in-viewport": "^4.1.0",
-    "ember-intl": "^6.5.3",
+    "ember-intl": "^7.0.4",
     "ember-math-helpers": "^4.0.0",
     "ember-power-select": "^7.2.0",
     "ember-truth-helpers": "^4.0.3",

--- a/packages/form/tests/helpers/index.js
+++ b/packages/form/tests/helpers/index.js
@@ -11,7 +11,7 @@ import {
 
 function setupApplicationTest(hooks, options) {
   upstreamSetupApplicationTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   // Additional setup for application tests can be done here.
   //
@@ -31,14 +31,14 @@ function setupApplicationTest(hooks, options) {
 
 function setupRenderingTest(hooks, options) {
   upstreamSetupRenderingTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   // Additional setup for rendering tests can be done here.
 }
 
 function setupTest(hooks, options) {
   upstreamSetupTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   // Additional setup for unit tests can be done here.
 }

--- a/packages/form/tests/integration/components/cf-content-test.js
+++ b/packages/form/tests/integration/components/cf-content-test.js
@@ -2,7 +2,6 @@ import { render, fillIn, click, triggerEvent } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { setFlatpickrDate } from "ember-flatpickr/test-support/helpers";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import DummyOneComponent from "dummy/components/dummy-one";
@@ -11,7 +10,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | cf-content", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     const form = this.server.create("form");

--- a/packages/form/tests/integration/components/cf-field-test.js
+++ b/packages/form/tests/integration/components/cf-field-test.js
@@ -1,7 +1,6 @@
 import { render, fillIn } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -9,7 +8,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | cf-field", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     const formatValidator = this.server.create("format-validator", {
@@ -169,9 +167,7 @@ module("Integration | Component | cf-field", function (hooks) {
 
     assert
       .dom("span.validation-errors")
-      .hasText(
-        't:caluma.form.validation.tooShort:("max":20,"min":10,"value":"Test")',
-      );
+      .hasText("The value of this field can't be shorter than 10 characters");
   });
 
   test("it hides the label", async function (assert) {
@@ -189,11 +185,7 @@ module("Integration | Component | cf-field", function (hooks) {
 
     await fillIn("input", "Test");
 
-    assert
-      .dom("span.validation-errors")
-      .hasText(
-        `t:caluma.form.validation.format:("errorMsg":"Invalid email","value":"Test")`,
-      );
+    assert.dom("span.validation-errors").hasText("Invalid email");
   });
 
   test("it saves the valid email address", async function (assert) {

--- a/packages/form/tests/integration/components/cf-field-value-test.js
+++ b/packages/form/tests/integration/components/cf-field-value-test.js
@@ -1,7 +1,7 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setLocale, setupIntl } from "ember-intl/test-support";
+import { setLocale } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -9,7 +9,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | cf-field-value", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("it renders multiple choice questions", async function (assert) {
     this.field = {

--- a/packages/form/tests/integration/components/cf-field/errors-test.js
+++ b/packages/form/tests/integration/components/cf-field/errors-test.js
@@ -1,13 +1,11 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/errors", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     await render(

--- a/packages/form/tests/integration/components/cf-field/hint-test.js
+++ b/packages/form/tests/integration/components/cf-field/hint-test.js
@@ -1,13 +1,11 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/hint", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     const form = {

--- a/packages/form/tests/integration/components/cf-field/info-test.js
+++ b/packages/form/tests/integration/components/cf-field/info-test.js
@@ -1,17 +1,15 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/info", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     await render(hbs`<CfField::Info />`);
 
-    assert.dom(this.element).hasText("t:caluma.form.info:()");
+    assert.dom(this.element).hasText("More information");
   });
 });

--- a/packages/form/tests/integration/components/cf-field/input-test.js
+++ b/packages/form/tests/integration/components/cf-field/input-test.js
@@ -1,13 +1,11 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/input", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders a text field", async function (assert) {
     assert.expect(2);

--- a/packages/form/tests/integration/components/cf-field/input/action-button-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/action-button-test.js
@@ -3,7 +3,6 @@ import { tracked } from "@glimmer/tracking";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { restartableTask } from "ember-concurrency";
-import { setupIntl } from "ember-intl/test-support";
 import { Response } from "miragejs";
 import { module, test } from "qunit";
 import UIkit from "uikit";
@@ -15,7 +14,6 @@ module(
   function (hooks) {
     setupRenderingTest(hooks);
     setupMirage(hooks);
-    setupIntl(hooks);
 
     hooks.beforeEach(function (assert) {
       UIkit.container = this.owner.rootElement;
@@ -125,7 +123,9 @@ module(
 
       assert
         .dom(".uk-alert-danger")
-        .hasText("t:caluma.form.validation.error:() foo");
+        .hasText(
+          "The following questions have not yet been filled in correctly: foo",
+        );
     });
 
     test("does not validate if action is skip", async function (assert) {

--- a/packages/form/tests/integration/components/cf-field/input/checkbox-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/checkbox-test.js
@@ -2,14 +2,12 @@ import { render, click, settled } from "@ember/test-helpers";
 import { tracked } from "@glimmer/tracking";
 import { hbs } from "ember-cli-htmlbars";
 import { timeout } from "ember-concurrency";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/input/checkbox", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     assert.expect(12);
@@ -148,7 +146,7 @@ module("Integration | Component | cf-field/input/checkbox", function (hooks) {
     assert.dom("label input[type=checkbox]").isEnabled();
     assert
       .dom("label del.uk-text-muted")
-      .hasAttribute("title", "t:caluma.form.optionNotAvailable:()");
+      .hasAttribute("title", "This option is not available anymore");
 
     this.set("disabled", true);
 

--- a/packages/form/tests/integration/components/cf-field/input/date-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/date-test.js
@@ -1,14 +1,13 @@
 import { fillIn, blur, render, waitFor } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setFlatpickrDate } from "ember-flatpickr/test-support/helpers";
-import { setupIntl, setLocale } from "ember-intl/test-support";
+import { setLocale } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/input/date", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     this.owner.resolveRegistration("config:environment")["ember-caluma"] = {

--- a/packages/form/tests/integration/components/cf-field/input/files-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/files-test.js
@@ -3,7 +3,6 @@ import { faker } from "@faker-js/faker";
 import { tracked } from "@glimmer/tracking";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -11,7 +10,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | cf-field/input/files", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks, ["en"]);
 
   test("it computes the proper element id", async function (assert) {
     await render(hbs`<CfField::Input::Files @field={{hash pk="test-id"}} />`);

--- a/packages/form/tests/integration/components/cf-field/input/float-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/float-test.js
@@ -1,13 +1,11 @@
 import { render, fillIn } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/input/float", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     this.set("field", {

--- a/packages/form/tests/integration/components/cf-field/input/integer-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/integer-test.js
@@ -1,13 +1,11 @@
 import { render, fillIn } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/input/integer", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it computes the proper element id", async function (assert) {
     await render(hbs`<CfField::Input::Integer @field={{hash pk="test-id"}} />`);

--- a/packages/form/tests/integration/components/cf-field/input/number-separator-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/number-separator-test.js
@@ -1,7 +1,7 @@
 import { fillIn, render } from "@ember/test-helpers";
 import { tracked } from "@glimmer/tracking";
 import { hbs } from "ember-cli-htmlbars";
-import { setLocale, setupIntl } from "ember-intl/test-support";
+import { setLocale } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -10,7 +10,6 @@ module(
   "Integration | Component | cf-field/input/number-separator",
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks);
 
     hooks.beforeEach(function () {
       setLocale(["de-ch", "de"]);

--- a/packages/form/tests/integration/components/cf-field/input/powerselect-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/powerselect-test.js
@@ -1,6 +1,5 @@
 import { click, render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -9,7 +8,6 @@ module(
   "Integration | Component | cf-field/input/powerselect",
   function (hooks) {
     setupRenderingTest(hooks);
-    setupIntl(hooks);
 
     hooks.beforeEach(function () {
       const singleChoice = {

--- a/packages/form/tests/integration/components/cf-field/input/radio-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/radio-test.js
@@ -1,13 +1,11 @@
 import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/input/radio", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     this.set("noop", () => {});
@@ -134,7 +132,7 @@ module("Integration | Component | cf-field/input/radio", function (hooks) {
     assert.dom("label input[type=radio]").isDisabled();
     assert
       .dom("label del.uk-text-muted")
-      .hasAttribute("title", "t:caluma.form.optionNotAvailable:()");
+      .hasAttribute("title", "This option is not available anymore");
 
     this.set("disabled", true);
 

--- a/packages/form/tests/integration/components/cf-field/input/static-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/static-test.js
@@ -1,13 +1,11 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/input/static", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   test("it renders", async function (assert) {
     assert.expect(1);

--- a/packages/form/tests/integration/components/cf-field/input/table-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/table-test.js
@@ -1,7 +1,6 @@
 import { waitFor, click, fillIn, render, scrollTo } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 import UIkit from "uikit";
 
@@ -10,7 +9,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/input/table", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     this.field = {

--- a/packages/form/tests/integration/components/cf-field/input/text-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/text-test.js
@@ -1,7 +1,6 @@
 import { render, fillIn } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -9,7 +8,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | cf-field/input/text", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("it computes the proper element id", async function (assert) {
     await render(hbs`<CfField::Input::Text @field={{hash pk="test-id"}} />`);

--- a/packages/form/tests/integration/components/cf-field/input/textarea-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/textarea-test.js
@@ -1,7 +1,6 @@
 import { render, fillIn } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
@@ -9,7 +8,6 @@ import { setupRenderingTest } from "dummy/tests/helpers";
 module("Integration | Component | cf-field/input/textarea", function (hooks) {
   setupRenderingTest(hooks);
   setupMirage(hooks);
-  setupIntl(hooks);
 
   test("it computes the proper element id", async function (assert) {
     await render(

--- a/packages/form/tests/integration/components/cf-field/label-test.js
+++ b/packages/form/tests/integration/components/cf-field/label-test.js
@@ -1,13 +1,11 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-field/label", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   hooks.beforeEach(function () {
     const form = {
@@ -56,6 +54,6 @@ module("Integration | Component | cf-field/label", function (hooks) {
 
     this.set("field.question.raw.isRequired", "false");
 
-    assert.dom("label").hasText("Test (t:caluma.form.optional:())");
+    assert.dom("label").hasText("Test (Optional)");
   });
 });

--- a/packages/form/tests/integration/components/cf-form-wrapper-test.js
+++ b/packages/form/tests/integration/components/cf-form-wrapper-test.js
@@ -1,13 +1,11 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, skip } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-form-wrapper", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   skip("it renders", async function (assert) {
     // Set any properties with this.set('myProperty', 'value');

--- a/packages/form/tests/integration/components/cf-navigation-item-test.js
+++ b/packages/form/tests/integration/components/cf-navigation-item-test.js
@@ -1,13 +1,11 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, skip } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-navigation-item", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   skip("it renders", async function (assert) {
     // Set any properties with this.set('myProperty', 'value');

--- a/packages/form/tests/integration/components/cf-navigation-test.js
+++ b/packages/form/tests/integration/components/cf-navigation-test.js
@@ -1,13 +1,11 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, skip } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-navigation", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   skip("it renders", async function (assert) {
     // Set any properties with this.set('myProperty', 'value');

--- a/packages/form/tests/integration/components/cf-pagination-test.js
+++ b/packages/form/tests/integration/components/cf-pagination-test.js
@@ -1,13 +1,11 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
-import { setupIntl } from "ember-intl/test-support";
 import { module, skip } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | cf-pagination", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
 
   skip("it renders", async function (assert) {
     // Set any properties with this.set('myProperty', 'value');

--- a/packages/form/tests/unit/lib/field-test.js
+++ b/packages/form/tests/unit/lib/field-test.js
@@ -1,6 +1,5 @@
 import { settled } from "@ember/test-helpers";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { rawDocumentWithWorkItem } from "./data";
@@ -11,7 +10,6 @@ import { setupTest } from "dummy/tests/helpers";
 
 module("Unit | Library | field", function (hooks) {
   setupTest(hooks);
-  setupIntl(hooks);
   setupMirage(hooks);
 
   hooks.beforeEach(async function () {
@@ -221,9 +219,7 @@ module("Unit | Library | field", function (hooks) {
     });
 
     await field.validate.perform();
-    assert.deepEqual(field.errors, [
-      't:caluma.form.validation.blank:("presence":true,"value":"")',
-    ]);
+    assert.deepEqual(field.errors, ["This field can't be blank"]);
   });
 
   test("it ignores optional fields", async function (assert) {
@@ -281,13 +277,13 @@ module("Unit | Library | field", function (hooks) {
     field.answer.value = "Testx";
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.tooLong:("max":4,"min":2,"value":"Testx")',
+      "The value of this field can't be longer than 4 characters",
     ]);
 
     field.answer.value = "x";
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.tooShort:("max":4,"min":2,"value":"x")',
+      "The value of this field can't be shorter than 2 characters",
     ]);
   });
 
@@ -312,13 +308,13 @@ module("Unit | Library | field", function (hooks) {
     field.answer.value = "Testx";
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.tooLong:("max":4,"min":2,"value":"Testx")',
+      "The value of this field can't be longer than 4 characters",
     ]);
 
     field.answer.value = "x";
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.tooShort:("max":4,"min":2,"value":"x")',
+      "The value of this field can't be shorter than 2 characters",
     ]);
   });
 
@@ -343,19 +339,19 @@ module("Unit | Library | field", function (hooks) {
     field.answer.value = 1;
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.greaterThanOrEqualTo:("gte":2,"integer":true,"lte":2,"value":1)',
+      "The value of this field must be greater than or equal to 2",
     ]);
 
     field.answer.value = 3;
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.lessThanOrEqualTo:("gte":2,"integer":true,"lte":2,"value":3)',
+      "The value of this field must be less than or equal to 2",
     ]);
 
     field.answer.value = 1.5;
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.notAnInteger:("gte":2,"integer":true,"lte":2,"value":1.5)',
+      "The value of this field must be an integer",
     ]);
   });
 
@@ -384,13 +380,13 @@ module("Unit | Library | field", function (hooks) {
 
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.greaterThanOrEqualTo:("gte":1.5,"lte":2.5,"value":1.4)',
+      "The value of this field must be greater than or equal to 1.5",
     ]);
 
     field.answer.value = 2.6;
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.lessThanOrEqualTo:("gte":1.5,"lte":2.5,"value":2.6)',
+      "The value of this field must be less than or equal to 2.5",
     ]);
   });
 
@@ -430,7 +426,7 @@ module("Unit | Library | field", function (hooks) {
     field.answer.value = "invalid-option";
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.inclusion:("allowBlank":true,"in":["option-1"],"label":"Invalid Option","value":"invalid-option")',
+      '"Invalid Option" is not a valid value for this field',
     ]);
   });
 
@@ -470,14 +466,14 @@ module("Unit | Library | field", function (hooks) {
     field.answer.value = ["option-1", "invalid-option"];
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.inclusion:("allowBlank":false,"in":["option-1"],"label":"Invalid Option","value":"invalid-option")',
+      '"Invalid Option" is not a valid value for this field',
     ]);
 
     field.answer.value = ["invalid-option", "other-invalid-option"];
     await field.validate.perform();
     assert.deepEqual(field.errors, [
-      't:caluma.form.validation.inclusion:("allowBlank":false,"in":["option-1"],"label":"Invalid Option","value":"invalid-option")',
-      't:caluma.form.validation.inclusion:("allowBlank":false,"in":["option-1"],"label":"other-invalid-option","value":"other-invalid-option")',
+      '"Invalid Option" is not a valid value for this field',
+      '"other-invalid-option" is not a valid value for this field',
     ]);
   });
 
@@ -493,7 +489,7 @@ module("Unit | Library | field", function (hooks) {
     row.findField("table-form-question").answer.value = null;
     await table.validate.perform();
     assert.deepEqual(table.errors, [
-      't:caluma.form.validation.table:("value":null)',
+      "At least one row of the table was not filled in correctly",
     ]);
   });
 

--- a/packages/workflow/package.json
+++ b/packages/workflow/package.json
@@ -23,7 +23,7 @@
     "ember-composable-helpers": "^5.0.0",
     "ember-concurrency": "^4.0.2",
     "ember-fetch": "^8.1.2",
-    "ember-intl": "^6.5.3",
+    "ember-intl": "^7.0.4",
     "ember-truth-helpers": "^4.0.3",
     "ember-uikit": "^9.1.2",
     "graphql": "^15.8.0",

--- a/packages/workflow/tests/helpers/index.js
+++ b/packages/workflow/tests/helpers/index.js
@@ -11,7 +11,7 @@ import {
 
 function setupApplicationTest(hooks, options) {
   upstreamSetupApplicationTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   // Additional setup for application tests can be done here.
   //
@@ -31,14 +31,14 @@ function setupApplicationTest(hooks, options) {
 
 function setupRenderingTest(hooks, options) {
   upstreamSetupRenderingTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   // Additional setup for rendering tests can be done here.
 }
 
 function setupTest(hooks, options) {
   upstreamSetupTest(hooks, options);
-  setupIntl(hooks);
+  setupIntl(hooks, "en");
 
   // Additional setup for unit tests can be done here.
 }

--- a/packages/workflow/tests/integration/components/task-button-test.js
+++ b/packages/workflow/tests/integration/components/task-button-test.js
@@ -1,14 +1,12 @@
 import { render } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | task-button", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
   setupMirage(hooks);
 
   hooks.beforeEach(function () {
@@ -39,7 +37,7 @@ module("Integration | Component | task-button", function (hooks) {
   test("it renders default", async function (assert) {
     await render(hbs`<TaskButton @mutation="complete" @task="test" />`);
 
-    assert.dom("button").hasText("t:caluma.mutate-work-item.complete:()");
+    assert.dom("button").hasText("Complete");
   });
 
   test("it renders label", async function (assert) {

--- a/packages/workflow/tests/integration/components/work-item-button-test.js
+++ b/packages/workflow/tests/integration/components/work-item-button-test.js
@@ -1,14 +1,12 @@
 import { render, click } from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
-import { setupIntl } from "ember-intl/test-support";
 import { module, test } from "qunit";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
 module("Integration | Component | work-item-button", function (hooks) {
   setupRenderingTest(hooks);
-  setupIntl(hooks);
   setupMirage(hooks);
 
   test("it renders default", async function (assert) {
@@ -16,7 +14,7 @@ module("Integration | Component | work-item-button", function (hooks) {
       hbs`<WorkItemButton @mutation="complete" @workItemId="test" />`,
     );
 
-    assert.dom("button").hasText("t:caluma.mutate-work-item.complete:()");
+    assert.dom("button").hasText("Complete");
   });
 
   test("it renders label", async function (assert) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -249,8 +249,8 @@ importers:
         specifier: 8.0.0
         version: 8.0.0(@babel/core@7.25.2)(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))(flatpickr@4.6.13)(webpack@5.93.0)
       ember-intl:
-        specifier: 6.5.3
-        version: 6.5.3(@babel/core@7.25.2)(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
+        specifier: 7.0.4
+        version: 7.0.4(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
       ember-load-initializers:
         specifier: 2.1.2
         version: 2.1.2(@babel/core@7.25.2)
@@ -357,8 +357,8 @@ importers:
         specifier: ^8.1.2
         version: 8.1.2
       ember-intl:
-        specifier: ^6.5.3
-        version: 6.5.3(@babel/core@7.25.2)(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
+        specifier: ^7.0.4
+        version: 7.0.4(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
       ember-power-select:
         specifier: ^7.2.0
         version: 7.2.0(@babel/core@7.25.2)(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))(webpack@5.93.0)
@@ -522,8 +522,8 @@ importers:
         specifier: ^4.0.2
         version: 4.0.3(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
       ember-intl:
-        specifier: ^6.5.3
-        version: 6.5.3(@babel/core@7.25.2)(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
+        specifier: ^7.0.4
+        version: 7.0.4(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
       ember-modify-based-class-resource:
         specifier: ^1.1.0
         version: 1.1.0(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-resources@7.0.2(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0)))(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
@@ -691,8 +691,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(@babel/core@7.25.2)(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))(flatpickr@4.6.13)(webpack@5.93.0)
       ember-intl:
-        specifier: ^6.5.3
-        version: 6.5.3(@babel/core@7.25.2)(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
+        specifier: ^7.0.4
+        version: 7.0.4(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
       ember-svg-jar:
         specifier: ^2.4.9
         version: 2.4.9(@glint/template@1.4.0)
@@ -878,8 +878,8 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@babel/core@7.25.2)(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))(webpack@5.93.0)
       ember-intl:
-        specifier: ^6.5.3
-        version: 6.5.3(@babel/core@7.25.2)(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
+        specifier: ^7.0.4
+        version: 7.0.4(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
       ember-math-helpers:
         specifier: ^4.0.0
         version: 4.0.0(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
@@ -1081,8 +1081,8 @@ importers:
         specifier: ^8.0.0
         version: 8.0.0(@babel/core@7.25.2)(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))(flatpickr@4.6.13)(webpack@5.93.0)
       ember-intl:
-        specifier: ^6.5.3
-        version: 6.5.3(@babel/core@7.25.2)(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
+        specifier: ^7.0.4
+        version: 7.0.4(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
       ember-math-helpers:
         specifier: ^4.0.0
         version: 4.0.0(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
@@ -1381,8 +1381,8 @@ importers:
         specifier: ^8.1.2
         version: 8.1.2
       ember-intl:
-        specifier: ^6.5.3
-        version: 6.5.3(@babel/core@7.25.2)(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
+        specifier: ^7.0.4
+        version: 7.0.4(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
       ember-truth-helpers:
         specifier: ^4.0.3
         version: 4.0.3(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
@@ -2851,20 +2851,12 @@ packages:
   '@miragejs/pretender-node-polyfill@0.1.2':
     resolution: {integrity: sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==}
 
-  '@mrmlnc/readdir-enhanced@2.2.1':
-    resolution: {integrity: sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g==}
-    engines: {node: '>=4'}
-
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
-
-  '@nodelib/fs.stat@1.1.3':
-    resolution: {integrity: sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==}
-    engines: {node: '>= 6'}
 
   '@nodelib/fs.stat@2.0.5':
     resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
@@ -4343,10 +4335,6 @@ packages:
   broccoli-kitchen-sink-helpers@0.3.1:
     resolution: {integrity: sha512-gqYnKSJxBSjj/uJqeuRAzYVbmjWhG0mOZ8jrp6+fnUIOgLN6MvI7XxBECDHkYMIFPJ8Smf4xaI066Q2FqQDnXg==}
 
-  broccoli-merge-files@0.8.0:
-    resolution: {integrity: sha512-S6dXHECbDkr7YMuCitAAQT8EZeW/kXom0Y8+QmQfiSkWspkKDGrr4vXgEZJjWqfa/FSx/Y18NEEOuMmbIW+XNQ==}
-    engines: {node: '>=8.0.0'}
-
   broccoli-merge-trees@1.2.4:
     resolution: {integrity: sha512-RXJAleytlED0dxXGEo2EXwrg5cCesY8LQzzGRogwGQmluoz+ijzxajpyWAW6wu/AyuQZj1vgnIqnld8jvuuXtQ==}
 
@@ -4517,9 +4505,6 @@ packages:
     resolution: {integrity: sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==}
     engines: {node: '>= 0.4'}
 
-  call-me-maybe@1.0.2:
-    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
-
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
@@ -4615,8 +4600,8 @@ packages:
     resolution: {integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==}
     engines: {node: '>=0.10.0'}
 
-  cldr-core@44.1.0:
-    resolution: {integrity: sha512-ssbJaXu3pCkc4YqNC6xHhgleZG7YqnOFZ9laMlJfHOfnspoA9waI4AH54gKB3Fe/+wI4i3cVxKFdCTVGTRw+UA==}
+  cldr-core@45.0.0:
+    resolution: {integrity: sha512-gQVxy3gzOQpXiTRGmlKiRQFLYimrr1RgvqGKZCS61JgmdkeNm7+LZGx+Lhw5/AW0t8WMM/uZhf4CMva6LuUobQ==}
 
   clean-base-url@1.0.0:
     resolution: {integrity: sha512-9q6ZvUAhbKOSRFY7A/irCQ/rF0KIpa3uXpx6izm8+fp7b2H4hLeUJ+F1YYk9+gDQ/X8Q0MEyYs+tG3cht//HTg==}
@@ -5896,11 +5881,11 @@ packages:
     peerDependencies:
       ember-source: ^3.16.0 || ^4.0.0 || ^5.0.0
 
-  ember-intl@6.5.3:
-    resolution: {integrity: sha512-wt3YyWHMHdK8pyJl2ymtXYhO3apgY1WnQB1w6glFthpNdO8q8p1lrK990gwX5kRvTDpXnfHwVhArHamb09E8PQ==}
-    engines: {node: 16.* || >= 18}
+  ember-intl@7.0.4:
+    resolution: {integrity: sha512-EKIEV24BiUTx05+zi1Y37+qaOwVO/bFMZtsHPzndMDJcj6wjC1e3aMm5nvs4+jldh1TVwnIMVs9ivEoUNeijHQ==}
+    engines: {node: 18.* || >= 20}
     peerDependencies:
-      typescript: ^4.8.0 || ^5.0.0
+      typescript: ^5.0.0
     peerDependenciesMeta:
       typescript:
         optional: true
@@ -6522,10 +6507,6 @@ packages:
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
-  fast-glob@2.2.7:
-    resolution: {integrity: sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==}
-    engines: {node: '>=4.0.0'}
-
   fast-glob@3.3.2:
     resolution: {integrity: sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==}
     engines: {node: '>=8.6.0'}
@@ -6535,9 +6516,6 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
-  fast-memoize@2.5.2:
-    resolution: {integrity: sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==}
 
   fast-ordered-set@1.0.3:
     resolution: {integrity: sha512-MxBW4URybFszOx1YlACEoK52P6lE3xiFcPaGCUZ7QQOZ6uJXKo++Se8wa31SjcZ+NC/fdAWX7UtKEfaGgHS2Vg==}
@@ -6929,9 +6907,6 @@ packages:
     resolution: {integrity: sha512-8aCohiDo4jwjOwma4FmYFd3i97urZulL8XL24nIPxuE+GZnfsAyy/g2Shqx6OjUiFKUXZM+Yy+KHnOmmA3FVcg==}
     engines: {node: '>= 4.0'}
 
-  glob-parent@3.1.0:
-    resolution: {integrity: sha512-E8Ak/2+dZY6fnzlR7+ueWvhsH1SjHr4jjss4YS/h4py44jY9MhK/VFdaZJAWDz6BbL21KeteKxFSFpq8OS5gVA==}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -6939,9 +6914,6 @@ packages:
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
-
-  glob-to-regexp@0.3.0:
-    resolution: {integrity: sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==}
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
@@ -7536,10 +7508,6 @@ packages:
     resolution: {integrity: sha512-UCFta9F9rWFSavp9H3zHEHrARUfZbdJvmHKeEpds4BK3v7W2LdXoNypMtXXi5w5YBDEBCTYmbI+vsSwI8LYJaQ==}
     engines: {node: '>=0.8'}
 
-  is-glob@3.1.0:
-    resolution: {integrity: sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==}
-    engines: {node: '>=0.10.0'}
-
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -7998,9 +7966,6 @@ packages:
 
   lodash.debounce@4.0.8:
     resolution: {integrity: sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==}
-
-  lodash.defaults@4.2.0:
-    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
 
   lodash.defaultsdeep@4.6.1:
     resolution: {integrity: sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==}
@@ -8880,10 +8845,6 @@ packages:
     resolution: {integrity: sha512-lastgtAdoH9YaLyDa5i5z64q+kzOcQHsQ5SsZJD3q0VEyI8mq872S3geuNbRUQLVAE9siMfgKrpj7MloKFHruw==}
     engines: {node: '>=12'}
 
-  p-event@2.3.1:
-    resolution: {integrity: sha512-NQCqOFhbpVTMX4qMe8PF8lbGtzZ+LCiN7pcNrb/413Na7+TRoe1xkKUzuWa/YEJdGQ0FvKtj35EEbDoVPO2kbA==}
-    engines: {node: '>=6'}
-
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -8959,10 +8920,6 @@ packages:
   p-reduce@3.0.0:
     resolution: {integrity: sha512-xsrIUgI0Kn6iyDYm9StOpOeK29XM1aboGji26+QEortiFST1hGZaUQOLhtEbqHErPpGW/aSz6allwK2qcptp0Q==}
     engines: {node: '>=12'}
-
-  p-timeout@2.0.1:
-    resolution: {integrity: sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==}
-    engines: {node: '>=4'}
 
   p-try@1.0.0:
     resolution: {integrity: sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==}
@@ -9047,9 +9004,6 @@ packages:
   path-absolute@1.0.1:
     resolution: {integrity: sha512-gds5iRhSeOcDtj8gfWkRHLtZKTPsFVuh7utbjYtvnclw4XM+ffRzJrwqMhOD1PVqef7nBLmgsu1vIujjvAJrAw==}
     engines: {node: '>=4'}
-
-  path-dirname@1.0.2:
-    resolution: {integrity: sha512-ALzNPpyNq9AqXMBjeymIjFDAkAFH06mHJH/cSBHAgU0s4vfpBn6b2nf8tiRLvagKD8RbTpq2FKTBg7cl9l3c7Q==}
 
   path-exists@3.0.0:
     resolution: {integrity: sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==}
@@ -13385,11 +13339,6 @@ snapshots:
 
   '@miragejs/pretender-node-polyfill@0.1.2': {}
 
-  '@mrmlnc/readdir-enhanced@2.2.1':
-    dependencies:
-      call-me-maybe: 1.0.2
-      glob-to-regexp: 0.3.0
-
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     dependencies:
       eslint-scope: 5.1.1
@@ -13398,8 +13347,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
       run-parallel: 1.2.0
-
-  '@nodelib/fs.stat@1.1.3': {}
 
   '@nodelib/fs.stat@2.0.5': {}
 
@@ -13793,7 +13740,7 @@ snapshots:
       ember-concurrency: 4.0.2(@babel/core@7.25.2)(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
       ember-fetch: 8.1.2
       ember-inflector: 4.0.3(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
-      ember-intl: 6.5.3(@babel/core@7.25.2)(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
+      ember-intl: 7.0.4(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
       ember-modify-based-class-resource: 1.1.0(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-resources@7.0.2(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0)))(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
       ember-source: 5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0)
       ember-uikit: 9.1.2(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))(webpack@5.93.0)
@@ -13833,7 +13780,7 @@ snapshots:
       ember-concurrency: 4.0.2(@babel/core@7.25.2)(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
       ember-fetch: 8.1.2
       ember-inflector: 4.0.3(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
-      ember-intl: 6.5.3(@babel/core@7.25.2)(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
+      ember-intl: 7.0.4(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
       ember-modify-based-class-resource: 1.1.0(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-resources@7.0.2(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0)))(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
       ember-source: 5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0)
       ember-uikit: 9.1.2(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))(webpack@5.93.0)
@@ -13941,7 +13888,7 @@ snapshots:
       ember-composable-helpers: 5.0.0
       ember-concurrency: 4.0.2(@babel/core@7.25.2)(@glimmer/tracking@1.1.2)(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
       ember-fetch: 8.1.2
-      ember-intl: 6.5.3(@babel/core@7.25.2)(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
+      ember-intl: 7.0.4(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0)
       ember-source: 5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0)
       ember-truth-helpers: 4.0.3(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))
       ember-uikit: 9.1.2(@glint/template@1.4.0)(ember-source@5.10.1(@glimmer/component@1.1.2(@babel/core@7.25.2))(@glint/template@1.4.0)(rsvp@4.8.5)(webpack@5.93.0))(webpack@5.93.0)
@@ -15791,15 +15738,6 @@ snapshots:
       glob: 5.0.15
       mkdirp: 0.5.6
 
-  broccoli-merge-files@0.8.0:
-    dependencies:
-      broccoli-plugin: 1.3.1
-      fast-glob: 2.2.7
-      lodash.defaults: 4.2.0
-      p-event: 2.3.1
-    transitivePeerDependencies:
-      - supports-color
-
   broccoli-merge-trees@1.2.4:
     dependencies:
       broccoli-plugin: 1.3.1
@@ -16181,8 +16119,6 @@ snapshots:
       get-intrinsic: 1.2.4
       set-function-length: 1.2.2
 
-  call-me-maybe@1.0.2: {}
-
   callsites@3.1.0: {}
 
   camelcase-css@2.0.1: {}
@@ -16296,7 +16232,7 @@ snapshots:
       isobject: 3.0.1
       static-extend: 0.1.2
 
-  cldr-core@44.1.0: {}
+  cldr-core@45.0.0: {}
 
   clean-base-url@1.0.0: {}
 
@@ -18321,32 +18257,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-intl@6.5.3(@babel/core@7.25.2)(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0):
+  ember-intl@7.0.4(@glint/template@1.4.0)(typescript@5.5.4)(webpack@5.93.0):
     dependencies:
+      '@babel/core': 7.25.2
       '@formatjs/icu-messageformat-parser': 2.7.8
       '@formatjs/intl': 2.10.4(typescript@5.5.4)
       broccoli-caching-writer: 3.0.3
       broccoli-funnel: 3.0.8
-      broccoli-merge-files: 0.8.0
       broccoli-merge-trees: 4.2.0
       broccoli-source: 3.0.1
-      broccoli-stew: 3.0.0
       calculate-cache-key-for-tree: 2.0.0
-      cldr-core: 44.1.0
+      cldr-core: 45.0.0
       ember-auto-import: 2.7.4(@glint/template@1.4.0)(webpack@5.93.0)
       ember-cli-babel: 8.2.0(@babel/core@7.25.2)
       ember-cli-typescript: 5.3.0
       eventemitter3: 5.0.1
       extend: 3.0.2
-      fast-memoize: 2.5.2
       intl-messageformat: 10.5.14
       js-yaml: 4.1.0
       json-stable-stringify: 1.1.1
-      silent-error: 1.1.1
     optionalDependencies:
       typescript: 5.5.4
     transitivePeerDependencies:
-      - '@babel/core'
       - '@glint/template'
       - supports-color
       - webpack
@@ -19442,17 +19374,6 @@ snapshots:
 
   fast-diff@1.3.0: {}
 
-  fast-glob@2.2.7:
-    dependencies:
-      '@mrmlnc/readdir-enhanced': 2.2.1
-      '@nodelib/fs.stat': 1.1.3
-      glob-parent: 3.1.0
-      is-glob: 4.0.3
-      merge2: 1.4.1
-      micromatch: 3.1.10
-    transitivePeerDependencies:
-      - supports-color
-
   fast-glob@3.3.2:
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -19464,8 +19385,6 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
-
-  fast-memoize@2.5.2: {}
 
   fast-ordered-set@1.0.3:
     dependencies:
@@ -19960,11 +19879,6 @@ snapshots:
 
   git-repo-info@2.1.1: {}
 
-  glob-parent@3.1.0:
-    dependencies:
-      is-glob: 3.1.0
-      path-dirname: 1.0.2
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -19972,8 +19886,6 @@ snapshots:
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
-
-  glob-to-regexp@0.3.0: {}
 
   glob-to-regexp@0.4.1: {}
 
@@ -20635,10 +20547,6 @@ snapshots:
 
   is-git-url@1.0.0: {}
 
-  is-glob@3.1.0:
-    dependencies:
-      is-extglob: 2.1.1
-
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
@@ -21101,8 +21009,6 @@ snapshots:
       lodash._getnative: 3.9.1
 
   lodash.debounce@4.0.8: {}
-
-  lodash.defaults@4.2.0: {}
 
   lodash.defaultsdeep@4.6.1: {}
 
@@ -21831,10 +21737,6 @@ snapshots:
 
   p-each-series@3.0.0: {}
 
-  p-event@2.3.1:
-    dependencies:
-      p-timeout: 2.0.1
-
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -21894,10 +21796,6 @@ snapshots:
   p-reduce@2.1.0: {}
 
   p-reduce@3.0.0: {}
-
-  p-timeout@2.0.1:
-    dependencies:
-      p-finally: 1.0.0
 
   p-try@1.0.0: {}
 
@@ -21973,8 +21871,6 @@ snapshots:
   pascalcase@0.1.1: {}
 
   path-absolute@1.0.1: {}
-
-  path-dirname@1.0.2: {}
 
   path-exists@3.0.0: {}
 


### PR DESCRIPTION
BREAKING CHANGE: `ember-caluma` now requires the usage of `ember-intl` v7.