### PR TITLE
feat(distribution): show tooltip for disabled distrubution types

### DIFF
--- a/packages/distribution/addon/components/cd-inquiry-new-form/select.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-new-form/select.hbs
@@ -1,14 +1,22 @@
 {{#unless this.showAllServices}}
   <div class="uk-margin-bottom uk-button-group" data-test-group-toggle-bar>
     {{#each-in this.config.new.types as |slug config|}}
-      {{#unless config.disabled}}
+      {{#if config.notAvailableText}}
         <UkButton
-          data-test-type={{slug}}
+          {{uk-tooltip config.notAvailableText pos="bottom" delay=200}}
           @label={{t config.label}}
-          @color={{if (includes slug @selectedTypes) "primary" "default"}}
-          @onClick={{fn this.updateSelectedTypes slug}}
+          disabled
         />
-      {{/unless}}
+      {{else}}
+        {{#unless config.disabled}}
+          <UkButton
+            data-test-type={{slug}}
+            @label={{t config.label}}
+            @color={{if (includes slug @selectedTypes) "primary" "default"}}
+            @onClick={{fn this.updateSelectedTypes slug}}
+          />
+        {{/unless}}
+      {{/if}}
     {{/each-in}}
   </div>
 {{/unless}}


### PR DESCRIPTION
## Description

Adds the option to disable buttons in the distribution with a tooltip instead of just hiding the button.

The translations are taken from the `caluma-options` service.

![grafik](https://github.com/user-attachments/assets/2ab9c5f6-ee0e-425b-a7df-53bb4e635abc)
