### PR TITLE
refactor(form-builder): refactor form components

### DIFF
--- a/packages/form-builder/addon/components/cfb-code-editor.hbs
+++ b/packages/form-builder/addon/components/cfb-code-editor.hbs
@@ -10,6 +10,7 @@
         {{if @isInvalid 'uk-form-danger'}}"
       {{did-insert this.didInsertNode}}
       {{will-destroy this.willDestroyNode}}
+      {{this.updateEditorContent @value}}
       {{autoresize mode="height"}}
       {{on "blur" @setDirty}}
     ></div>

--- a/packages/form-builder/addon/components/cfb-code-editor.hbs
+++ b/packages/form-builder/addon/components/cfb-code-editor.hbs
@@ -8,8 +8,7 @@
         {{concat 'language-' @language}}
         {{if @isValid 'uk-form-success'}}
         {{if @isInvalid 'uk-form-danger'}}"
-      {{did-insert this.didInsertNode}}
-      {{will-destroy this.willDestroyNode}}
+      {{this.initCodeEditor}}
       {{this.updateEditorContent @value}}
       {{autoresize mode="height"}}
       {{on "blur" @setDirty}}

--- a/packages/form-builder/addon/components/cfb-code-editor.js
+++ b/packages/form-builder/addon/components/cfb-code-editor.js
@@ -1,8 +1,8 @@
 import { action } from "@ember/object";
-import { addObserver } from "@ember/object/observers";
 import Component from "@glimmer/component";
 import { CodeJar } from "codejar";
 import { task, timeout } from "ember-concurrency";
+import { modifier } from "ember-modifier";
 import hljs from "highlight.js/lib/core";
 import json from "highlight.js/lib/languages/json";
 import markdown from "highlight.js/lib/languages/markdown";
@@ -60,14 +60,18 @@ export default class CfbCodeEditorComponent extends Component {
     this.args.update(value);
   }
 
-  updateEditorContent = task({ restartable: true }, async () => {
+  updateEditorContent = modifier((_, [value]) => {
+    this.updateEditorContentTask.perform(value);
+  });
+
+  updateEditorContentTask = task({ restartable: true }, async (value) => {
     // This function is called everytime `this.args.value` changes. In order to
     // not trigger too many updates, we debounce it for 10ms.
     await timeout(10);
 
-    if (!this._didChange(this.args.value)) return;
+    if (!this._didChange(value)) return;
 
-    this._lastValue = simplify(this.args.value);
+    this._lastValue = simplify(value);
     this._editor.updateCode(this.stringValue, false);
   });
 
@@ -78,15 +82,8 @@ export default class CfbCodeEditorComponent extends Component {
       hljs.highlightElement(editor);
     });
 
-    // set initial value
-    this._editor.updateCode(this.stringValue, false);
-    this._lastValue = simplify(this.args.value);
-
     // register update method
     this._editor.onUpdate(this.onUpdate);
-
-    // eslint-disable-next-line ember/no-observers
-    addObserver(this.args, "value", this.updateEditorContent, "perform");
   }
 
   @action

--- a/packages/form-builder/addon/components/cfb-code-editor.js
+++ b/packages/form-builder/addon/components/cfb-code-editor.js
@@ -75,8 +75,7 @@ export default class CfbCodeEditorComponent extends Component {
     this._editor.updateCode(this.stringValue, false);
   });
 
-  @action
-  didInsertNode(element) {
+  initCodeEditor = modifier((element) => {
     this._editor = CodeJar(element, (editor) => {
       editor.removeAttribute("data-highlighted");
       hljs.highlightElement(editor);
@@ -84,10 +83,11 @@ export default class CfbCodeEditorComponent extends Component {
 
     // register update method
     this._editor.onUpdate(this.onUpdate);
-  }
 
-  @action
-  willDestroyNode() {
-    this._editor.destroy();
-  }
+    // Register destructor on component destroy to make sure
+    // CodeJar instance is destroyed as well
+    return () => {
+      this._editor.destroy();
+    };
+  });
 }

--- a/packages/form-builder/addon/components/cfb-form-editor/general.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/general.hbs
@@ -1,10 +1,10 @@
-{{#if this._data.isRunning}}
+{{#if this.data.isLoading}}
   <div class="uk-flex uk-flex-center uk-flex-middle uk-height-small">
     <UkSpinner ratio="2" />
   </div>
-{{else if this.data}}
+{{else if this.dataIsLoaded}}
   <ValidatedForm
-    @model={{changeset this.data this.Validations}}
+    @model={{changeset this.data.value this.Validations}}
     @on-submit={{perform this.submit}}
     as |f|
   >
@@ -58,7 +58,7 @@
     </CfbFormEditor::CfbAdvancedSettings>
 
     <div class="uk-text-right">
-      <CfbFormEditor::CopyModal @item={{this.data}} as |modal|>
+      <CfbFormEditor::CopyModal @item={{this.data.value}} as |modal|>
         <f.button
           @disabled={{f.loading}}
           @label={{t "caluma.form-builder.copy-modal.submit"}}

--- a/packages/form-builder/addon/components/cfb-form-editor/general.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/general.js
@@ -3,7 +3,7 @@ import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 import { queryManager } from "ember-apollo-client";
 import { task } from "ember-concurrency";
-import { trackedTask } from "reactiveweb/ember-concurrency";
+import { trackedFunction } from "reactiveweb/function";
 
 import FormValidations from "../../validations/form";
 
@@ -19,22 +19,20 @@ export default class CfbFormEditorGeneral extends Component {
 
   Validations = FormValidations;
 
-  get data() {
-    return this._data.value?.[0]?.node;
+  get dataIsLoaded() {
+    // watchQuery returns an empty TrackedObject which is truthy
+    // so we need to check if the slug property exists in the object
+    return this.data.value && "slug" in this.data.value;
   }
 
-  fetchData = task({ restartable: true }, async () => {
+  data = trackedFunction(this, async () => {
     if (!this.args.slug) {
-      return [
-        {
-          node: {
-            name: "",
-            slug: "",
-            description: "",
-            isPublished: true,
-          },
-        },
-      ];
+      return {
+        name: "",
+        slug: "",
+        description: "",
+        isPublished: true,
+      };
     }
 
     return await this.apollo.watchQuery(
@@ -43,11 +41,9 @@ export default class CfbFormEditorGeneral extends Component {
         variables: { slug: this.args.slug },
         fetchPolicy: "cache-and-network",
       },
-      "allForms.edges",
+      "allForms.edges.0.node",
     );
   });
-
-  _data = trackedTask(this, this.fetchData, () => [this.args.slug]);
 
   get prefix() {
     return this.calumaOptions.namespace


### PR DESCRIPTION
## Description

This PR cleans up the data fetching in the general view of the `form-builder` and refactors how the `code-editor` component loads and updates the third-party CodeJar module

Fixes the issue where `form-builder` would crash when switching slugs, since the `code-editor` component didn't remove the observer before unloading

## Dependencies

Does this PR depend on other PRs of the `ember-caluma` or `caluma` repository? No