### PR TITLE
fix(form): showing of field value in case of calculated questions

### DIFF
--- a/packages/form/addon/components/cf-field-value.hbs
+++ b/packages/form/addon/components/cf-field-value.hbs
@@ -24,5 +24,5 @@
 {{else if (and @field.answer.value @field.question.useNumberSeparatorWidget)}}
   {{format-number @field.answer.value maximumFractionDigits=20}}
 {{else}}
-  {{@field.answer.value}}
+  {{@field.value}}
 {{/if}}

--- a/packages/form/tests/integration/components/cf-field-value-test.js
+++ b/packages/form/tests/integration/components/cf-field-value-test.js
@@ -106,11 +106,28 @@ module("Integration | Component | cf-field-value", function (hooks) {
       answer: {
         value: "foo",
       },
+      value: "foo",
     };
 
     await render(hbs`<CfFieldValue @field={{this.field}} />`);
 
     assert.dom(this.element).hasText("foo");
+  });
+
+  test("it renders calculated float questions", async function (assert) {
+    this.field = {
+      questionType: "CalculatedFloatQuestion",
+      question: {
+        raw: {
+          __typename: "CalculatedFloatQuestion",
+        },
+      },
+      value: 1111111.111111,
+    };
+
+    await render(hbs`<CfFieldValue @field={{this.field}} />`);
+
+    assert.dom(this.element).hasText("1111111.111111");
   });
 
   test("it renders file questions", async function (assert) {

--- a/packages/form/tests/integration/components/cf-field/input/table-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/table-test.js
@@ -23,6 +23,7 @@ module("Integration | Component | cf-field/input/table", function (hooks) {
                   slug: "first-name",
                 },
                 answer: { value: "Max" },
+                value: "Max",
               },
               {
                 question: {
@@ -30,6 +31,7 @@ module("Integration | Component | cf-field/input/table", function (hooks) {
                   slug: "last-name",
                 },
                 answer: { value: "Muster" },
+                value: "Muster",
               },
             ],
           },


### PR DESCRIPTION
## Description

This change is supposed to fix the value of a calculated_float field not showing in a table row.
The value does not show up currently because the answer for calculated_float fields is not written, just evaluated (see `get calculatedValue()` in `packages/form/addon/lib/field.js`)

## Depedencies

no dependencies
