### PR TITLE
fix(form-builder): default answer not selectable for choice questions

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/question/default.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question/default.js
@@ -38,11 +38,16 @@ export default class CfbFormEditorQuestionDefault extends Component {
         raw.meta = { widgetOverride: "cf-field/input/powerselect" };
       }
 
-      const key = this.args.model.__typename
-        .replace(/^./, (match) => match.toLowerCase())
-        .replace("Question", "Options");
+      const key = camelize(
+        this.args.model.__typename.replace(/Question$/, "Options"),
+      );
 
-      raw[key] = raw.options;
+      // Format option changesets to match the raw format needed in lib.
+      raw[key] = {
+        edges: raw.options.map((node) => {
+          return { node };
+        }),
+      };
       delete raw.options;
     }
 


### PR DESCRIPTION
## Description

Multiple Choice and Choice question default answer was not selectable because `lib/question` expected the `raw` format while default answer was passing a list of changesets for the options

Fixes #2851


