### PR TITLE
refactor(form-builder): cleanup question-list and options

### DIFF
--- a/packages/analytics/addon/components/ca-field-selector-list.hbs
+++ b/packages/analytics/addon/components/ca-field-selector-list.hbs
@@ -16,7 +16,7 @@
     data-test-field-list
     class="uk-list"
     id="field-list"
-    {{sortable-group onChange=(perform this.reorderFields)}}
+    {{sortable-group onChange=this.reorderFields.perform}}
   >
     {{#each this.fields as |field|}}
       {{#let (fn this.updateField field) as |update|}}
@@ -76,7 +76,7 @@
               class="uk-icon-button"
               uk-icon="trash"
               name={{t "caluma.analytics.edit.delete-field"}}
-              {{on "click" (perform this.removeAnalyticsField field.id)}}
+              {{on "click" (fn this.removeAnalyticsField.perform field.id)}}
             >
               <span hidden>{{t "caluma.analytics.edit.delete-field"}}</span>
             </button>

--- a/packages/analytics/addon/components/ca-field-selector-list/ca-field-alias-input.hbs
+++ b/packages/analytics/addon/components/ca-field-selector-list/ca-field-alias-input.hbs
@@ -3,5 +3,5 @@
   aria-label={{t "caluma.analytics.edit.display-title"}}
   class="uk-input"
   value={{@value}}
-  {{on "input" (perform this.debounceInput)}}
+  {{on "input" this.debounceInput.perform}}
 />

--- a/packages/analytics/addon/components/ca-filter-modal.hbs
+++ b/packages/analytics/addon/components/ca-filter-modal.hbs
@@ -63,7 +63,7 @@
     />
     <UkButton
       @color="primary"
-      @onClick={{perform this.saveField this.graphqlInput}}
+      @onClick={{fn this.saveField.perform this.graphqlInput}}
       @loading={{this.saveField.isRunning}}
       @label={{t "caluma.analytics.save"}}
     />

--- a/packages/analytics/addon/components/ca-report-builder.hbs
+++ b/packages/analytics/addon/components/ca-report-builder.hbs
@@ -1,7 +1,7 @@
 <div data-test-analytics-table ...attributes>
   <ValidatedForm
     @model={{@analyticsTable}}
-    @on-submit={{perform this.createTable}}
+    @on-submit={{this.createTable.perform}}
     as |f|
   >
     <f.input

--- a/packages/analytics/addon/templates/reports/edit.hbs
+++ b/packages/analytics/addon/templates/reports/edit.hbs
@@ -28,7 +28,7 @@
         type="button"
         class="uk-icon-button"
         uk-icon="trash"
-        {{on "click" (perform this.deleteTable)}}
+        {{on "click" this.deleteTable.perform}}
         name={{t "caluma.analytics.report.delete"}}
       >
         <span hidden>{{t "caluma.analytics.report.delete"}}</span>

--- a/packages/distribution/addon/components/cd-inquiry-answer-form.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-answer-form.hbs
@@ -91,7 +91,7 @@
                   )
                 }}
                 @onClick={{fn
-                  (perform this.completeWorkItem)
+                  this.completeWorkItem.perform
                   buttonConfig.workItemId
                   buttonConfig.willCompleteInquiry
                   validate
@@ -115,7 +115,7 @@
                 )
               }}
               @onClick={{fn
-                (perform this.completeWorkItem)
+                this.completeWorkItem.perform
                 buttonConfig.workItemId
                 buttonConfig.willCompleteInquiry
                 null

--- a/packages/distribution/addon/components/cd-inquiry-dialog.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-dialog.hbs
@@ -10,7 +10,7 @@
         class="uk-icon-button"
         {{uk-tooltip (t "caluma.distribution.new.title")}}
         data-test-new-inquiry
-        {{on "click" (perform this.createInquiry)}}
+        {{on "click" this.createInquiry.perform}}
       >
         {{#if this.createInquiry.isRunning}}
           <UkSpinner @ratio={{0.6}} />

--- a/packages/distribution/addon/components/cd-inquiry-dialog/inquiry-part.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-dialog/inquiry-part.hbs
@@ -56,7 +56,7 @@
             <li>
               <a
                 href=""
-                {{on "click" (perform this.withdraw)}}
+                {{on "click" this.withdraw.perform}}
                 data-test-withdraw
               >
                 {{t "caluma.distribution.withdraw.link"}}
@@ -76,7 +76,7 @@
         {{/if}}
         {{#if (and (eq @type "answer") (can "reopen inquiry" @inquiry))}}
           <li>
-            <a href="" {{on "click" (perform this.reopen)}} data-test-reopen>
+            <a href="" {{on "click" this.reopen.perform}} data-test-reopen>
               {{t "caluma.distribution.reopen-inquiry.link"}}
             </a>
           </li>
@@ -86,7 +86,7 @@
             <a
               data-test-send-reminder
               href=""
-              {{on "click" (perform this.sendReminder)}}
+              {{on "click" this.sendReminder.perform}}
             >
               {{t "caluma.distribution.reminder.link"}}
             </a>

--- a/packages/distribution/addon/components/cd-inquiry-edit-form.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-edit-form.hbs
@@ -53,7 +53,7 @@
             this.send.isRunning
             this.distribution.sendAllInquiries.isRunning
           }}
-          @onClick={{perform this.send validate}}
+          @onClick={{fn this.send.perform validate}}
           @loading={{this.send.isRunning}}
         >{{t "caluma.distribution.edit.send"}}</UkButton>
       </DocumentValidity>

--- a/packages/distribution/addon/components/cd-inquiry-new-form/bulk-edit.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-new-form/bulk-edit.hbs
@@ -18,7 +18,7 @@
       @type="submit"
       @loading={{this.submit.isRunning}}
       @disabled={{or (not isValid) this.submit.isRunning}}
-      @onClick={{perform this.submit validate}}
+      @onClick={{fn this.submit.perform validate}}
       data-test-submit
     />
   </DocumentValidity>

--- a/packages/distribution/addon/components/cd-inquiry-new-form/select.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-new-form/select.hbs
@@ -22,7 +22,7 @@
     type="search"
     value={{@search}}
     data-test-search
-    {{on "input" (perform this.updateSearch)}}
+    {{on "input" this.updateSearch.perform}}
   />
 </div>
 

--- a/packages/distribution/addon/components/cd-navigation/controls.hbs
+++ b/packages/distribution/addon/components/cd-navigation/controls.hbs
@@ -19,7 +19,7 @@
     {{/if}}
     {{#if (can "complete distribution")}}
       <UkButton
-        @onClick={{perform this.completeDistribution}}
+        @onClick={{this.completeDistribution.perform}}
         @label={{t "caluma.distribution.skip"}}
         @loading={{this.completeDistribution.isRunning}}
         @disabled={{this.completeDistribution.isRunning}}
@@ -28,7 +28,7 @@
     {{/if}}
     {{#if (can "reopen distribution")}}
       <UkButton
-        @onClick={{perform this.reopenDistribution}}
+        @onClick={{this.reopenDistribution.perform}}
         @label={{t "caluma.distribution.reopen"}}
         @loading={{this.reopenDistribution.isRunning}}
         @disabled={{this.reopenDistribution.isRunning}}
@@ -44,7 +44,7 @@
             class="uk-icon-button uk-button-primary"
             {{uk-tooltip (t "caluma.distribution.send")}}
             data-test-send-pending-inquiries
-            {{on "click" (perform this.distribution.sendAllInquiries)}}
+            {{on "click" this.distribution.sendAllInquiries.perform}}
           >
             {{#if this.distribution.sendAllInquiries.isRunning}}
               <UkSpinner @ratio={{0.6}} />
@@ -69,7 +69,7 @@
             class="uk-icon-button"
             {{uk-tooltip (t "caluma.distribution.check-inquiries")}}
             data-test-check-inquiries
-            {{on "click" (perform this.checkInquiries)}}
+            {{on "click" this.checkInquiries.perform}}
           >
             {{#if this.checkInquiries.isRunning}}
               <UkSpinner @ratio={{0.6}} />
@@ -84,7 +84,7 @@
             class="uk-icon-button"
             {{uk-tooltip (t "caluma.distribution.complete")}}
             data-test-complete-distribution
-            {{on "click" (perform this.completeDistribution)}}
+            {{on "click" this.completeDistribution.perform}}
           >
             {{#if this.completeDistribution.isRunning}}
               <UkSpinner @ratio={{0.6}} />
@@ -99,7 +99,7 @@
             class="uk-icon-button"
             {{uk-tooltip (t "caluma.distribution.reopen")}}
             data-test-reopen-distribution
-            {{on "click" (perform this.reopenDistribution)}}
+            {{on "click" this.reopenDistribution.perform}}
           >
             {{#if this.reopenDistribution.isRunning}}
               <UkSpinner @ratio={{0.6}} />

--- a/packages/form-builder/addon/components/cfb-form-editor/copy-modal.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/copy-modal.hbs
@@ -7,7 +7,7 @@
   {{#if this.visible}}
     <ValidatedForm
       @model={{this.changeset}}
-      @on-submit={{perform this.submit}}
+      @on-submit={{this.submit.perform}}
       as |f|
     >
       <modal.header>

--- a/packages/form-builder/addon/components/cfb-form-editor/general.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/general.hbs
@@ -5,7 +5,7 @@
 {{else if this.dataIsLoaded}}
   <ValidatedForm
     @model={{changeset this.data.value this.Validations}}
-    @on-submit={{perform this.submit}}
+    @on-submit={{this.submit.perform}}
     as |f|
   >
     <f.input

--- a/packages/form-builder/addon/components/cfb-form-editor/question-list.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list.hbs
@@ -41,7 +41,7 @@
         placeholder="{{t 'caluma.form-builder.global.search'}}..."
         aria-label="{{t 'caluma.form-builder.global.search'}}"
         value={{this.search}}
-        {{on "input" (perform this.searchTask)}}
+        {{on "input" this.searchTask.perform}}
       />
     </div>
   {{/if}}
@@ -73,8 +73,8 @@
           @mode={{this.mode}}
           @question={{item.node}}
           @onEditQuestion={{@onEditQuestion}}
-          @onRemoveQuestion={{perform this.removeQuestion}}
-          @onAddQuestion={{perform this.addQuestion}}
+          @onRemoveQuestion={{this.removeQuestion.perform}}
+          @onAddQuestion={{this.addQuestion.perform}}
           @onClickForm={{@onClickForm}}
         />
       {{else}}

--- a/packages/form-builder/addon/components/cfb-form-editor/question-list.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list.hbs
@@ -1,6 +1,7 @@
 <div
   ...attributes
-  {{did-insert (queue this.setupUIkit (perform this.questionTask))}}
+  {{on "moved" this._handleMoved}}
+  {{did-insert (perform this.questionTask)}}
   {{did-update (perform this.questionTask) @form}}
 >
   <div class="uk-text-center uk-margin">
@@ -80,8 +81,6 @@
           @onRemoveQuestion={{perform this.removeQuestion}}
           @onAddQuestion={{perform this.addQuestion}}
           @onClickForm={{@onClickForm}}
-          @onRegister={{this.registerChild}}
-          @onUnregister={{this.unregisterChild}}
         />
       {{else}}
         <li

--- a/packages/form-builder/addon/components/cfb-form-editor/question-list.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list.hbs
@@ -1,9 +1,4 @@
-<div
-  ...attributes
-  {{on "moved" this._handleMoved}}
-  {{did-insert (perform this.questionTask)}}
-  {{did-update (perform this.questionTask) @form}}
->
+<div ...attributes {{on "moved" this._handleMoved}}>
   <div class="uk-text-center uk-margin">
     {{#if (includes this.mode (array "remove" "add"))}}
       <button
@@ -69,10 +64,10 @@
         </a>
       </li>
     {{/if}}
-    {{#if this.questionTask.isRunning}}
+    {{#if this.questions.isRunning}}
       <li class="uk-text-center"><UkSpinner @ratio={{1.5}} /></li>
     {{else}}
-      {{#each this.questions key="node.slug" as |item|}}
+      {{#each this.questions.value key="node.slug" as |item|}}
         <CfbFormEditor::QuestionList::Item
           data-test-question-list-item={{item.node.slug}}
           @mode={{this.mode}}
@@ -100,7 +95,7 @@
       {{#if (and this.hasNextPage (eq this.mode "add"))}}
         <li class="uk-text-center cfb-pointer"><a
             href="#"
-            {{on "click" (perform this.questionTask)}}
+            {{on "click" this.loadMore}}
           >{{t "caluma.form-builder.question.loadMore"}}</a></li>
       {{/if}}
     {{/if}}

--- a/packages/form-builder/addon/components/cfb-form-editor/question-list.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list.hbs
@@ -41,7 +41,7 @@
         placeholder="{{t 'caluma.form-builder.global.search'}}..."
         aria-label="{{t 'caluma.form-builder.global.search'}}"
         value={{this.search}}
-        {{on "input" (fn (mut this.search))}}
+        {{on "input" (perform this.searchTask)}}
       />
     </div>
   {{/if}}

--- a/packages/form-builder/addon/components/cfb-form-editor/question-list.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list.js
@@ -5,6 +5,7 @@ import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { queryManager } from "ember-apollo-client";
 import { timeout, task } from "ember-concurrency";
+import { trackedTask } from "reactiveweb/ember-concurrency";
 
 import addFormQuestionMutation from "@projectcaluma/ember-form-builder/gql/mutations/add-form-question.graphql";
 import removeFormQuestionMutation from "@projectcaluma/ember-form-builder/gql/mutations/remove-form-question.graphql";
@@ -22,13 +23,9 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
   @tracked mode = this.args.mode || "reorder";
   @tracked cursor = null;
   @tracked hasNextPage = true;
-  @tracked items = [];
 
-  get questions() {
-    return this.mode === "add"
-      ? this.questionTaskValue
-      : this.questionTaskValue[0]?.node.questions.edges;
-  }
+  nextCursor = null;
+  items = [];
 
   // Use built in input component when it works instead of this getter and setter
   get search() {
@@ -37,18 +34,10 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
   set search(event) {
     this._search = event.target.value;
     this._resetParameters();
-    this.questionTask.perform();
   }
 
-  get questionTaskValue() {
-    return this.questionTask.lastSuccessful?.value ?? [];
-  }
-
-  questionTask = task({ restartable: true }, async (event) => {
-    event?.preventDefault?.();
-
-    const mode = this.mode;
-    const search = mode !== "reorder" ? this.search : "";
+  questionTask = task({ restartable: true }, async (mode, input, cursor) => {
+    const search = mode !== "reorder" ? input : "";
 
     /* istanbul ignore next */
     if (macroCondition(isTesting())) {
@@ -59,7 +48,7 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
       }
     }
 
-    if (mode === "add" && this.hasNextPage) {
+    if (mode === "add") {
       const questions = await this.apollo.watchQuery(
         {
           query: searchQuestionQuery,
@@ -67,14 +56,14 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
             search,
             excludeForms: [this.args.form],
             pageSize: 20,
-            cursor: this.cursor,
+            cursor,
           },
           fetchPolicy: "network-only",
         },
         "allQuestions",
       );
 
-      this.cursor = questions.pageInfo.endCursor;
+      this.nextCursor = questions.pageInfo.endCursor;
       this.hasNextPage = questions.pageInfo.hasNextPage;
 
       this.items = [...this.items, ...questions.edges];
@@ -91,9 +80,15 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
         },
         fetchPolicy: "cache-and-network",
       },
-      "allForms.edges",
+      "allForms.edges.0.node.questions.edges",
     );
   });
+
+  questions = trackedTask(this, this.questionTask, () => [
+    this.mode,
+    this.search,
+    this.cursor,
+  ]);
 
   reorderQuestions = task({ restartable: true }, async (slugs) => {
     try {
@@ -143,8 +138,6 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
 
       this._resetParameters();
 
-      this.questionTask.perform();
-
       this.args.onAfterAddQuestion?.(question);
     } catch {
       this.notification.danger(
@@ -193,20 +186,19 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
   }
 
   @action
+  loadMore(e) {
+    e.preventDefault();
+
+    this.cursor = this.nextCursor;
+  }
+
+  @action
   setMode(mode) {
     this.mode = mode;
 
     if (mode === "add") {
       this._resetParameters();
     }
-
-    this.questionTask.perform();
-  }
-
-  @action
-  performSearch() {
-    this._resetParameters();
-    this.questionTask.perform();
   }
 
   @action

--- a/packages/form-builder/addon/components/cfb-form-editor/question-list.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list.js
@@ -19,7 +19,7 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
 
   @queryManager apollo;
 
-  @tracked _search = "";
+  @tracked search = "";
   @tracked mode = this.args.mode || "reorder";
   @tracked cursor = null;
   @tracked hasNextPage = true;
@@ -27,26 +27,20 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
   nextCursor = null;
   items = [];
 
-  // Use built in input component when it works instead of this getter and setter
-  get search() {
-    return this._search;
-  }
-  set search(event) {
-    this._search = event.target.value;
-    this._resetParameters();
-  }
-
-  questionTask = task({ restartable: true }, async (mode, input, cursor) => {
-    const search = mode !== "reorder" ? input : "";
-
+  searchTask = task({ restartable: true }, async (event) => {
     /* istanbul ignore next */
     if (macroCondition(isTesting())) {
       // no timeout
     } else {
-      if (search) {
-        await timeout(500);
-      }
+      await timeout(500);
     }
+
+    this.search = event.target.value;
+    this._resetParameters();
+  });
+
+  questionTask = task({ restartable: true }, async (mode, input, cursor) => {
+    const search = mode !== "reorder" ? input : "";
 
     if (mode === "add") {
       const questions = await this.apollo.watchQuery(

--- a/packages/form-builder/addon/components/cfb-form-editor/question-list.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list.js
@@ -1,12 +1,10 @@
 import { action } from "@ember/object";
-import { run } from "@ember/runloop";
 import { inject as service } from "@ember/service";
 import { macroCondition, isTesting } from "@embroider/macros";
 import Component from "@glimmer/component";
 import { tracked } from "@glimmer/tracking";
 import { queryManager } from "ember-apollo-client";
 import { timeout, task } from "ember-concurrency";
-import UIkit from "uikit";
 
 import addFormQuestionMutation from "@projectcaluma/ember-form-builder/gql/mutations/add-form-question.graphql";
 import removeFormQuestionMutation from "@projectcaluma/ember-form-builder/gql/mutations/remove-form-question.graphql";
@@ -22,7 +20,6 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
 
   @tracked _search = "";
   @tracked mode = this.args.mode || "reorder";
-  @tracked _children = [];
   @tracked cursor = null;
   @tracked hasNextPage = true;
   @tracked items = [];
@@ -185,35 +182,14 @@ export default class ComponentsCfbFormEditorQuestionList extends Component {
     }
   });
 
-  _handleMoved({ detail: [sortable] }) {
-    const children = [...sortable.$el.children];
-
-    this.reorderQuestions.perform(
-      children.map((child) => this._children[child.id]),
-    );
-  }
+  _handleMoved = ({ detail: [sortable] }) => {
+    this.reorderQuestions.perform(sortable.items.map((item) => item.id));
+  };
 
   _resetParameters() {
     this.cursor = null;
     this.hasNextPage = true;
     this.items = [];
-  }
-
-  @action
-  setupUIkit() {
-    UIkit.util.on("#question-list", "moved", (...args) =>
-      run(this, this._handleMoved, ...args),
-    );
-  }
-
-  @action
-  registerChild(elementId, slug) {
-    this._children[elementId] = slug;
-  }
-
-  @action
-  unregisterChild(elementId) {
-    this._children[elementId] = undefined;
   }
 
   @action

--- a/packages/form-builder/addon/components/cfb-form-editor/question-list/item.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list/item.hbs
@@ -1,11 +1,9 @@
 <li
-  id={{this.elementId}}
+  id={{@question.slug}}
   class={{if
     @question.isArchived
     "cfb-form-editor__question-list__item__archived"
   }}
-  {{did-insert (fn (optional @onRegister) this.elementId @question.slug)}}
-  {{will-destroy (fn (optional @onUnregister) this.elementId @question.slug)}}
   ...attributes
 >
   <div class="uk-flex uk-flex-middle">

--- a/packages/form-builder/addon/components/cfb-form-editor/question-list/item.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question-list/item.js
@@ -1,5 +1,4 @@
 import { action } from "@ember/object";
-import { guidFor } from "@ember/object/internals";
 import { service } from "@ember/service";
 import Component from "@glimmer/component";
 
@@ -9,10 +8,6 @@ const cleanJexl = (expr) => expr.replace(/\s/g, "");
 
 export default class CfbFormEditorQuestionListItem extends Component {
   @service router;
-
-  get elementId() {
-    return guidFor(this);
-  }
 
   get required() {
     return this.requiredType !== "not-required";

--- a/packages/form-builder/addon/components/cfb-form-editor/question.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question.hbs
@@ -6,7 +6,7 @@
   {{else if this.changeset}}
     <ValidatedForm
       @model={{this.changeset}}
-      @on-submit={{perform this.submit}}
+      @on-submit={{this.submit.perform}}
       as |f|
     >
       {{#if (and f.model.isDirty @slug)}}

--- a/packages/form-builder/addon/components/cfb-form-editor/question/options.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question/options.hbs
@@ -17,17 +17,17 @@
         @updateLabel={{this.updateLabel}}
       />
     {{/each}}
-    <li class="uk-text-center">
-      <button
-        data-test-add-row
-        type="button"
-        class="uk-icon-button"
-        uk-icon="plus"
-        {{on "click" this.addRow}}
-      >
-      </button>
-    </li>
   </UkSortable>
+  <div class="uk-text-center uk-margin-small-top">
+    <button
+      data-test-add-row
+      type="button"
+      class="uk-icon-button"
+      uk-icon="plus"
+      {{on "click" this.addRow}}
+    >
+    </button>
+  </div>
 
   <@hintComponent />
   <@errorComponent />

--- a/packages/form-builder/addon/components/cfb-form-editor/question/options.js
+++ b/packages/form-builder/addon/components/cfb-form-editor/question/options.js
@@ -99,11 +99,10 @@ export default class CfbFormEditorQuestionOptions extends Component {
 
   @action
   _handleMoved({ detail: [sortable] }) {
-    // Remove last element as it is the add row button
-    const options = [...sortable.$el.children].slice(0, -1);
-
     this.reorderOptions.perform(
-      options.map((option) => option.firstElementChild.firstElementChild.id),
+      sortable.items.map(
+        (option) => option.firstElementChild.firstElementChild.id,
+      ),
     );
   }
 }

--- a/packages/form-builder/addon/components/cfb-form-editor/question/validation.hbs
+++ b/packages/form-builder/addon/components/cfb-form-editor/question/validation.hbs
@@ -2,7 +2,8 @@
   <@labelComponent />
 
   <div class="uk-form-controls">
-    <PowerSelectMultiple
+    <PowerSelect
+      @multiple={{true}}
       @selected={{this.selected}}
       @placeholder={{@placeholder}}
       @options={{this.validators}}
@@ -12,7 +13,7 @@
       as |item|
     >
       {{item.name}}
-    </PowerSelectMultiple>
+    </PowerSelect>
   </div>
 
   <@hintComponent />

--- a/packages/form-builder/addon/components/cfb-form-list.hbs
+++ b/packages/form-builder/addon/components/cfb-form-list.hbs
@@ -27,7 +27,7 @@
     placeholder="{{t 'caluma.form-builder.global.search'}}..."
     aria-label="{{t 'caluma.form-builder.global.search'}}"
     value={{@search}}
-    {{on "input" (perform this.search)}}
+    {{on "input" this.search.perform}}
   />
 </div>
 

--- a/packages/form-builder/tests/acceptance/question-reorder-test.js
+++ b/packages/form-builder/tests/acceptance/question-reorder-test.js
@@ -27,7 +27,7 @@ module("Acceptance | question reorder", function (hooks) {
     const item = await find("[data-test-question-list-item=test]");
 
     // create a new array of children in which the chosen item is first instead of last
-    const children = [
+    const items = [
       item,
       ...[...list.children].filter(
         (c) => c.dataset.testQuestionListItem !== "test",
@@ -37,9 +37,7 @@ module("Acceptance | question reorder", function (hooks) {
     await triggerEvent(list, "moved", {
       detail: [
         {
-          $el: {
-            children,
-          },
+          items,
         },
       ],
     });

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question-list-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question-list-test.js
@@ -125,7 +125,7 @@ module(
       const item = await find("[data-test-question-list-item=test]");
 
       // create a new array of children in which the chosen item is first instead of last
-      const children = [
+      const items = [
         item,
         ...[...list.children].filter(
           (c) => c.dataset.testQuestionListItem !== "test",
@@ -135,9 +135,7 @@ module(
       await triggerEvent(list, "moved", {
         detail: [
           {
-            $el: {
-              children,
-            },
+            items,
           },
         ],
       });
@@ -197,9 +195,7 @@ module(
       await triggerEvent("[data-test-question-list]", "moved", {
         detail: [
           {
-            $el: {
-              children: [],
-            },
+            items: [],
           },
         ],
       });

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question-list-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question-list-test.js
@@ -155,9 +155,10 @@ module(
 
       assert.dom("[data-test-question-list-item=test]").exists();
       await click("[data-test-question-list-item=test] [data-test-add-item]");
-      assert.dom("[data-test-question-list-item=test]").doesNotExist();
       await click("[data-test-cancel]");
       assert.dom("[data-test-question-list-item=test]").exists();
+      await click("[data-test-add-question]");
+      assert.dom("[data-test-question-list-item=test]").doesNotExist();
     });
 
     test("it can remove questions", async function (assert) {

--- a/packages/form-builder/tests/integration/components/cfb-form-editor/question/options-test.js
+++ b/packages/form-builder/tests/integration/components/cfb-form-editor/question/options-test.js
@@ -49,7 +49,7 @@ module(
       );
 
       // one is the add row
-      assert.dom("li").exists({ count: 3 });
+      assert.dom("li").exists({ count: 2 });
       assert.dom("input[name=option-1-label]").hasValue("Option 1");
       assert.dom("input[name=option-1-slug]").hasValue("option-1"); // This must trim the prefix!
     });
@@ -71,11 +71,11 @@ module(
         { owner: this.engine },
       );
 
-      assert.dom("li").exists({ count: 2 });
+      assert.dom("li").exists({ count: 1 });
 
       await click("[data-test-add-row]");
 
-      assert.dom("li").exists({ count: 3 });
+      assert.dom("li").exists({ count: 2 });
     });
 
     test("it can delete unsaved row", async function (assert) {
@@ -96,12 +96,12 @@ module(
         { owner: this.engine },
       );
 
-      assert.dom("li").exists({ count: 3 });
+      assert.dom("li").exists({ count: 2 });
 
       await click("[data-test-add-row]");
       await click("[data-test-row=option-3] [data-test-delete-row]");
 
-      assert.dom("li").exists({ count: 3 });
+      assert.dom("li").exists({ count: 2 });
       assert.dom("[data-test-row=option-3]").doesNotExist();
     });
 

--- a/packages/form/addon/components/cf-field.hbs
+++ b/packages/form/addon/components/cf-field.hbs
@@ -34,7 +34,7 @@
               @field={{@field}}
               @disabled={{or @disabled @field.refreshAnswer.isRunning}}
               @context={{@context}}
-              @onSave={{perform this.save}}
+              @onSave={{this.save.perform}}
             />
           {{/let}}
         {{/if}}

--- a/packages/form/addon/components/cf-field/input-compare.hbs
+++ b/packages/form/addon/components/cf-field/input-compare.hbs
@@ -4,7 +4,7 @@
     field=@field
     disabled=true
     context=@context
-    onSave=(perform this.save)
+    onSave=this.save.perform
   )
   as |FieldComponent|
 }}

--- a/packages/form/addon/components/cf-field/input/powerselect.hbs
+++ b/packages/form/addon/components/cf-field/input/powerselect.hbs
@@ -1,4 +1,5 @@
 <this.selectComponent
+  @multiple={{this.multiple}}
   @options={{@field.options}}
   @selected={{this.selected}}
   @disabled={{@disabled}}

--- a/packages/form/addon/components/cf-field/input/powerselect.js
+++ b/packages/form/addon/components/cf-field/input/powerselect.js
@@ -3,7 +3,6 @@ import { inject as service } from "@ember/service";
 import { ensureSafeComponent } from "@embroider/util";
 import Component from "@glimmer/component";
 import PowerSelectComponent from "ember-power-select/components/power-select";
-import PowerSelectMultipleComponent from "ember-power-select/components/power-select-multiple";
 
 import getConfig from "@projectcaluma/ember-core/utils/get-config";
 
@@ -33,10 +32,7 @@ export default class CfFieldInputPowerselectComponent extends Component {
   }
 
   get selectComponent() {
-    return ensureSafeComponent(
-      this.multiple ? PowerSelectMultipleComponent : PowerSelectComponent,
-      this,
-    );
+    return ensureSafeComponent(PowerSelectComponent, this);
   }
 
   get searchEnabled() {

--- a/packages/form/addon/components/cf-field/input/table.hbs
+++ b/packages/form/addon/components/cf-field/input/table.hbs
@@ -79,7 +79,7 @@
               </UkButton>
               <UkButton
                 @color="link"
-                @onClick={{fn (perform this.delete) document}}
+                @onClick={{fn this.delete.perform document}}
                 title={{t "caluma.form.delete"}}
                 class="uk-flex-inline uk-margin-small-left table-controls"
                 data-test-delete-row
@@ -99,7 +99,7 @@
         <td colspan={{add this.columns.length 1}} class="uk-text-center">
           <UkButton
             @color="link"
-            @onClick={{perform this.add}}
+            @onClick={{this.add.perform}}
             title={{t "caluma.form.addRow"}}
             data-test-add-row
           >
@@ -115,7 +115,7 @@
 {{#if this.documentToEdit}}
   <UkModal
     @visible={{this.showAddModal}}
-    @onHide={{perform this.close}}
+    @onHide={{this.close.perform}}
     @bgClose={{false}}
     as |modal|
   >
@@ -134,7 +134,7 @@
         <UkButton
           @label={{t "caluma.form.close"}}
           @color="primary"
-          @onClick={{perform this.close}}
+          @onClick={{this.close.perform}}
           @disabled={{this.close.isRunning}}
           @loading={{this.close.isRunning}}
           data-test-close
@@ -142,7 +142,7 @@
       {{else}}
         <UkButton
           @label={{t "caluma.form.cancel"}}
-          @onClick={{perform this.close}}
+          @onClick={{this.close.perform}}
           @disabled={{this.close.isRunning}}
           @loading={{this.close.isRunning}}
           data-test-cancel
@@ -158,7 +158,7 @@
             @type="submit"
             @disabled={{or this.save.isRunning (not isValid)}}
             @loading={{this.save.isRunning}}
-            @onClick={{fn (perform this.save) validate}}
+            @onClick={{fn this.save.perform validate}}
             data-test-save
           />
         </DocumentValidity>

--- a/packages/workflow/addon/components/work-item-button.hbs
+++ b/packages/workflow/addon/components/work-item-button.hbs
@@ -7,7 +7,7 @@
   @color={{or @color "default"}}
   @size={{@size}}
   @title={{@title}}
-  @onClick={{perform this.mutate}}
+  @onClick={{this.mutate.perform}}
 >
   {{#if (has-block)}}
     {{yield}}


### PR DESCRIPTION
## Description

This cleans up some of the implementations of `question-list` and fixes a reordering bug in `options`

## Dependencies

Does this PR depend on other PRs of the `ember-caluma` or `caluma` repository? No