### PR TITLE
chore(jexl): revert JEXL evaluation condition

### DIFF
--- a/packages/form/addon/lib/field.js
+++ b/packages/form/addon/lib/field.js
@@ -528,7 +528,7 @@ export default class Field extends Base {
     if (
       this.fieldset.field?.hidden ||
       (this.hiddenDependencies.length &&
-        this.hiddenDependencies.every(fieldIsHidden))
+        this.hiddenDependencies.every(fieldIsHiddenOrEmpty))
     ) {
       return true;
     }


### PR DESCRIPTION
Revert the JEXL trigger condition to skip on empty dependending question answers in the minor release changes.

In https://github.com/projectcaluma/ember-caluma/pull/2935 we created a bugfix to trigger JEXL evaluations only when depending questions are hidden, not when they are empty. This is currently not in sync with the backend logic and it should be reverted for now in the minor release changes.

We will still plan to re-introduce the bugfix in a major upgrade on a later stage, in sync with the backend logic.