### PR TITLE
fix(table): don't show form while the row doc is being attached

### DIFF
--- a/packages/form/addon/components/cf-field/input/table.hbs
+++ b/packages/form/addon/components/cf-field/input/table.hbs
@@ -124,13 +124,19 @@
     as |modal|
   >
     <modal.body>
-      <CfFormWrapper
-        @document={{this.documentToEdit}}
-        @fieldset={{object-at 0 this.documentToEdit.fieldsets}}
-        @disabled={{or @disabled this.add.isRunning}}
-        @context={{@context}}
-        @compare={{@compare}}
-      />
+      {{#if this.add.isRunning}}
+        <div class="uk-text-center">
+          <UkSpinner class="uk-animation-fade" @ratio={{2}} />
+        </div>
+      {{else}}
+        <CfFormWrapper
+          @document={{this.documentToEdit}}
+          @fieldset={{object-at 0 this.documentToEdit.fieldsets}}
+          @disabled={{@disabled}}
+          @context={{@context}}
+          @compare={{@compare}}
+        />
+      {{/if}}
     </modal.body>
 
     <modal.footer class="uk-text-right">

--- a/packages/form/tests/integration/components/cf-field/input/table-test.js
+++ b/packages/form/tests/integration/components/cf-field/input/table-test.js
@@ -313,7 +313,7 @@ module("Integration | Component | cf-field/input/table", function (hooks) {
       assert.verifySteps(["raw-save"]);
     });
 
-    test("it disables the row form while the new row is being attached", async function (assert) {
+    test("it shows a spinner instead of the row form while the new row is being attached", async function (assert) {
       let resolveSave;
 
       this.save = () => {};
@@ -330,16 +330,18 @@ module("Integration | Component | cf-field/input/table", function (hooks) {
       await click("[data-test-add-row]");
 
       const input = `input[name$=":Question:${this.rowQuestion.slug}"]`;
-      await waitFor(input);
 
-      // The modal opens immediately, but the fields and the cancel button
-      // must be disabled until the row is attached to the table answer.
-      assert.dom(input).hasAttribute("readonly");
+      // The modal opens immediately, but shows a spinner in place of the
+      // form until the row is attached to the table answer. The cancel
+      // button must be disabled until then as well.
+      await waitFor(".uk-modal [uk-spinner]");
+      assert.dom(input).doesNotExist();
       assert.dom("[data-test-cancel]").isDisabled();
 
       resolveSave();
       await settled();
 
+      assert.dom(input).exists();
       assert.dom(input).doesNotHaveAttribute("readonly");
       assert.dom("[data-test-cancel]").isEnabled();
     });


### PR DESCRIPTION
We shouldn't abuse the `@disabled` attribute to pass along "loading" state. Some components don't deal well with quick state changes and may behave incorrectly.

Instead, we now show a spinner until the row document is fully attached.
