### PR TITLE
feat(distribution): build the global JEXL context for new inquiries

### DIFF
--- a/packages/core/addon/services/caluma-options.js
+++ b/packages/core/addon/services/caluma-options.js
@@ -116,6 +116,28 @@ export default class CalumaOptionsService extends Service {
     return DateTime.now().plus({ days: defaultLeadTime }).toISODate();
   }
 
+  /**
+   * The meta of the work item a new distribution inquiry will be created on.
+   *
+   * The inquiry work item doesn't exist yet while its form is being filled out,
+   * so its meta can't be fetched from the backend. It is part of the JEXL
+   * context though (`info.workItem.meta`), so expressions on the inquiry form
+   * may depend on it.
+   *
+   * This may be overwritten by the host app if it creates inquiry work items
+   * with a meta. It must match what the backend will store on the work item,
+   * otherwise expressions evaluate differently before and after creation.
+   *
+   * @async
+   * @method distributionInquiryWorkItemMeta
+   * @param {Array<String>} selectedGroups
+   * @returns {Promise<Object>} The meta of the inquiry work item to be created
+   */
+  // eslint-disable-next-line no-unused-vars
+  async distributionInquiryWorkItemMeta(selectedGroups) {
+    return {};
+  }
+
   groupIdentifierProperty = "id";
   groupNameProperty = "name";
   resolveGroups(identifiers) {

--- a/packages/distribution/addon/components/cd-inquiry-new-form/bulk-edit.js
+++ b/packages/distribution/addon/components/cd-inquiry-new-form/bulk-edit.js
@@ -24,6 +24,50 @@ export default class CdInquiryNewFormBulkEditComponent extends Component {
 
   answers = {};
 
+  /**
+   * Build the global JEXL context of the inquiry document.
+   *
+   * Neither the document nor its work item exist in the backend while the form
+   * is being filled out, so `documentGlobalJexlContext` can't be used here. The
+   * case comes from the controls query, the work item is the one
+   * `createInquiry` is about to create.
+   *
+   * @async
+   * @private
+   * @method #buildJexlContext
+   * @returns {Promise<Object>} The "faked" JEXL context for the bulk edit form
+   */
+  async #buildJexlContext() {
+    await this.distribution.controls;
+
+    const _case = this.distribution.controls.value?.case.edges[0]?.node;
+    // A case without a family is its own root, same as in the backend
+    const root = _case?.family ?? _case;
+
+    return {
+      info: {
+        case: _case
+          ? {
+              form: _case.document?.form.slug ?? null,
+              workflow: _case.workflow.slug,
+              meta: _case.meta,
+              root: {
+                form: root.document?.form.slug ?? null,
+                workflow: root.workflow.slug,
+                meta: root.meta,
+              },
+            }
+          : null,
+        workItem: {
+          task: this.config.inquiry.task,
+          meta: await this.calumaOptions.distributionInquiryWorkItemMeta(
+            this.args.selectedGroups,
+          ),
+        },
+      },
+    };
+  }
+
   document = trackedFunction(this, async () => {
     // Fetch the full form (like in cf-content) of the inquiry task
     const response = await this.apollo.query({
@@ -34,6 +78,7 @@ export default class CdInquiryNewFormBulkEditComponent extends Component {
     });
     const form = response.allTasks.edges[0].node.form;
     const answers = { edges: [] };
+    const jexlContext = await this.#buildJexlContext();
 
     // If we configured a default deadline lead time, we need to calculate the
     // deadline that should be displayed in the form per default and add it to
@@ -69,6 +114,7 @@ export default class CdInquiryNewFormBulkEditComponent extends Component {
       __typename: "Document",
       answers,
       form,
+      jexlContext,
     });
 
     const owner = getOwner(this);

--- a/packages/distribution/addon/gql/queries/controls.graphql
+++ b/packages/distribution/addon/gql/queries/controls.graphql
@@ -76,6 +76,37 @@ query Controls(
           isRedoable
           addressedGroups
         }
+        # A new inquiry document doesn't exist in the backend yet, so its
+        # global JEXL context can't be fetched via `documentGlobalJexlContext`
+        # and has to be assembled from the case.
+        # See `#buildJexlContext` in `cd-inquiry-new-form/bulk-edit.js`
+        meta
+        workflow {
+          id
+          slug
+        }
+        document {
+          id
+          form {
+            id
+            slug
+          }
+        }
+        family {
+          id
+          meta
+          workflow {
+            id
+            slug
+          }
+          document {
+            id
+            form {
+              id
+              slug
+            }
+          }
+        }
       }
     }
   }

