### PR TITLE
fix(ember-form): fix typo in component class name

### DIFF
--- a/packages/form/addon/components/cf-field/input/radio.js
+++ b/packages/form/addon/components/cf-field/input/radio.js
@@ -1,7 +1,7 @@
 import { action } from "@ember/object";
 import Component from "@glimmer/component";
 
-export default class CfFieldInpuRadio extends Component {
+export default class CfFieldInputRadio extends Component {
   isAnswerRemoved = (option) => {
     return (
       this.args.compare &&


### PR DESCRIPTION
## Description

I fixed a typo in a class name:

<img width="337" height="145" alt="image" src="https://github.com/user-attachments/assets/75419121-8d2e-48a6-997d-be5cbd2c9859" />


Fixes # (issue)

## Dependencies

None.
