### PR TITLE
test(number-separator): assert new thousand separator char for de-CH

### DIFF
--- a/packages/form/tests/integration/components/cf-field-value-test.js
+++ b/packages/form/tests/integration/components/cf-field-value-test.js
@@ -165,6 +165,6 @@ module("Integration | Component | cf-field-value", function (hooks) {
 
     await render(hbs`<CfFieldValue @field={{this.field}} />`);
 
-    assert.dom(this.element).hasText("1’111’111.111111");
+    assert.dom(this.element).hasText("1'111'111.111111");
   });
 });

--- a/packages/form/tests/integration/components/cf-field/input/number-separator-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/number-separator-test.js
@@ -33,7 +33,7 @@ module(
       await fillIn("input", "1234");
 
       assert.strictEqual(this.field.value, 1234);
-      assert.dom("input").hasValue("1’234");
+      assert.dom("input").hasValue("1'234");
 
       await fillIn("input", "0");
       assert.dom("input").hasValue("0");
@@ -49,7 +49,7 @@ module(
       await fillIn("input", "1234.123");
 
       assert.strictEqual(this.field.value, 1234.123);
-      assert.dom("input").hasValue("1’234.123");
+      assert.dom("input").hasValue("1'234.123");
 
       await fillIn("input", "0");
       assert.dom("input").hasValue("0");
@@ -66,7 +66,7 @@ module(
 
       assert.dom("input").hasAttribute("readonly");
       assert.dom("input").hasClass("uk-disabled");
-      assert.dom("input").hasValue("1’234.123");
+      assert.dom("input").hasValue("1'234.123");
     });
 
     test("it works with other locales", async function (assert) {


### PR DESCRIPTION
CLDR 48 (Oct 2025) changed the de-CH group separator from U+2019 (’) to U+0027 ('). Chrome/V8 picks this up via its bundled ICU, so `Intl.NumberFormat` output (which we use via `ember-intl`s `formatNumber`) for de-CH now emits a straight apostrophe where it previously emitted a curly one.

CLDR 48.2 (Mar 2026) applied the same change to fr-CH for consistency.

For more information, check the CLDR changelog:

- https://cldr.unicode.org/downloads/cldr-48#numbers-1
- https://cldr.unicode.org/downloads/cldr-48#482-changes