### PR TITLE
JEXL evaluation fixes

### DIFF
--- a/packages/form/addon/lib/document.js
+++ b/packages/form/addon/lib/document.js
@@ -6,9 +6,9 @@ import { cached } from "tracked-toolbox";
 
 import { decodeId } from "@projectcaluma/ember-core/helpers/decode-id";
 import {
+  flatten,
   intersects,
   mapby,
-  flatten,
 } from "@projectcaluma/ember-core/utils/jexl";
 import Base from "@projectcaluma/ember-form/lib/base";
 
@@ -280,7 +280,7 @@ export default class Document extends Base {
     }
 
     if (field.hidden || [undefined, null].includes(field.value)) {
-      return (defaultValue ?? field.question.isMultipleChoice) ? [] : null;
+      return defaultValue ?? (field.question.isMultipleChoice ? [] : null);
     }
 
     if (field.question.isTable) {

--- a/packages/form/addon/lib/field.js
+++ b/packages/form/addon/lib/field.js
@@ -6,7 +6,7 @@ import { camelize } from "@ember/string";
 import { isEmpty } from "@ember/utils";
 import { tracked } from "@glimmer/tracking";
 import { queryManager } from "ember-apollo-client";
-import { restartableTask, lastValue, dropTask } from "ember-concurrency";
+import { dropTask, lastValue, restartableTask } from "ember-concurrency";
 import { validate } from "ember-validators";
 import isEqual from "lodash.isequal";
 import { cached } from "tracked-toolbox";
@@ -50,12 +50,19 @@ const MUTATION_MAP = {
   TableAnswer: saveDocumentTableAnswerMutation,
 };
 
-const fieldIsHiddenOrEmpty = (field) => {
+const fieldIsHidden = (field) => {
+  return field.hidden;
+};
+
+const fieldIsEmpty = (field) => {
   return (
-    field.hidden ||
-    (!field.question.isTable &&
-      (field.answer.value === null || field.answer.value === undefined))
+    !field.question.isTable &&
+    (field.answer.value === null || field.answer.value === undefined)
   );
+};
+
+const fieldIsHiddenOrEmpty = (field) => {
+  return fieldIsHidden(field) || fieldIsEmpty(field);
 };
 
 /**
@@ -521,7 +528,7 @@ export default class Field extends Base {
     if (
       this.fieldset.field?.hidden ||
       (this.hiddenDependencies.length &&
-        this.hiddenDependencies.every(fieldIsHiddenOrEmpty))
+        this.hiddenDependencies.every(fieldIsHidden))
     ) {
       return true;
     }


### PR DESCRIPTION
This PR proposes 2 fixes in JEXL evaluation. 

# 1. JEXL evaluation for empty depending fields:

Currently, the JEXL evaluation is completely skipped when all depending fields are hidden or empty, this should be changed to only skip when they are hidden.

**Take the following example:**

`field-a` is visible, but has no value
`field-b` has a hidden JEXL expression `"field-a"|answer("no") == "yes"`

So, field-b is a field we only want to hide when field-a is set to "yes". But currently the JEXL evaluation completely skipped and ignored (so just hiding field-b), because field-a has no value, and the default value passed through the answer transform is also ignored. 

So, without this fix it is not possible to show/hide field-b based on the value of field-a, until you actually save a value in field-a. (You would expect this answer transform in the JEXL to use the provided default value if no value is set)

# 2. JEXL answer transform default value:

The second fix is to get the correct default value for an answer transform when the value is empty. The current ternary will always return an empty array when a default value is set, instead of the provided default value. 