### PR TITLE
fix(number-separator): don't allow not wanted input 

### DIFF
--- a/packages/form/addon/components/cf-field/input/number-separator.hbs
+++ b/packages/form/addon/components/cf-field/input/number-separator.hbs
@@ -14,6 +14,7 @@
     value={{this.displayValue}}
     placeholder={{@field.question.raw.placeholder}}
     readonly={{this.disabled}}
+    {{on "keydown" this.checkInput}}
     {{on "input" this.input}}
   />
 {{/if}}

--- a/packages/form/addon/components/cf-field/input/number-separator.js
+++ b/packages/form/addon/components/cf-field/input/number-separator.js
@@ -5,6 +5,10 @@ import { cached } from "tracked-toolbox";
 
 export default class CfFieldInputNumberSeparatorComponent extends Component {
   @service intl;
+  @service notification;
+
+  blockCount = 0;
+  blockNotified = false;
 
   get disabled() {
     return this.args.disabled || this.args.field?.question.isCalculated;
@@ -38,11 +42,57 @@ export default class CfFieldInputNumberSeparatorComponent extends Component {
     return this.intl.formatNumber(1.1).replace(/\p{Number}/gu, "");
   }
 
+  @cached
+  get allowedRegex() {
+    // Returns a regex for allowed input characters: digits and thousands
+    // separators for integers, plus decimal separators for floats.
+    const mil = RegExp.escape(this.thousandSeparator);
+    const dec = RegExp.escape(this.decimalSeparator);
+
+    if (this.args.field.questionType === "IntegerQuestion") {
+      return new RegExp(`(\\d|${mil})`);
+    }
+    return new RegExp(`(\\d|${mil}|${dec})`);
+  }
+
+  @action
+  checkInput(event) {
+    // allow keys like backspace, tab and arrows
+    if (event.key.length > 1 || event.ctrlKey || event.metaKey) {
+      return;
+    }
+
+    if (!this.allowedRegex.test(event.key)) {
+      event.preventDefault();
+      this.blockCount += 1;
+    }
+
+    // After the sixth attempt to enter a invalid character, the user will
+    // see a warning listing the characters that are allowed.
+    if (this.blockCount > 5 && !this.blockNotified) {
+      const allowedChars = ["0-9", this.thousandSeparator];
+
+      if (this.args.field.questionType === "FloatQuestion") {
+        allowedChars.push(this.decimalSeparator);
+      }
+
+      this.notification.warning(
+        this.intl.t(`caluma.form.validation.blockNotification`, {
+          allowedChars: allowedChars.join(" "),
+        }),
+      );
+
+      this.blockCount = 0;
+      this.blockNotified = true;
+    }
+  }
+
   @action
   input({ target: { value } }) {
     // We need to remove the thousand separator and replace the decimal
     // separator with a dot in order to parse it into a number. Which character
     // those are is determined per locale in the getters above.
+
     const serialized = parseFloat(
       value
         .replace(new RegExp(`\\${this.thousandSeparator}`, "g"), "")

--- a/packages/form/tests/integration/components/cf-field/input/number-separator-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/number-separator-test.js
@@ -1,8 +1,9 @@
-import { fillIn, render } from "@ember/test-helpers";
+import { fillIn, render, triggerKeyEvent } from "@ember/test-helpers";
 import { tracked } from "@glimmer/tracking";
 import { hbs } from "ember-cli-htmlbars";
 import { setLocale } from "ember-intl/test-support";
 import { module, test } from "qunit";
+import { stub } from "sinon";
 
 import { setupRenderingTest } from "dummy/tests/helpers";
 
@@ -80,6 +81,82 @@ module(
 
       assert.strictEqual(this.field.value, 1234.123);
       assert.dom("input").hasValue("1,234.123");
+    });
+
+    test("it blocks invalid characters for integer questions", async function (assert) {
+      await render(
+        hbs`<CfField::Input::NumberSeparator @field={{this.field}} @onSave={{this.save}} />`,
+      );
+
+      await fillIn("input", "10");
+      assert.dom("input").hasValue("10");
+
+      await triggerKeyEvent("input", "keydown", "A");
+      assert.dom("input").hasValue("10");
+
+      await triggerKeyEvent("input", "keydown", ",");
+      assert.dom("input").hasValue("10");
+
+      await triggerKeyEvent("input", "keydown", ".");
+      assert.dom("input").hasValue("10");
+    });
+
+    test("it blocks invalid characters for float questions", async function (assert) {
+      this.field.questionType = "FloatQuestion";
+
+      await render(
+        hbs`<CfField::Input::NumberSeparator @field={{this.field}} @onSave={{this.save}} />`,
+      );
+
+      await fillIn("input", "10.55");
+      assert.dom("input").hasValue("10.55");
+
+      await triggerKeyEvent("input", "keydown", "A");
+      assert.dom("input").hasValue("10.55");
+
+      await triggerKeyEvent("input", "keydown", ",");
+      assert.dom("input").hasValue("10.55");
+
+      await triggerKeyEvent("input", "keydown", ".");
+      assert.dom("input").hasValue("10.55");
+    });
+
+    test("triggers a warning exactly once after 6 attempts", async function (assert) {
+      this.field.questionType = "FloatQuestion";
+      const service = this.owner.lookup("service:notification");
+      const warning = stub(service, "warning");
+
+      await render(
+        hbs`<CfField::Input::NumberSeparator @field={{this.field}} @onSave={{this.save}} />`,
+      );
+
+      assert.ok(warning.notCalled);
+
+      await triggerKeyEvent("input", "keydown", ",");
+      await triggerKeyEvent("input", "keydown", ",");
+      await triggerKeyEvent("input", "keydown", ",");
+      await triggerKeyEvent("input", "keydown", ",");
+      await triggerKeyEvent("input", "keydown", ",");
+      // this one should trigger the notification
+      await triggerKeyEvent("input", "keydown", ",");
+
+      assert.ok(warning.called);
+      assert.ok(warning.calledOnce);
+      assert.strictEqual(
+        warning.args[0][0],
+        "In diesem Feld sind nur folgende Zeichen erlaubt: 0-9 ' .",
+      );
+
+      await triggerKeyEvent("input", "keydown", ",");
+      await triggerKeyEvent("input", "keydown", ",");
+      await triggerKeyEvent("input", "keydown", ",");
+      await triggerKeyEvent("input", "keydown", ",");
+      await triggerKeyEvent("input", "keydown", ",");
+      // this one does not trigger the notification again
+      await triggerKeyEvent("input", "keydown", ",");
+
+      assert.ok(warning.calledOnce);
+      assert.notOk(warning.calledTwice);
     });
   },
 );

--- a/packages/form/translations/de.yaml
+++ b/packages/form/translations/de.yaml
@@ -57,6 +57,7 @@ caluma:
       format: "{errorMsg}"
       table: "Mindestens eine Zeile der Tabelle wurde nicht korrekt ausgefüllt"
       error: "Folgende Fragen sind noch nicht korrekt ausgefüllt:"
+      blockNotification: "In diesem Feld sind nur folgende Zeichen erlaubt: {allowedChars}"
 
     compare:
       note: "Geändert von {username} am {date}"

--- a/packages/form/translations/en.yaml
+++ b/packages/form/translations/en.yaml
@@ -57,6 +57,7 @@ caluma:
       format: "{errorMsg}"
       table: "At least one row of the table was not filled in correctly"
       error: "The following questions have not yet been filled in correctly:"
+      blockNotification: "Only the following characters are allowed in this field: {allowedChars}"
 
     compare:
       note: "Changed by {username} on {date}"

--- a/packages/form/translations/fr.yaml
+++ b/packages/form/translations/fr.yaml
@@ -57,6 +57,7 @@ caluma:
       format: "{errorMsg}"
       table: "Au moins une ligne du tableau n'a pas été remplie correctement"
       error: "Les questions suivantes n'ont pas encore été correctement remplies :"
+      blockNotification: "Seuls les caractères suivants sont autorisés dans ce champ : {allowedChars}"
 
     compare:
       note: "Modifié par {username} le {date}"

--- a/packages/form/translations/it.yaml
+++ b/packages/form/translations/it.yaml
@@ -57,6 +57,7 @@ caluma:
       format: "{errorMsg}"
       table: "Almeno una riga della tabella non è stata compilata correttamente."
       error: "Le domande seguenti non sono state compilate in modo corretto:"
+      blockNotification: "In questo campo sono consentiti solo i seguenti caratteri: {allowedChars}"
 
     compare:
       note: "Modificato da {username} il {date}"


### PR DESCRIPTION
When a user adds a comma in an integer or float question everything after the comma and the comma itself is getting stripped from the original input. But the user can't see that because it does only show after a reload. Because of that we don't allow unwanted input in those fields anymore. If the user enters a not allowed character 6 times, a notification shows up.