### PR TITLE
fix(ember-form): resolve form config from the host app inside engines

### DIFF
--- a/packages/core/addon/utils/get-config.js
+++ b/packages/core/addon/utils/get-config.js
@@ -1,0 +1,40 @@
+import { getOwner } from "@ember/application";
+import { getEngineParent } from "@ember/engine";
+
+const DEFAULTS = {
+  floatStep: 0.001,
+  powerSelectEnableSearchLimit: 10,
+  USE_MANDATORY_ASTERISK: false,
+  FLATPICKR_DATE_FORMAT: {
+    de: "d.m.Y",
+    fr: "d.m.Y",
+    en: "m/d/Y",
+  },
+  FLATPICKR_DATE_FORMAT_DEFAULT: "m/d/Y",
+};
+
+/**
+ * Resolve the host application's `ember-caluma` configuration, merged with the
+ * addon defaults.
+ *
+ * Ember engines have their own, isolated `config:environment`. Resolving config
+ * off an engine's own owner (e.g. via `getOwner(this)`) therefore yields the
+ * engine's config instead of the host application's, which means addon
+ * components rendered inside an engine silently fall back to defaults.
+ *
+ * When rendered inside an engine we resolve the config from the engine's parent
+ * (the host application), otherwise we use the owner directly.
+ *
+ * @function getConfig
+ * @param {Object} context Any object with an owner (e.g. a component).
+ * @return {Object} The resolved `ember-caluma` config, with defaults applied.
+ */
+export default function getConfig(context) {
+  const owner = getOwner(context);
+  const host = getEngineParent(owner) ?? owner;
+
+  return {
+    ...DEFAULTS,
+    ...(host.resolveRegistration("config:environment")["ember-caluma"] ?? {}),
+  };
+}

--- a/packages/form/addon/components/cf-field/input/date.js
+++ b/packages/form/addon/components/cf-field/input/date.js
@@ -1,9 +1,10 @@
-import { getOwner } from "@ember/application";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { DateTime } from "luxon";
+
+import getConfig from "@projectcaluma/ember-core/utils/get-config";
 
 export default class CfFieldInputDateComponent extends Component {
   @service intl;
@@ -14,21 +15,13 @@ export default class CfFieldInputDateComponent extends Component {
     return this.intl.primaryLocale.split("-")[0];
   }
 
-  get config() {
-    return getOwner(this).resolveRegistration("config:environment");
-  }
-
   get dateFormat() {
-    const {
-      FLATPICKR_DATE_FORMAT = {
-        de: "d.m.Y",
-        fr: "d.m.Y",
-        en: "m/d/Y",
-      },
-      FLATPICKR_DATE_FORMAT_DEFAULT = "m/d/Y",
-    } = this.config["ember-caluma"] || {};
+    const config = getConfig(this);
 
-    return FLATPICKR_DATE_FORMAT[this.locale] ?? FLATPICKR_DATE_FORMAT_DEFAULT;
+    return (
+      config.FLATPICKR_DATE_FORMAT[this.locale] ??
+      config.FLATPICKR_DATE_FORMAT_DEFAULT
+    );
   }
 
   @action

--- a/packages/form/addon/components/cf-field/input/float.js
+++ b/packages/form/addon/components/cf-field/input/float.js
@@ -1,6 +1,7 @@
-import { getOwner } from "@ember/application";
 import { action } from "@ember/object";
 import Component from "@glimmer/component";
+
+import getConfig from "@projectcaluma/ember-core/utils/get-config";
 
 export default class CfFieldInputFloatComponent extends Component {
   get disabled() {
@@ -12,9 +13,7 @@ export default class CfFieldInputFloatComponent extends Component {
       return this.args.field.question.raw.floatStep;
     }
 
-    const config = getOwner(this).resolveRegistration("config:environment");
-    const { floatStep = 0.001 } = config["ember-caluma"] || {};
-    return floatStep;
+    return getConfig(this).floatStep;
   }
 
   /**

--- a/packages/form/addon/components/cf-field/input/powerselect.js
+++ b/packages/form/addon/components/cf-field/input/powerselect.js
@@ -1,10 +1,11 @@
-import { getOwner } from "@ember/application";
 import { action } from "@ember/object";
 import { inject as service } from "@ember/service";
 import { ensureSafeComponent } from "@embroider/util";
 import Component from "@glimmer/component";
 import PowerSelectComponent from "ember-power-select/components/power-select";
 import PowerSelectMultipleComponent from "ember-power-select/components/power-select-multiple";
+
+import getConfig from "@projectcaluma/ember-core/utils/get-config";
 
 /**
  * Dropdown component for the single and multiple choice question type
@@ -39,10 +40,10 @@ export default class CfFieldInputPowerselectComponent extends Component {
   }
 
   get searchEnabled() {
-    const config = getOwner(this).resolveRegistration("config:environment");
-    const { powerSelectEnableSearchLimit = 10 } = config["ember-caluma"] || {};
-
-    return this.args.field?.options?.length > powerSelectEnableSearchLimit;
+    return (
+      this.args.field?.options?.length >
+      getConfig(this).powerSelectEnableSearchLimit
+    );
   }
 
   get placeholder() {

--- a/packages/form/addon/components/cf-field/label.js
+++ b/packages/form/addon/components/cf-field/label.js
@@ -1,5 +1,6 @@
-import { getOwner } from "@ember/application";
 import Component from "@glimmer/component";
+
+import getConfig from "@projectcaluma/ember-core/utils/get-config";
 
 /**
  * Label component of the CfField
@@ -7,14 +8,9 @@ import Component from "@glimmer/component";
  * @class CfFieldLabelComponent
  */
 export default class CfFieldLabelComponent extends Component {
-  get config() {
-    return getOwner(this).resolveRegistration("config:environment");
-  }
-
   get useMandatoryAsterisk() {
-    const { USE_MANDATORY_ASTERISK = false } =
-      this.config["ember-caluma"] || {};
-
-    return this.args.useMandatoryAsterisk ?? USE_MANDATORY_ASTERISK;
+    return (
+      this.args.useMandatoryAsterisk ?? getConfig(this).USE_MANDATORY_ASTERISK
+    );
   }
 }


### PR DESCRIPTION
Form settings (e.g. `USE_MANDATORY_ASTERISK`) were read via `getOwner(this).resolveRegistration("config:environment")`. Inside an Ember engine the owner is the engine, which has its own isolated `config:environment`, so these components silently fell back to defaults and ignored the host application's `ember-caluma` config.

Add a `get-config` util that resolves the config from the engine's parent (the host app) when mounted in an engine, and centralize the defaults there.