### PR TITLE
fix(form-builder): fix hidden and required indicators in form-builder

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/question-list/item.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list/item.js
@@ -2,9 +2,10 @@ import { action } from "@ember/object";
 import { guidFor } from "@ember/object/internals";
 import { service } from "@ember/service";
 import Component from "@glimmer/component";
-import jexl from "jexl";
 
 import { hasQuestionType } from "@projectcaluma/ember-core/helpers/has-question-type";
+
+const cleanJexl = (expr) => expr.replace(/\s/g, "");
 
 export default class CfbFormEditorQuestionListItem extends Component {
   @service router;
@@ -14,33 +15,31 @@ export default class CfbFormEditorQuestionListItem extends Component {
   }
 
   get required() {
-    try {
-      return jexl.evalSync(this.args.question?.isRequired);
-    } catch (error) {
-      return this.args.question?.isRequired;
-    }
+    return this.requiredType !== "not-required";
   }
 
   get requiredType() {
-    const required = this.required;
-    return required === true
+    const required = cleanJexl(this.args.question?.isRequired ?? "");
+
+    return required === "true"
       ? "required"
-      : required
-        ? "conditional"
-        : "not-required";
+      : required === "false"
+        ? "not-required"
+        : "conditional";
   }
 
   get hidden() {
-    try {
-      return jexl.evalSync(this.args.question?.isHidden);
-    } catch (error) {
-      return this.args.question?.isHidden;
-    }
+    return this.hiddenType !== "not-hidden";
   }
 
   get hiddenType() {
-    const hidden = this.hidden;
-    return hidden === true ? "hidden" : hidden ? "conditional" : "not-hidden";
+    const hidden = cleanJexl(this.args.question?.isHidden ?? "");
+
+    return hidden === "true"
+      ? "hidden"
+      : hidden === "false"
+        ? "not-hidden"
+        : "conditional";
   }
 
   get showFormLink() {


### PR DESCRIPTION
This drops the usage of actual JEXL evaluation in the question list of the form builder in favour of static analysis of the expression (true or false). The problem with the evaluation was, that if an expression only uses context (e.g. `info.form`) it didn't throw and error but evaluated to false. This caused such questions to be marked as always visible when in truth, they'd be conditionally hidden.
