### PR TITLE
fix(form-builder): prevent duplicate questions on certain reorders

### DIFF
--- a/packages/form-builder/addon/components/cfb-form-editor/question-list.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list.hbs
@@ -71,7 +71,7 @@
     {{#if this.questionTask.isRunning}}
       <li class="uk-text-center"><UkSpinner @ratio={{1.5}} /></li>
     {{else}}
-      {{#each this.questions as |item|}}
+      {{#each this.questions key="node.slug" as |item|}}
         <CfbFormEditor::QuestionList::Item
           data-test-question-list-item={{item.node.slug}}
           @mode={{this.mode}}


### PR DESCRIPTION
## Description

Because `key` value wasn't set on the `each` helper for question list, Ember was losing track of which DOM elements belonged to the component when the list was reordered with UIkit's `uk-sortable`.

This caused an unstable rerendering of the component and old elements were not properly destroyed, showing up as duplicate questions.

This lets Ember properly keep track of the DOM elements, and reuses them instead of destroying and recreating them.

Fixes #2135

## Dependencies

Does this PR depend on other PRs of the `ember-caluma` or `caluma` repository? No