### PR TITLE
fix(form/tables): don't validate row document when adding

### DIFF
--- a/packages/form/addon/components/cf-field/input/table.js
+++ b/packages/form/addon/components/cf-field/input/table.js
@@ -89,7 +89,8 @@ export default class CfFieldInputTableComponent extends Component {
     // removed again if the edit dialog is cancelled.
     try {
       const rows = this.args.field.answer.value ?? [];
-      await this.args.onSave([...rows, newDocument]);
+      this.args.field.answer.value = [...rows, newDocument];
+      await this.args.field.save.perform();
     } catch {
       this.notification.danger(
         this.intl.t("caluma.form.notification.table.add.error"),

--- a/packages/form/tests/integration/components/cf-field/input/table-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/table-test.js
@@ -9,6 +9,7 @@ import {
 import { hbs } from "ember-cli-htmlbars";
 import { setupMirage } from "ember-cli-mirage/test-support";
 import { module, test } from "qunit";
+import { fake, replace } from "sinon";
 import UIkit from "uikit";
 
 import { parseDocument } from "@projectcaluma/ember-form/lib/parsers";
@@ -281,10 +282,15 @@ module("Integration | Component | cf-field/input/table", function (hooks) {
     test("it can add a row", async function (assert) {
       assert.expect(5);
 
-      this.save = (value) => {
-        assert.strictEqual(value.length, 2);
-        assert.step("save");
-      };
+      this.save = () => {};
+      replace(
+        this.field.save,
+        "perform",
+        fake(() => {
+          assert.strictEqual(this.field.answer.value.length, 2);
+          assert.step("raw-save");
+        }),
+      );
 
       await render(
         hbs`<CfField::Input::Table @field={{this.field}} @onSave={{this.save}} />`,
@@ -304,12 +310,18 @@ module("Integration | Component | cf-field/input/table", function (hooks) {
 
       await click("[data-test-save]");
 
-      assert.verifySteps(["save"]);
+      assert.verifySteps(["raw-save"]);
     });
 
     test("it disables the row form while the new row is being attached", async function (assert) {
       let resolveSave;
-      this.save = () => new Promise((resolve) => (resolveSave = resolve));
+
+      this.save = () => {};
+      replace(
+        this.field.save,
+        "perform",
+        fake(() => new Promise((resolve) => (resolveSave = resolve))),
+      );
 
       await render(
         hbs`<CfField::Input::Table @field={{this.field}} @onSave={{this.save}} />`,


### PR DESCRIPTION
The `onSave` UI action will immediately validate the respective row document. Since we just added it and it's empty, this will fail, as soon as the row form has a required question (which it always should). In order to prevent that, we use the private save task of the field itself directly.