### PR TITLE
chore: use trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,35 +11,38 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/beta'
+    permissions:
+      id-token: write # to enable use of OIDC for trusted publishing and npm provenance
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
+
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+
       - name: Install Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
+
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
-      - name: Configure pnpm
-        run: |
-          pnpm config set registry https://registry.npmjs.org
-          pnpm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Prepare release
         run: pnpm semantic-release
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
       - name: Copy readme into packages
         run: find packages/* -maxdepth 0 -exec cp README.md {} \;
+
       - name: Publish packages
         if: github.ref == 'refs/heads/main'
-        run: pnpm publish -r --no-git-checks
+        run: pnpm publish -r --no-git-checks --provenance
+
       - name: Publish packages (beta)
         if: github.ref == 'refs/heads/beta'
-        run: pnpm publish -r --no-git-checks --tag beta --publish-branch beta
+        run: pnpm publish -r --no-git-checks --tag beta --publish-branch beta --provenance


### PR DESCRIPTION
## Description

setup trusted publishing. if/once this works the `NPM_TOKEN` secret can be removed

See https://docs.npmjs.com/trusted-publishers
