### PR TITLE
fix(compare): pass compare context to table row view

### DIFF
--- a/packages/form/addon/components/cf-field/input/table.hbs
+++ b/packages/form/addon/components/cf-field/input/table.hbs
@@ -125,6 +125,7 @@
         @fieldset={{object-at 0 this.documentToEdit.fieldsets}}
         @disabled={{@disabled}}
         @context={{@context}}
+        @compare={{@compare}}
       />
     </modal.body>
 


### PR DESCRIPTION
## Description

When opening the modal of a table row the `compare` context should be passed down, so it will also show the changes made inside the table row as well.

(Originally it was in the `context` and already passed down, since it's in a separate `compare` now that one needs to be passed down as well) 
