### PR TITLE
feat(form/tables): add row document to table question before editing

### DIFF
--- a/packages/form/addon/components/cf-field/input/table.hbs
+++ b/packages/form/addon/components/cf-field/input/table.hbs
@@ -70,6 +70,7 @@
               <UkButton
                 @color="link"
                 @onClick={{fn this.edit document}}
+                @disabled={{or this.add.isRunning this.delete.isRunning}}
                 title={{t "caluma.form.edit"}}
                 class="uk-flex-inline uk-margin-small-left table-controls"
                 data-test-edit-row
@@ -80,6 +81,7 @@
               <UkButton
                 @color="link"
                 @onClick={{fn this.delete.perform document}}
+                @disabled={{or this.add.isRunning this.delete.isRunning}}
                 title={{t "caluma.form.delete"}}
                 class="uk-flex-inline uk-margin-small-left table-controls"
                 data-test-delete-row
@@ -100,6 +102,8 @@
           <UkButton
             @color="link"
             @onClick={{this.add.perform}}
+            @disabled={{this.add.isRunning}}
+            @loading={{this.add.isRunning}}
             title={{t "caluma.form.addRow"}}
             data-test-add-row
           >
@@ -123,7 +127,7 @@
       <CfFormWrapper
         @document={{this.documentToEdit}}
         @fieldset={{object-at 0 this.documentToEdit.fieldsets}}
-        @disabled={{@disabled}}
+        @disabled={{or @disabled this.add.isRunning}}
         @context={{@context}}
         @compare={{@compare}}
       />
@@ -143,7 +147,7 @@
         <UkButton
           @label={{t "caluma.form.cancel"}}
           @onClick={{this.close.perform}}
-          @disabled={{this.close.isRunning}}
+          @disabled={{or this.close.isRunning this.add.isRunning}}
           @loading={{this.close.isRunning}}
           data-test-cancel
         />

--- a/packages/form/addon/components/cf-field/input/table.js
+++ b/packages/form/addon/components/cf-field/input/table.js
@@ -74,22 +74,68 @@ export default class CfFieldInputTableComponent extends Component {
       owner,
     });
 
+    // Open the modal immediately - attaching the row to the table (below) is
+    // debounced and would otherwise noticeably delay opening the modal. While
+    // this task runs, the row's fields and the cancel button are disabled in
+    // the modal, so no answer can be saved to (and validated by) the backend
+    // and the row cannot be removed again before it is attached to the table.
     this.documentToEditIsNew = true;
     this.documentToEdit = newDocument;
     this.showAddModal = true;
+
+    // Attach the row document to the table answer, so the backend has the
+    // full context to validate and evaluate the row's fields while editing.
+    // `documentToEditIsNew` marks the row as preliminary, so it will be
+    // removed again if the edit dialog is cancelled.
+    try {
+      const rows = this.args.field.answer.value ?? [];
+      await this.args.onSave([...rows, newDocument]);
+    } catch {
+      this.notification.danger(
+        this.intl.t("caluma.form.notification.table.add.error"),
+      );
+
+      // Attaching failed - remove the preliminary row and close the modal.
+      // `close` cannot be performed here, as it waits for this task to finish.
+      await this.deleteRow(this.documentToEdit);
+      this.documentToEditIsNew = false;
+      this.showAddModal = false;
+      this.documentToEdit = null;
+    }
   });
