### PR TITLE
fix(gql): fetch hintText for Dynamic{,Multiple}ChoiceQuestions as well

### DIFF
--- a/packages/form/addon/gql/fragments/field.graphql
+++ b/packages/form/addon/gql/fragments/field.graphql
@@ -98,6 +98,12 @@ fragment SimpleQuestion on Question {
     }
     hintText
   }
+  ... on DynamicChoiceQuestion {
+    hintText
+  }
+  ... on DynamicMultipleChoiceQuestion {
+    hintText
+  }
   ... on DateQuestion {
     dateDefaultAnswer: defaultAnswer {
       id


### PR DESCRIPTION
`DynamicChoiceQuestion` and `DynamicMultipleChoiceQuestion` support querying the `hintText` property. This should resolve the issue where no hint text is displayed for dynamic questions (via the `CfField` component) despite a hint text being set via FormBuilder.