### PR TITLE
fix(calc-questions): always calculate calculated answer if possible

### DIFF
--- a/packages/form/addon/lib/document.js
+++ b/packages/form/addon/lib/document.js
@@ -271,16 +271,25 @@ export default class Document extends Base {
   findAnswer(slug, defaultValue) {
     const field = this.findField(slug);
 
+    const hasDefault = !(defaultValue === undefined);
+
     if (!field) {
-      if (defaultValue === undefined) {
+      if (!hasDefault) {
         throw new Error(`Field for question \`${slug}\` could not be found`);
       }
 
       return defaultValue;
     }
 
-    if (field.hidden || [undefined, null].includes(field.value)) {
-      return (defaultValue ?? field.question.isMultipleChoice) ? [] : null;
+    const emptyValue =
+      field.question.isTable || field.question.isMultipleChoice ? [] : null;
+
+    if (field.hidden) {
+      return emptyValue;
+    }
+
+    if ([undefined, null].includes(field.value)) {
+      return hasDefault ? defaultValue : emptyValue;
     }
 
     if (field.question.isTable) {

--- a/packages/form/addon/lib/field.js
+++ b/packages/form/addon/lib/field.js
@@ -274,10 +274,7 @@ export default class Field extends Base {
    */
   @cached
   get calculatedValue() {
-    if (
-      !this.question.isCalculated ||
-      !this.calculatedDependencies.every((field) => !field.hidden)
-    ) {
+    if (!this.question.isCalculated) {
       return null;
     }
 


### PR DESCRIPTION
We don't need to ensure that *every* dependency is non-hidden; indeed it should be possible to evaluate an expression where parts of the dependencies are not set. This is how the backend does it. Also, the `answer` transform does have a default option, so we should easily be able to deal with this.
