### PR TITLE
feat: enable JEXLs for options in choice and multiple choice questions

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/question-option.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-option.hbs
@@ -1,0 +1,89 @@
+<li class="cfb-option-row" data-test-row={{concat "option-" (add @i 1)}}>
+  <ValidatedForm @model={{@row}} as |f|>
+    <div uk-grid class="uk-grid-small uk-flex uk-flex-top" id={{@row.slug}}>
+      <div class="uk-width-auto uk-flex uk-flex-middle">
+        {{#if @canReorder}}
+          <span
+            data-test-sort-handle
+            uk-icon="menu"
+            class="uk-sortable-handle uk-margin-small-right"
+            role="button"
+          ></span>
+        {{/if}}
+        {{#if (is-empty @row.id)}}
+          <button
+            data-test-delete-row
+            type="button"
+            class="uk-icon-button"
+            uk-icon="trash"
+            title={{t "caluma.form-builder.options.delete"}}
+            {{on "click" (fn @deleteRow @row)}}
+          >
+          </button>
+        {{else}}
+          <button
+            data-test-archive-row
+            type="button"
+            class="uk-icon-button"
+            uk-icon={{if @row.isArchived "refresh" "close"}}
+            title={{t
+              (concat
+                "caluma.form-builder.options."
+                (if @row.isArchived "restore" "archive")
+              )
+            }}
+            {{on
+              "click"
+              (fn (changeset-set @row "isArchived") (not @row.isArchived))
+            }}
+          >
+          </button>
+        {{/if}}
+      </div>
+      <div class="uk-width-expand">
+        <f.input
+          @name="label"
+          @inputName={{concat "option-" (add @i 1) "-label"}}
+          @required={{true}}
+          @disabled={{@row.isArchived}}
+          @submitted={{@submitted}}
+          @on-update={{@updateLabel}}
+        />
+      </div>
+      <div class="uk-width-1-4">
+        <f.input
+          @name="slug"
+          @inputName={{concat "option-" (add @i 1) "-slug"}}
+          @required={{true}}
+          @disabled={{not (is-empty @row.id)}}
+          @submitted={{@submitted}}
+          @renderComponent={{component
+            "cfb-slug-input"
+            hidePrefix=true
+            prefix=@model.slug
+            onUnlink=(fn (mut @row.slugUnlinked) true)
+          }}
+        />
+      </div>
+      <div class="uk-width-auto">
+        <button
+          data-test-toggle-jexl
+          type="button"
+          class="uk-icon-button"
+          uk-icon={{if this.showJexl "triangle-up" "triangle-down"}}
+          title={{t "caluma.form-builder.options.show-jexl"}}
+          {{on "click" (fn (mut this.showJexl) (not this.showJexl))}}
+        />
+      </div>
+      {{#if this.showJexl}}
+        <div class="uk-width-4-4">
+          <f.input
+            @label={{t "caluma.form-builder.question.isHidden"}}
+            @name="isHidden"
+            @renderComponent={{component "cfb-code-editor" language="jexl"}}
+          />
+        </div>
+      {{/if}}
+    </div>
+  </ValidatedForm>
+</li>

--- a/packages/form-builder/addon/components/cfb-form-editor/question-option.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-option.hbs
@@ -17,7 +17,7 @@
             class="uk-icon-button"
             uk-icon="trash"
             title={{t "caluma.form-builder.options.delete"}}
-            {{on "click" (fn @deleteRow @row)}}
+            {{on "click" @deleteRow}}
           >
           </button>
         {{else}}
@@ -46,7 +46,6 @@
           @inputName={{concat "option-" (add @i 1) "-label"}}
           @required={{true}}
           @disabled={{@row.isArchived}}
-          @submitted={{@submitted}}
           @on-update={{@updateLabel}}
         />
       </div>
@@ -56,7 +55,6 @@
           @inputName={{concat "option-" (add @i 1) "-slug"}}
           @required={{true}}
           @disabled={{not (is-empty @row.id)}}
-          @submitted={{@submitted}}
           @renderComponent={{component
             "cfb-slug-input"
             hidePrefix=true

--- a/packages/form-builder/addon/components/cfb-form-editor/question-option.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-option.js
@@ -1,0 +1,6 @@
+import Component from "@glimmer/component";
+import { tracked } from "@glimmer/tracking";
+
+export default class CfbFormEditorQuestionOption extends Component {
+  @tracked showJexl = false;
+}

--- a/packages/form-builder/addon/components/cfb-form-editor/question.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.js
@@ -363,11 +363,11 @@ export default class CfbFormEditorQuestion extends Component {
       (changeset.get("options") || [])
         .filter((option) => option.get("isDirty"))
         .map(async (option) => {
-          const { label, slug, isArchived } = option;
+          const { label, slug, isArchived, isHidden } = option;
 
           await this.apollo.mutate({
             mutation: saveOptionMutation,
-            variables: { input: { label, slug, isArchived } },
+            variables: { input: { label, slug, isArchived, isHidden } },
           });
         }),
     );

--- a/packages/form-builder/addon/components/cfb-form-editor/question.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.js
@@ -471,6 +471,7 @@ export default class CfbFormEditorQuestion extends Component {
             label: "",
             slug: "",
             isArchived: false,
+            isHidden: "false",
             slugUnlinked: false,
             question: this.model.slug,
           },

--- a/packages/form-builder/addon/components/cfb-form-editor/question/default.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question/default.hbs
@@ -1,6 +1,8 @@
 <div class="uk-margin">
   <@labelComponent />
 
+  {{! Default values for ChoiceQuestions and MultipleChoiceQuestion options are not updated
+  when a new one is added because the object returned by `this.field` is too nested to track properly. }}
   <div class="uk-form-controls">
     {{component
       (get-widget this.field.question)

--- a/packages/form-builder/addon/components/cfb-form-editor/question/default.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question/default.js
@@ -45,7 +45,16 @@ export default class CfbFormEditorQuestionDefault extends Component {
       // Format option changesets to match the raw format needed in lib.
       raw[key] = {
         edges: raw.options.map((node) => {
-          return { node };
+          return {
+            node: {
+              ...node.get("data"),
+              ...node.get("change"),
+              // While we want the real value of the option, the option should never
+              // be hidden in the form-builder. We need to set a value here as no
+              // value will lead to a Jexl error.
+              isHidden: "false",
+            },
+          };
         }),
       };
       delete raw.options;

--- a/packages/form-builder/addon/components/cfb-form-editor/question/options.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question/options.hbs
@@ -8,80 +8,14 @@
     class="uk-list uk-list-divider uk-form-controls uk-margin-small-top"
   >
     {{#each @value as |row i|}}
-      <li class="cfb-option-row" data-test-row={{concat "option-" (add i 1)}}>
-        <ValidatedForm @model={{row}} as |f|>
-          <div
-            uk-grid
-            class="uk-grid-small uk-flex uk-flex-top"
-            id={{row.slug}}
-          >
-            <div class="uk-width-auto uk-flex uk-flex-middle">
-              {{#if this.canReorder}}
-                <span
-                  data-test-sort-handle
-                  uk-icon="menu"
-                  class="uk-sortable-handle uk-margin-small-right"
-                  role="button"
-                ></span>
-              {{/if}}
-              {{#if (is-empty row.id)}}
-                <button
-                  data-test-delete-row
-                  type="button"
-                  class="uk-icon-button"
-                  uk-icon="trash"
-                  title={{t "caluma.form-builder.options.delete"}}
-                  {{on "click" (fn this.deleteRow row)}}
-                >
-                </button>
-              {{else}}
-                <button
-                  data-test-archive-row
-                  type="button"
-                  class="uk-icon-button"
-                  uk-icon={{if row.isArchived "refresh" "close"}}
-                  title={{t
-                    (concat
-                      "caluma.form-builder.options."
-                      (if row.isArchived "restore" "archive")
-                    )
-                  }}
-                  {{on
-                    "click"
-                    (fn (changeset-set row "isArchived") (not row.isArchived))
-                  }}
-                >
-                </button>
-              {{/if}}
-            </div>
-            <div class="uk-width-expand">
-              <f.input
-                @name="label"
-                @inputName={{concat "option-" (add i 1) "-label"}}
-                @required={{true}}
-                @disabled={{row.isArchived}}
-                @submitted={{@submitted}}
-                @on-update={{this.updateLabel}}
-              />
-            </div>
-            <div class="uk-width-1-4">
-              <f.input
-                @name="slug"
-                @inputName={{concat "option-" (add i 1) "-slug"}}
-                @required={{true}}
-                @disabled={{not (is-empty row.id)}}
-                @submitted={{@submitted}}
-                @renderComponent={{component
-                  "cfb-slug-input"
-                  hidePrefix=true
-                  prefix=@model.slug
-                  onUnlink=(fn (mut row.slugUnlinked) true)
-                }}
-              />
-            </div>
-          </div>
-        </ValidatedForm>
-      </li>
+      <CfbFormEditor::QuestionOption
+        @i={{i}}
+        @row={{row}}
+        @model={{@model}}
+        @canReorder={{this.canReorder}}
+        @deleteRow={{fn this.deleteRow row}}
+        @updateLabel={{this.updateLabel}}
+      />
     {{/each}}
     <li class="uk-text-center">
       <button

--- a/packages/form-builder/addon/components/cfb-form-editor/question/options.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question/options.js
@@ -64,6 +64,7 @@ export default class CfbFormEditorQuestionOptions extends Component {
           slug: "",
           label: "",
           isArchived: false,
+          isHidden: "false",
           slugUnlinked: false,
           question: this.args.model.slug,
         },

--- a/packages/form-builder/addon/gql/mutations/save-option.graphql
+++ b/packages/form-builder/addon/gql/mutations/save-option.graphql
@@ -4,6 +4,7 @@ mutation SaveOption($input: SaveOptionInput!) {
       id
       label
       slug
+      isHidden
     }
   }
 }

--- a/packages/form-builder/addon/gql/queries/form-editor-question.graphql
+++ b/packages/form-builder/addon/gql/queries/form-editor-question.graphql
@@ -76,6 +76,7 @@ query FormEditorQuestion($slug: String!) {
                 label
                 slug
                 isArchived
+                isHidden
               }
             }
           }
@@ -93,6 +94,7 @@ query FormEditorQuestion($slug: String!) {
                 label
                 slug
                 isArchived
+                isHidden
               }
             }
           }

--- a/packages/form-builder/translations/de.yaml
+++ b/packages/form-builder/translations/de.yaml
@@ -144,6 +144,7 @@ caluma:
       delete: "Option löschen"
       archive: "Option archivieren (verstecken)"
       restore: "Option wiederherstellen"
+      show-jexl: "JEXL anzeigen"
 
     notification:
       form:

--- a/packages/form-builder/translations/en.yaml
+++ b/packages/form-builder/translations/en.yaml
@@ -144,6 +144,7 @@ caluma:
       delete: "Delete option"
       archive: "Archive (hide) option"
       restore: "Restore option"
+      show-jexl: "Show JEXL"
 
     notification:
       form:

--- a/packages/form-builder/translations/fr.yaml
+++ b/packages/form-builder/translations/fr.yaml
@@ -144,6 +144,7 @@ caluma:
       delete: "Supprimer l'option"
       archive: "Archiver (masquer) l'option"
       restore: "Restaurer l'option"
+      show-jexl: "Afficher JEXL"
 
     notification:
       form:

--- a/packages/form-builder/translations/it.yaml
+++ b/packages/form-builder/translations/it.yaml
@@ -144,6 +144,7 @@ caluma:
       delete: "Elimina opzione"
       archive: "Archivia (nascondi) opzione"
       restore: "Ripristina opzione"
+      show-jexl: "Mostra JEXL"
 
     notification:
       form:

--- a/packages/form/addon/gql/fragments/field.graphql
+++ b/packages/form/addon/gql/fragments/field.graphql
@@ -72,6 +72,7 @@ fragment SimpleQuestion on Question {
           slug
           label
           isArchived
+          isHidden
         }
       }
     }
@@ -89,6 +90,7 @@ fragment SimpleQuestion on Question {
           slug
           label
           isArchived
+          isHidden
         }
       }
     }

--- a/packages/form/addon/lib/question.js
+++ b/packages/form/addon/lib/question.js
@@ -141,11 +141,14 @@ export default class Question extends Base {
     const key = camelize(this.raw.__typename.replace(/Question$/, "Options"));
     const raw = this.isDynamic ? this[key] : this.raw[key];
 
-    return (raw?.edges || []).map(({ node: { label, slug, isArchived } }) => ({
-      label,
-      slug,
-      disabled: isArchived || false,
-    }));
+    return (raw?.edges || []).map(
+      ({ node: { label, slug, isArchived, isHidden } }) => ({
+        label,
+        slug,
+        disabled: isArchived || false,
+        isHidden,
+      }),
+    );
   }
 
   /**

--- a/packages/form/tests/unit/lib/field-test.js
+++ b/packages/form/tests/unit/lib/field-test.js
@@ -391,7 +391,7 @@ module("Unit | Library | field", function (hooks) {
   });
 
   test("it can validate radio fields", async function (assert) {
-    assert.expect(1);
+    assert.expect(2);
 
     const field = this.addField({
       question: {
@@ -401,6 +401,7 @@ module("Unit | Library | field", function (hooks) {
               node: {
                 slug: "option-1",
                 label: "Option 1",
+                isHidden: "false",
               },
             },
             {
@@ -408,6 +409,14 @@ module("Unit | Library | field", function (hooks) {
                 slug: "invalid-option",
                 label: "Invalid Option",
                 isArchived: true,
+                isHidden: "false",
+              },
+            },
+            {
+              node: {
+                slug: "hidden-option",
+                label: "Hidden Option",
+                isHidden: "true",
               },
             },
           ],
@@ -428,10 +437,16 @@ module("Unit | Library | field", function (hooks) {
     assert.deepEqual(field.errors, [
       '"Invalid Option" is not a valid value for this field',
     ]);
+
+    field.answer.value = "hidden-option";
+    await field.validate.perform();
+    assert.deepEqual(field.errors, [
+      '"Hidden Option" is not a valid value for this field',
+    ]);
   });
 
   test("it can validate checkbox fields", async function (assert) {
-    assert.expect(2);
+    assert.expect(3);
 
     const field = this.addField({
       question: {
@@ -448,6 +463,13 @@ module("Unit | Library | field", function (hooks) {
                 slug: "invalid-option",
                 label: "Invalid Option",
                 isArchived: true,
+              },
+            },
+            {
+              node: {
+                slug: "hidden-option",
+                label: "Hidden Option",
+                isHidden: "true",
               },
             },
           ],
@@ -474,6 +496,12 @@ module("Unit | Library | field", function (hooks) {
     assert.deepEqual(field.errors, [
       '"Invalid Option" is not a valid value for this field',
       '"other-invalid-option" is not a valid value for this field',
+    ]);
+
+    field.answer.value = ["hidden-option"];
+    await field.validate.perform();
+    assert.deepEqual(field.errors, [
+      '"Hidden Option" is not a valid value for this field',
     ]);
   });
 

--- a/packages/testing/addon-mirage-support/factories/option.js
+++ b/packages/testing/addon-mirage-support/factories/option.js
@@ -8,4 +8,5 @@ export default Factory.extend({
   label: (i) => `Option ${i + 1}`,
   meta: () => ({}),
   isArchived: false,
+  isHidden: "false",
 });

--- a/packages/testing/addon/mirage-graphql/schema.graphql
+++ b/packages/testing/addon/mirage-graphql/schema.graphql
@@ -3237,6 +3237,7 @@ input SaveOptionInput {
   slug: String!
   label: String!
   isArchived: Boolean
+  isHidden: Boolean
   meta: JSONString
   clientMutationId: String
 }

--- a/packages/testing/addon/mirage-graphql/schema.graphql
+++ b/packages/testing/addon/mirage-graphql/schema.graphql
@@ -3237,7 +3237,7 @@ input SaveOptionInput {
   slug: String!
   label: String!
   isArchived: Boolean
-  isHidden: Boolean
+  isHidden: QuestionJexl
   meta: JSONString
   clientMutationId: String
 }


### PR DESCRIPTION
## Description

Adds JEXLs to options for choice and multiple choice questions.

If an option has been selected which becomes invisible due to it's JEXL it behaves like an option that isn't available anymore.

Form builder:
![grafik](https://github.com/user-attachments/assets/40197462-ff39-40be-a388-a5ca61b6e68f)


Fixes # (issue)

## Depedencies

Depends on ~~https://github.com/projectcaluma/caluma/pull/2269~~ (merged)