+
+  /**
+   * Delete row without asking. Remove from the table, then remove row document
+   *
+   * @async
+   * @method deleteRow
+   * @param {Document} document The row document to delete
+   * @return {Promise<Void>}
+   */
+  async deleteRow(document) {
+    const remainingDocuments = (this.args.field.answer.value ?? []).filter(
+      (doc) => doc.pk !== document.pk,
+    );
+
+    // remove row from table
+    await this.args.onSave(remainingDocuments);
+
+    // delete row document
+    await this.apollo.mutate({
+      mutation: removeDocumentMutation,
+      variables: { input: { document: document.uuid } },
+    });
+
+    // Remove orphaned document from Caluma store.
+    this.calumaStore.delete(document.pk);
+  }
 
   delete = task({ drop: true }, async (document) => {
     if (!(await confirm(this.intl.t("caluma.form.deleteRow")))) {
       return;
     }
 
-    const remainingDocuments = this.args.field.answer.value.filter(
-      (doc) => doc.pk !== document.pk,
-    );
-
-    await this.args.onSave(remainingDocuments);
-    await this.removeOrphan(document);
+    await this.deleteRow(document);
   });
 
   save = task({ drop: true }, async (validate) => {
@@ -106,18 +152,12 @@ export default class CfFieldInputTableComponent extends Component {
         return;
       }
 
-      const rows = this.args.field.answer.value ?? [];
-
-      if (!rows.find((doc) => doc.pk === newDocument.pk)) {
-        // add document to table
-        await this.args.onSave([...rows, newDocument]);
-
+      if (this.documentToEditIsNew) {
         this.notification.success(
           this.intl.t("caluma.form.notification.table.add.success"),
         );
+        this.documentToEditIsNew = false;
       }
-
-      this.documentToEditIsNew = false;
 
       await this.close.perform();
     } catch {
@@ -128,10 +168,20 @@ export default class CfFieldInputTableComponent extends Component {
   });
 
   close = task({ drop: true }, async () => {
-    if (this.documentToEditIsNew) {
-      await this.removeOrphan(this.documentToEdit);
+    // Wait for a pending "add" to finish attaching the new row to the table
+    // before closing - otherwise removing or validating the row would race
+    // with the debounced save of the table answer.
+    if (this.add.isRunning) {
+      await this.add.last;
+    }
 
+    if (this.documentToEditIsNew) {
+      await this.deleteRow(this.documentToEdit);
       this.documentToEditIsNew = false;
+      this.showAddModal = false;
+      this.documentToEdit = null;
+      // No validation for new documents that are deleted
+      return;
     }
 
     if (!this.args.disabled) {
@@ -141,17 +191,6 @@ export default class CfFieldInputTableComponent extends Component {
     this.showAddModal = false;
     this.documentToEdit = null;
   });
-
-  async removeOrphan(calumaDocument) {
-    // Remove orphaned document from database.
-    await this.apollo.mutate({
-      mutation: removeDocumentMutation,
-      variables: { input: { document: calumaDocument.uuid } },
-    });
-
-    // Remove orphaned document from Caluma store.
-    this.calumaStore.delete(calumaDocument.pk);
-  }
 
   @action
   edit(document) {

--- a/packages/form/tests/integration/components/cf-field/input/table-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/table-test.js
@@ -1,4 +1,11 @@
-import { waitFor, click, fillIn, render, scrollTo } from "@ember/test-helpers";
+import {
+  waitFor,
+  click,
+  fillIn,
+  render,
+  scrollTo,
+  settled,
+} from "@ember/test-helpers";
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { module, test } from "qunit";
@@ -298,6 +305,31 @@ module("Integration | Component | cf-field/input/table", function (hooks) {
       await click("[data-test-save]");
 
       assert.verifySteps(["save"]);
+    });
+
+    test("it disables the row form while the new row is being attached", async function (assert) {
+      let resolveSave;
+      this.save = () => new Promise((resolve) => (resolveSave = resolve));
+
+      await render(
+        hbs`<CfField::Input::Table @field={{this.field}} @onSave={{this.save}} />`,
+      );
+
+      await click("[data-test-add-row]");
+
+      const input = `input[name$=":Question:${this.rowQuestion.slug}"]`;
+      await waitFor(input);
+
+      // The modal opens immediately, but the fields and the cancel button
+      // must be disabled until the row is attached to the table answer.
+      assert.dom(input).hasAttribute("readonly");
+      assert.dom("[data-test-cancel]").isDisabled();
+
+      resolveSave();
+      await settled();
+
+      assert.dom(input).doesNotHaveAttribute("readonly");
+      assert.dom("[data-test-cancel]").isEnabled();
     });
 
     test("it can edit a row", async function (assert) {


### PR DESCRIPTION
## Description

Earlier, we only attached a row document to the table upon "saving". This has the problem that any JEXL expression (calc, option visibility, etc) that relies on a question *outside* of the table is not visible in the backend, leading to inconsistent behaviour.

Now, a table row is attached properly directly after creating the row doc, so the backend has all the context to validate and evaluate the row's fields as the user edits it.

Of course, if we "cancel" editing, this now requires two operations as well.

## Dependencies

Not a strict dependency, but this goes along with the following backend change:

https://github.com/projectcaluma/caluma/pull/2633
