### PR TITLE
fix(distribution): apply color and tooltip to custom status icons

### DIFF
--- a/packages/-ember-caluma/app/components/custom-status-icon.hbs
+++ b/packages/-ember-caluma/app/components/custom-status-icon.hbs
@@ -1,1 +1,1 @@
-✨
+<span ...attributes>✨</span>

--- a/packages/distribution/addon/components/cd-inquiry-status-icon.hbs
+++ b/packages/distribution/addon/components/cd-inquiry-status-icon.hbs
@@ -1,5 +1,10 @@
 {{#if @status.iconComponent}}
-  <@status.iconComponent @status={{@status}} @tooltipPos={{@tooltipPos}} />
+  <@status.iconComponent
+    @status={{@status}}
+    @tooltipPos={{@tooltipPos}}
+    class="uk-text-{{@status.color}}"
+    {{uk-tooltip @status.label pos=@tooltipPos}}
+  />
 {{else}}
   <UkIcon
     @icon={{@status.icon}}

--- a/packages/distribution/tests/integration/components/cd-inquiry-status-icon-test.js
+++ b/packages/distribution/tests/integration/components/cd-inquiry-status-icon-test.js
@@ -54,7 +54,7 @@ module("Integration | Component | cd-inquiry-status-icon", function (hooks) {
     // eslint-disable-next-line ember/no-empty-glimmer-component-classes
     class CustomIconComponent extends Component {}
     setComponentTemplate(
-      hbs`<span class="custom-icon">✨</span>`,
+      hbs`<span class="custom-icon" ...attributes>✨</span>`,
       CustomIconComponent,
     );
 
@@ -71,5 +71,13 @@ module("Integration | Component | cd-inquiry-status-icon", function (hooks) {
 
     assert.dom("[uk-icon]").doesNotExist();
     assert.dom(".custom-icon").hasText("✨");
+
+    // color and tooltip are applied via `...attributes` of the custom component
+    assert.dom(".custom-icon").hasClass("uk-text-success");
+    assert.tooltipHasText(this.element, ".custom-icon", "Custom!");
+    assert.deepEqual(
+      UIkit.tooltip(this.element.querySelector(".custom-icon")).pos,
+      ["top", "center"], // UIkit adds "center" automatically
+    );
   });
 });


### PR DESCRIPTION
The color class and the status tooltip are now applied to a configured `iconComponent` as well, not only to the default `UkIcon`. Custom icon components therefore need to spread `...attributes` onto their root element, if they want the default color class and tooltop handling.
