### PR TITLE
fix: add length transform to validators

### DIFF
--- a/packages/form-builder/addon/validators/jexl.js
+++ b/packages/form-builder/addon/validators/jexl.js
@@ -13,6 +13,7 @@ const TRANSFORMS = [
   "avg",
   "stringify",
   "flatten",
+  "length",
 ];
 const BINARY_OPS = ["intersects"];
 


### PR DESCRIPTION
## Description

adds the length jexl transform to the validators for frontend form validation