--- a/packages/distribution/tests/integration/components/cd-inquiry-new-form-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-new-form-test.js
@@ -18,13 +18,30 @@ module("Integration | Component | cd-inquiry-new-form", function (hooks) {
   hooks.beforeEach(async function () {
     createBlueprint(this.server);
 
+    // Only visible if the work item meta the host app provides makes it into
+    // the global JEXL context of the inquiry document. That document doesn't
+    // exist in the backend yet, so the context can't be fetched from there.
+    // See `#buildJexlContext` in `bulk-edit.js`
+    this.server.create("question", {
+      slug: "inquiry-context-check",
+      label: "Context check",
+      isRequired: "false",
+      isHidden: "info.workItem.meta.test != true",
+      maxLength: 9999,
+      minLength: 0,
+      formIds: ["inquiry"],
+      type: "TEXTAREA",
+    });
+
     this.case = createCase(this.server, { group: { id: "1" } });
 
     this.selectedTypes = ["a"];
     this.search = "";
 
-    this.owner.lookup("service:caluma-options").currentGroupId = 1;
-    this.owner.lookup("service:caluma-options").distribution = {
+    const options = this.owner.lookup("service:caluma-options");
+
+    options.currentGroupId = 1;
+    options.distribution = {
       new: {
         types: {
           suggestions: {
@@ -37,10 +54,7 @@ module("Integration | Component | cd-inquiry-new-form", function (hooks) {
         },
       },
     };
-    this.owner.lookup("service:caluma-options").fetchTypedGroups = (
-      types,
-      search,
-    ) => {
+    options.fetchTypedGroups = (types, search) => {
       const re = new RegExp(`.*${search}.*`, "i");
 
       const records = {
@@ -63,6 +77,7 @@ module("Integration | Component | cd-inquiry-new-form", function (hooks) {
         return { ...retval, [type]: recs.filter((rec) => re.test(rec.name)) };
       }, {});
     };
+    options.distributionInquiryWorkItemMeta = () => ({ test: true });
 
     const distribution = this.engine.lookup("service:distribution");
 
@@ -153,6 +168,9 @@ module("Integration | Component | cd-inquiry-new-form", function (hooks) {
     assert
       .dom(`[name$="Question:inquiry-deadline"] + input`)
       .hasValue(expectedDeadline);
+    assert
+      .dom(`[name$="Question:inquiry-context-check"]`)
+      .exists("question depending on the work item meta is visible");
 
     await fillIn('[name$="Question:inquiry-remark"]', "My remark");
     await setFlatpickrDate(

--- a/packages/testing/addon/scenarios/distribution.js
+++ b/packages/testing/addon/scenarios/distribution.js
@@ -246,7 +246,7 @@ export function createCase(server, { group }) {
   const distributionWorkItem = server.create("work-item", {
     taskId: "distribution",
     status: "READY",
-    case: server.create("case"),
+    case: server.create("case", { workflowId: "distribution" }),
   });
 
   const distributionCase = server.create("case", {


### PR DESCRIPTION
## Description

Documents are evaluated against the global JEXL context the backend delivers, but the bulk edit form has no document to ask one for - it constructs a throwaway document to render the inquiry form of an inquiry that doesn't exist yet. Expressions on that form would see neither the case nor the work item.

So we assemble the context ourselves, for this one case. The case comes from the controls query, extended with the fields it needs. The work item is the one `createInquiry` is about to create: its task is configured, and its meta - the one thing we can't know here - comes from `distributionInquiryWorkItemMeta` on the caluma options service, which
the host app can implement if it creates inquiries with a meta. What comes out has to match what the backend will return once the inquiry exists, otherwise expressions change under the user on save.

## Dependencies

Depends on #3073
