### PR TITLE
fix(jexl): pass property `parentField` when creating a new table row

### DIFF
--- a/packages/form/addon/components/cf-field/input/table.js
+++ b/packages/form/addon/components/cf-field/input/table.js
@@ -66,9 +66,11 @@ export default class CfFieldInputTableComponent extends Component {
     );
 
     const owner = getOwner(this);
-    const newDocument = new (owner.factoryFor("caluma-model:document").class)({
+    const Document = owner.factoryFor("caluma-model:document").class;
+    const newDocument = new Document({
       raw: this.parseDocument(raw),
       parentDocument: this.args.field.document,
+      parentField: this.args.field,
       owner,
     });
 


### PR DESCRIPTION
This is a follow-up fix for #3025