### PR TITLE
fix(analytics): display new lines in table

### DIFF
--- a/packages/analytics/addon/components/ca-report-preview.hbs
+++ b/packages/analytics/addon/components/ca-report-preview.hbs
@@ -33,6 +33,7 @@
               <td
                 data-t={{this.getXLSXType entry.value}}
                 data-v={{this.cleanValue entry.value}}
+                class={{this.getCSSClass entry.value}}
               >
                 {{entry.value}}
               </td>
@@ -45,6 +46,7 @@
               <td
                 data-t={{this.getXLSXType summary.value}}
                 data-v={{this.cleanValue summary.value}}
+                class={{this.getCSSClass summary.value}}
               >
                 {{summary.value}}
               </td>

--- a/packages/analytics/addon/components/ca-report-preview.js
+++ b/packages/analytics/addon/components/ca-report-preview.js
@@ -90,6 +90,14 @@ export default class CaReportPreviewComponent extends Component {
     return "s";
   }
 
+  getCSSClass(value) {
+    if (value?.includes("\n")) {
+      return "multiline-data";
+    }
+
+    return "";
+  }
+
   // cleaning needed because excel does not support carriage returns
   cleanValue = (value) => value?.replaceAll(/\r/g, "");
 }

--- a/packages/analytics/app/styles/@projectcaluma/ember-analytics.scss
+++ b/packages/analytics/app/styles/@projectcaluma/ember-analytics.scss
@@ -4,3 +4,10 @@
 .sortable-item.is-dragging {
   z-index: 10;
 }
+
+.multiline-data {
+  white-space: pre-line;
+  line-height: normal;
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
+}


### PR DESCRIPTION
## Description

Display new lines in analytics table. As it is not openable like a normal caluma table.
Without the change the newline information would be entirely lost on the analytics user.

New look
![image](https://github.com/user-attachments/assets/eb0d9354-0a87-4aba-a8b0-a4236947e541)
