### PR TITLE
Improve JEXL context

### DIFF
--- a/packages/form/addon/gql/fragments/case-form-and-workflow.graphql
+++ b/packages/form/addon/gql/fragments/case-form-and-workflow.graphql
@@ -1,5 +1,6 @@
 fragment CaseFormAndWorkflow on Case {
   id
+  meta
   workflow {
     id
     slug
@@ -13,6 +14,7 @@ fragment CaseFormAndWorkflow on Case {
   }
   family {
     id
+    meta
     workflow {
       id
       slug

--- a/packages/form/addon/gql/queries/document-answers.graphql
+++ b/packages/form/addon/gql/queries/document-answers.graphql
@@ -12,6 +12,10 @@ query DocumentAnswers($id: ID!) {
         }
         workItem {
           id
+          meta
+          task {
+            slug
+          }
           case {
             ...CaseFormAndWorkflow
           }

--- a/packages/form/addon/lib/document.js
+++ b/packages/form/addon/lib/document.js
@@ -244,14 +244,18 @@ export default class Document extends Base {
             form: this.rootForm.slug,
             formMeta: this.rootForm.raw.meta,
           },
-          case: {
-            form: _case?.document?.form.slug,
-            workflow: _case?.workflow.slug,
-            root: {
-              form: _case?.family.document?.form.slug,
-              workflow: _case?.family.workflow.slug,
-            },
-          },
+          case: _case
+            ? {
+                form: _case.document?.form.slug,
+                workflow: _case.workflow.slug,
+                meta: _case.meta,
+                root: {
+                  form: _case.family.document?.form.slug,
+                  workflow: _case.family.workflow.slug,
+                  meta: _case.family.meta,
+                },
+              }
+            : null,
         },
       }
     );

--- a/packages/form/addon/lib/document.js
+++ b/packages/form/addon/lib/document.js
@@ -232,7 +232,9 @@ export default class Document extends Base {
    * @property {Object} jexlContext
    */
   get jexlContext() {
-    const _case = this.raw.workItem?.case ?? this.raw.case;
+    const workItem = this.raw.workItem;
+    const _case = workItem?.case ?? this.raw.case;
+
     return (
       this.parentDocument?.jexlContext ?? {
         // JEXL interprets null in an expression as variable instead of a
@@ -254,6 +256,12 @@ export default class Document extends Base {
                   workflow: _case.family.workflow.slug,
                   meta: _case.family.meta,
                 },
+              }
+            : null,
+          workItem: workItem
+            ? {
+                task: workItem.task.slug,
+                meta: workItem.meta,
               }
             : null,
         },

--- a/packages/form/addon/lib/field.js
+++ b/packages/form/addon/lib/field.js
@@ -554,13 +554,17 @@ export default class Field extends Base {
    * - `info.formMeta`: The meta of the form this question is attached to.
    * - `info.parent.form`: The parent form if applicable.
    * - `info.parent.formMeta`: The parent form meta if applicable.
-   * - `info.parent.question`: The parent field question if applicable.
+   * - `info.parent.question`: The parent question (table or form question)
    * - `info.root.form`: The new property for the root form.
    * - `info.root.formMeta`: The new property for the root form meta.
    * - `info.case.form`: The cases' form (works for task forms and case forms).
    * - `info.case.workflow`: The cases' workflow (works for task forms and case forms).
+   * - `info.case.meta`: The cases' meta (works for task forms and case forms).
    * - `info.case.root.form`: The _root_ cases' form (works for task forms and case forms).
    * - `info.case.root.workflow`: The _root_ cases' workflow (works for task forms and case forms).
+   * - `info.case.root.meta`: The _root_ cases' meta (works for task forms and case forms).
+   * - `info.workItem.task`: The task slug of the work item
+   * - `info.workItem.meta`: The meta of the work item
    *
    * @property {Object} jexlContext
    */

--- a/packages/form/tests/unit/lib/data.js
+++ b/packages/form/tests/unit/lib/data.js
@@ -160,6 +160,7 @@ const form = {
 
 const _case = {
   id: id("Case"),
+  meta: { "is-main-case": false },
   workflow: {
     id: id("Workflow", "child-case-workflow"),
     slug: "child-case-workflow",
@@ -173,6 +174,7 @@ const _case = {
   },
   family: {
     id: id("Case"),
+    meta: { "is-main-case": true },
     workflow: {
       id: id("Workflow", "root-case-workflow"),
       slug: "root-case-workflow",
@@ -522,6 +524,10 @@ const historicalAnswers = {
 
 const workItem = {
   id: id("WorkItem"),
+  meta: { "notify-on-completion": true },
+  task: {
+    slug: "some-task",
+  },
   case: _case,
 };
 

--- a/packages/form/tests/unit/lib/document-test.js
+++ b/packages/form/tests/unit/lib/document-test.js
@@ -297,11 +297,17 @@ module("Unit | Library | document", function (hooks) {
       info: {
         case: {
           form: "child-case-form",
+          meta: { "is-main-case": false },
           root: {
             form: "root-case-form",
             workflow: "root-case-workflow",
+            meta: { "is-main-case": true },
           },
           workflow: "child-case-workflow",
+        },
+        workItem: {
+          meta: { "notify-on-completion": true },
+          task: "some-task",
         },
         root: { form: "form", formMeta: { "is-top-form": true, level: 0 } },
       },
@@ -323,12 +329,15 @@ module("Unit | Library | document", function (hooks) {
       info: {
         case: {
           form: "child-case-form",
+          meta: { "is-main-case": false },
           root: {
             form: "root-case-form",
             workflow: "root-case-workflow",
+            meta: { "is-main-case": true },
           },
           workflow: "child-case-workflow",
         },
+        workItem: null,
         root: { form: "form", formMeta: { "is-top-form": true, level: 0 } },
       },
     });
@@ -348,6 +357,7 @@ module("Unit | Library | document", function (hooks) {
       form: "form",
       info: {
         case: null,
+        workItem: null,
         root: { form: "form", formMeta: { "is-top-form": true, level: 0 } },
       },
     });

--- a/packages/form/tests/unit/lib/document-test.js
+++ b/packages/form/tests/unit/lib/document-test.js
@@ -347,14 +347,7 @@ module("Unit | Library | document", function (hooks) {
       null: null,
       form: "form",
       info: {
-        case: {
-          form: undefined,
-          root: {
-            form: undefined,
-            workflow: undefined,
-          },
-          workflow: undefined,
-        },
+        case: null,
         root: { form: "form", formMeta: { "is-top-form": true, level: 0 } },
       },
     });

--- a/packages/form/tests/unit/lib/field-test.js
+++ b/packages/form/tests/unit/lib/field-test.js
@@ -163,10 +163,18 @@ module("Unit | Library | field", function (hooks) {
         case: {
           form: "child-case-form",
           workflow: "child-case-workflow",
+          meta: { "is-main-case": false },
           root: {
             form: "root-case-form",
             workflow: "root-case-workflow",
+            meta: { "is-main-case": true },
           },
+        },
+        workItem: {
+          meta: {
+            "notify-on-completion": true,
+          },
+          task: "some-task",
         },
       },
     });


### PR DESCRIPTION
### fix(jexl): set info.case to null if the document has no case

The JEXL context always contained a `case` object, even for documents
without a case - all of its properties were simply `undefined`. Checking
for the absence of a case therefore required inspecting a nested
property instead of `info.case` itself.

Only build the object if a case is given and pass `null` otherwise,
which mimics the behaviour of the backend.

### feat(jexl): expose case and work item meta in JEXL context

Add `info.case.meta` and `info.case.root.meta`, and introduce
`info.workItem` with `task` and `meta`.

- [Backend PR](https://github.com/projectcaluma/caluma/pull/2628)
- [Docs PR](https://github.com/projectcaluma/docs/pull/12)