### PR TITLE
fix(compare): timeline select should not show a clear button

### DIFF
--- a/packages/form/addon/components/timeline-select.hbs
+++ b/packages/form/addon/components/timeline-select.hbs
@@ -4,7 +4,6 @@
   @options={{@options}}
   @searchEnabled={{false}}
   @searchField="label"
-  @allowClear={{true}}
   @onChange={{@onChange}}
   as |option|
 >


### PR DESCRIPTION
## Description

Timeline select dropdown is not optional so it should not show the `x` to clear the field (it shows right now and doesn't do anything)